### PR TITLE
MODORDERS-130 PO number camelCase instead of under_score

### DIFF
--- a/src/test/java/org/folio/rest/impl/PoNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/PoNumberTest.java
@@ -33,6 +33,6 @@ public class PoNumberTest extends OrdersStorageTest {
       .statusCode(200)
       .extract()
       .response()
-      .path("po_number"));
+      .path("poNumber"));
   }
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDERS-130
FOLIO naming conventions for schemas dictate that camelCase is used for field names instead of under_score notation.

## Approach
* code is updated
* acq-models sub module moved to the last commit


#### TODOS and Open Questions
* https://github.com/folio-org/acq-models/pull/80
* move acq-models sub module to the last commit
