### PR TITLE
FOLIO-1027 enable lint-raml jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
+  runLintRamlCop = 'no'
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Enable lint-raml with CI.
(When ready with the MODORDSTOR-7, then set the Jenkinsfile to "yes".)

Developers can run the same script locally at `../folio-tools/lint-raml/lint_raml_cop.py`

See the [guides/raml-cop](https://dev.folio.org/guides/raml-cop/).