### PR TITLE
Release 1.0.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 1.1.0 - Unreleased
+
+## 1.0.2 - Released 
+* Omit tenant/schema from reference data COPY scripts executed when enabling the module for a tenant.
+
 ## 1.0.1 - Released
 * [MODORDSTOR-20](https://issues.folio.org/browse/MODORDSTOR-20) - Migrate to RAML1.0 and RMB 23
 * Purchase order and po_line reference data

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0.2</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.0.2</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>1.0.2</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v1.0.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
This is somewhat confusing/mysterious... the fix that prompted this hotfix release was actually made las Friday (12/7), committed to the release-1.0.1 branch, and merged back into the master branch.

Version 1.0.1 was created and released from the release-1.0.1 branch the following Monday (12/10), but somehow did not include the hotfix.  However, when looking at the release-1.0.1 branch it's there...  Not sure what happened; I didn't perform the release and I don't immediately see anything that explains this in the git history.

Anyway, I created a release-1.0.2 branch from release-1.0.1, updated the news and cut a new release (v1.0.2).  This resulting PR that needs to get merged into master only contains the changes to the NEWS file since as I mentioned before the "hotfix" was already committed to release-1.0.1 and merged with master.