### PR TITLE
Release 2.0.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 ## 3.0.0 - Unreleased
 
+## 2.0.2 - Released
+
+This is a patch release to resolve an issue where the loading of sample data was preventing the module from being upgraded.
+
+* [MODORDSTOR-44](https://issues.folio.org/browse/MODORDSTOR-44)
+
 ## 2.0.1 - Released
 
 The sole purpose of this release is to bring the interface versions in the RAML files inline with those in the module descriptor.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>2.0.2</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.2</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>2.0.2</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v2.0.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
## Purpose
A patch release is required to address a critical problem: [MODORDSTOR-44](https://issues.folio.org/browse/MODORDSTOR-44)

NOTE:  it looks like the removal of `po_line_workflow_status` snuck into this branch as well, but that shouldn't be a big deal.

## Approach
Merge the MODORDSTOR-44 branch into the release-2.0.1 branch and cut a new release (2.0.2)