### PR TITLE
MODORDSTOR-43 - Release 2.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 The sole purpose of this release is to bring the interface versions in the RAML files inline with those in the module descriptor.
 
+* [MODORDSTOR-43](https://issues.folio.org/browse/MODORDSTOR-43)
+
 ## 2.0.0 - Released
 
 This release was originally slated to be 1.1.0, but since this release contains significant refactoring of the APIs, the major version number is being bumped.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 2.1.0 - Unreleased
+## 3.0.0 - Unreleased
 
 ## 2.0.1 - Released
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 2.1.0 - Unreleased
+
+## 2.0.1 - Released
+
+The sole purpose of this release is to bring the interface versions in the RAML files inline with those in the module descriptor.
+
 ## 2.0.0 - Released
 
 This release was originally slated to be 1.1.0, but since this release contains significant refactoring of the APIs, the major version number is being bumped.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.0.1</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.1</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>2.0.1</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v2.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/ramls/adjustment.raml
+++ b/ramls/adjustment.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Adjustment

--- a/ramls/alert.raml
+++ b/ramls/alert.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Alerts

--- a/ramls/claim.raml
+++ b/ramls/claim.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Claims

--- a/ramls/cost.raml
+++ b/ramls/cost.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Cost

--- a/ramls/details.raml
+++ b/ramls/details.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Details

--- a/ramls/eresource.raml
+++ b/ramls/eresource.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: EResources

--- a/ramls/fund_distribution.raml
+++ b/ramls/fund_distribution.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: https://github.com/folio-org/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Fund Distributions

--- a/ramls/license.raml
+++ b/ramls/license.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Licenses

--- a/ramls/location.raml
+++ b/ramls/location.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Locations

--- a/ramls/physical.raml
+++ b/ramls/physical.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Physicals

--- a/ramls/po_line.raml
+++ b/ramls/po_line.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: PO Line

--- a/ramls/purchase_order.raml
+++ b/ramls/purchase_order.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders-storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Purchase Order

--- a/ramls/reporting_code.raml
+++ b/ramls/reporting_code.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Reporting Code

--- a/ramls/source.raml
+++ b/ramls/source.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Source

--- a/ramls/vendor_detail.raml
+++ b/ramls/vendor_detail.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Vendor Detail


### PR DESCRIPTION
See [MODORDSTOR-43](https://issues.folio.org/browse/MODORDSTOR-43)

## Purpose
This is a follow-on release to fix the RAML so that the API version is consistent with that specified in the module descriptor.

## Approach
Push button, turn crank, voila! New and improved.