### PR TITLE
updated 'mod-orders' to 'mod-orders-storage' in pom and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM folioci/openjdk8-jre:latest
 
-ENV VERTICLE_FILE mod-orders-fat.jar
+ENV VERTICLE_FILE mod-orders-storage-fat.jar
 
 # Set the location of the verticles
 ENV VERTICLE_HOME /usr/verticles

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.folio</groupId>
-    <artifactId>mod-orders</artifactId>
+    <artifactId>mod-orders-storage</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
@@ -15,7 +15,7 @@
 
     <properties>
         <aspectj.version>1.8.9</aspectj.version>
-        <module_name>mod-orders</module_name>
+        <module_name>mod-orders-storage</module_name>
         <http.port>8081</http.port>
         <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
         <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>


### PR DESCRIPTION
Updated references to mod-orders in the pom and Docker file to mod-orders-storage.  This will complete the renaming of the repo. 