### PR TITLE
MODORDSTOR-42 unique index for po_number

### DIFF
--- a/src/main/resources/templates/db_scripts/purchase_order_table.sql
+++ b/src/main/resources/templates/db_scripts/purchase_order_table.sql
@@ -1,4 +1,4 @@
 CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.po_number MAXVALUE 9999999999999999 START WITH 10000 CACHE 1 NO CYCLE;
 GRANT USAGE ON SEQUENCE ${myuniversity}_${mymodule}.po_number TO ${myuniversity}_${mymodule};
 
-CREATE UNIQUE INDEX purchase_order_po_number_idx ON ${myuniversity}_${mymodule}.purchase_order ((jsonb->>'po_number') );
+CREATE UNIQUE INDEX IF NOT EXISTS purchase_order_po_number_unique_idx ON ${myuniversity}_${mymodule}.purchase_order ((jsonb->>'po_number'));

--- a/src/main/resources/templates/db_scripts/purchase_order_table.sql
+++ b/src/main/resources/templates/db_scripts/purchase_order_table.sql
@@ -1,2 +1,4 @@
 CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.po_number MAXVALUE 9999999999999999 START WITH 10000 CACHE 1 NO CYCLE;
 GRANT USAGE ON SEQUENCE ${myuniversity}_${mymodule}.po_number TO ${myuniversity}_${mymodule};
+
+CREATE UNIQUE INDEX purchase_order_po_number_idx ON ${myuniversity}_${mymodule}.purchase_order ((jsonb->>'po_number') );

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -171,7 +171,7 @@
       "fromModuleVersion": 1.0,
       "withMetadata": true,
       "populateJsonWithId": true,
-      "customSnippetPath": "createPoNumberSequence.sql"
+      "customSnippetPath": "purchase_order_table.sql"
     },
     {
       "tableName": "po_line",

--- a/src/test/java/org/folio/rest/impl/POsTest.java
+++ b/src/test/java/org/folio/rest/impl/POsTest.java
@@ -93,7 +93,7 @@ public class POsTest extends OrdersStorageTest {
     response
       .then()
        .statusCode(500)
-       .body(containsString("duplicate key value violates unique constraint \"purchase_order_po_number_idx\""));
+       .body(containsString("duplicate key value violates unique constraint \"purchase_order_po_number_unique_idx\""));
   }
 
   private void testDeletePO() {

--- a/src/test/java/org/folio/rest/impl/POsTest.java
+++ b/src/test/java/org/folio/rest/impl/POsTest.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @RunWith(VertxUnitRunner.class)
@@ -52,7 +53,7 @@ public class POsTest extends OrdersStorageTest {
 
       logger.info("--- mod-orders-storage PO test: Creating purchase order with the same po_number ... ");
       Response samePoNumberErrorResponse = postData(PO_ENDPOINT, purchaseOrderSample);
-      testPoNumberUniqness(samePoNumberErrorResponse, context);
+      testPoNumberUniqness(samePoNumberErrorResponse);
 
       sampleId = response.then().extract().path("id");
       
@@ -88,8 +89,11 @@ public class POsTest extends OrdersStorageTest {
     }
   }
 
-  private void testPoNumberUniqness(Response response, TestContext context) {
-    context.assertTrue(response.getBody().asString().contains("duplicate key value violates unique constraint \"purchase_order_po_number_idx\""));
+  private void testPoNumberUniqness(Response response) {
+    response
+      .then()
+       .statusCode(500)
+       .body(containsString("duplicate key value violates unique constraint \"purchase_order_po_number_idx\""));
   }
 
   private void testDeletePO() {

--- a/src/test/resources/purchase_order.sample
+++ b/src/test/resources/purchase_order.sample
@@ -1,5 +1,4 @@
 {
-  "id": "0804ddec-6545-404a-b54d-a693f505681d",
   "adjustment": "9b3be694-6716-4e14-b81d-8d76f0ae4146",
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
@@ -10,7 +9,7 @@
     "ABCDEFGHIJKLMNOPQRSTUV"
   ],
   "order_type": "Ongoing",
-  "po_number": "268758",
+  "po_number": "268759",
   "re_encumber": false,
   "renewal": {
      "cycle": "6 Months",


### PR DESCRIPTION
## Purpose
In order to guarantee PO number uniqueness across all orders a unique constraint needs to be added for PO number filed in DB
https://issues.folio.org/browse/MODORDSTOR-42

## Approach
Adding unique index in database creation snippet