### PR TITLE
MODORDSTOR-51 Add 'purchase_order_id' and "dateOrdered" to the receiving_history_view

### DIFF
--- a/src/main/resources/data/purchase_orders/14383007_ongoing_open.json
+++ b/src/main/resources/data/purchase_orders/14383007_ongoing_open.json
@@ -1,6 +1,7 @@
 {
   "id": "8c328a18-5761-4329-95f6-599412c32310",
   "approved": true,
+  "dateOrdered": "2018-07-24T00:00:00Z",
   "manual_po": true,
   "po_number": "14383007",
   "order_type": "Ongoing",

--- a/src/main/resources/data/purchase_orders/268758_one-time_open.json
+++ b/src/main/resources/data/purchase_orders/268758_one-time_open.json
@@ -1,6 +1,7 @@
 {
   "id": "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
   "approved": true,
+  "dateOrdered": "2018-06-30T00:00:00Z",
   "manual_po": false,
   "po_number": "268758",
   "order_type": "One-Time",

--- a/src/main/resources/data/purchase_orders/268879_one-time_closed.json
+++ b/src/main/resources/data/purchase_orders/268879_one-time_closed.json
@@ -1,6 +1,7 @@
 {
   "id": "e5ae4afd-3fa9-494e-a972-f541df9b877e",
   "approved": true,
+  "dateOrdered": "2014-07-10T00:00:00Z",
   "manual_po": false,
   "po_number": "268879",
   "order_type": "One-Time",

--- a/src/main/resources/data/purchase_orders/306251_one-time_closed.json
+++ b/src/main/resources/data/purchase_orders/306251_one-time_closed.json
@@ -1,6 +1,7 @@
 {
   "id": "e20af8c8-b07d-47a1-9ebd-f1187e9335bd",
   "approved": true,
+  "dateOrdered": "2018-06-20T00:00:00Z",
   "notes": [
     "CAC one time funding proposal by Bob Barker"
   ],

--- a/src/main/resources/data/purchase_orders/306857_ongoing_open.json
+++ b/src/main/resources/data/purchase_orders/306857_ongoing_open.json
@@ -1,6 +1,7 @@
 {
   "id": "e41e0161-2bc6-41f3-a6e7-34fc13250bf1",
   "approved": true,
+  "dateOrdered": "2018-07-24T00:00:00Z",
   "notes": [
     "Published twice a year"
   ],

--- a/src/main/resources/data/purchase_orders/312325_one-time_open.json
+++ b/src/main/resources/data/purchase_orders/312325_one-time_open.json
@@ -1,6 +1,7 @@
 {
   "id": "f4dc647c-ec82-442e-b13d-f9505b7ce8e9",
   "approved": true,
+  "dateOrdered": "2018-07-14T00:00:00Z",
   "notes": [
     "DXiao",
     "DHalling",

--- a/src/main/resources/data/purchase_orders/313000_one-time_open.json
+++ b/src/main/resources/data/purchase_orders/313000_one-time_open.json
@@ -1,6 +1,7 @@
 {
   "id": "05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33",
   "approved": true,
+  "dateOrdered": "2018-07-24T00:00:00Z",
   "notes": [
     "DVD plus 3 years streaming"
   ],

--- a/src/main/resources/data/purchase_orders/36547_one_time_closed.json
+++ b/src/main/resources/data/purchase_orders/36547_one_time_closed.json
@@ -1,6 +1,7 @@
 {
   "id": "1d6a455f-29c5-4e51-84d9-e28450ef86ad",
   "approved": true,
+  "dateOrdered": "2019-05-17T00:00:00Z",
   "manual_po": false,
   "po_number": "36547",
   "order_type": "One-Time",

--- a/src/main/resources/data/purchase_orders/S60402_ongoing_closed.json
+++ b/src/main/resources/data/purchase_orders/S60402_ongoing_closed.json
@@ -1,6 +1,7 @@
 {
   "id": "07f65192-44a4-483d-97aa-b137bbd96390",
   "approved": true,
+  "dateOrdered": "2018-07-24T00:00:00Z",
   "manual_po": false,
   "po_number": "S60402",
   "order_type": "Ongoing",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -2,7 +2,7 @@
   "scripts": [
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW receiving_history_view AS SELECT pieces.id AS id, json_build_object('id', pieces.jsonb->>'id', 'caption', pieces.jsonb->>'caption', 'comment', pieces.jsonb->>'comment', 'itemId', pieces.jsonb->>'itemId', 'poLineId', pieces.jsonb->>'poLineId', 'poLineNumber', po_line.jsonb->>'po_line_number', 'receivedDate', pieces.jsonb->>'receivedDate', 'title', po_line.jsonb->>'title', 'receivingNote', details.jsonb->>'receiving_note', 'receivingStatus', pieces.jsonb->>'receivingStatus', 'supplement', pieces.jsonb->>'supplement') AS jsonb FROM pieces LEFT OUTER JOIN po_line ON pieces.jsonb->>'poLineId' = po_line.jsonb->>'id' LEFT OUTER JOIN details ON details.jsonb->>'po_line_id' = po_line.jsonb->>'id';",
+      "snippet": "CREATE OR REPLACE VIEW receiving_history_view AS SELECT pieces.id AS id, json_build_object('id', pieces.jsonb->>'id', 'caption', pieces.jsonb->>'caption', 'comment', pieces.jsonb->>'comment','dateOrdered', purchase_order.jsonb->>'dateOrdered','itemId', pieces.jsonb->>'itemId', 'poLineId', pieces.jsonb->>'poLineId', 'poLineNumber', po_line.jsonb->>'po_line_number', 'purchaseOrderId', po_line.jsonb->>'purchase_order_id','receivedDate', pieces.jsonb->>'receivedDate', 'title', po_line.jsonb->>'title', 'receivingNote', details.jsonb->>'receiving_note', 'receivingStatus', pieces.jsonb->>'receivingStatus', 'supplement', pieces.jsonb->>'supplement') AS jsonb FROM pieces LEFT OUTER JOIN po_line ON pieces.jsonb->>'poLineId' = po_line.jsonb->>'id' LEFT OUTER JOIN details ON details.jsonb->>'po_line_id' = po_line.jsonb->>'id' LEFT OUTER JOIN purchase_order ON po_line.jsonb->>'purchase_order_id' = purchase_order.jsonb->>'id';",
       "fromModuleVersion": "1.0"
     }
   ],

--- a/src/test/java/org/folio/rest/impl/POsTest.java
+++ b/src/test/java/org/folio/rest/impl/POsTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl;
 
 import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.json.JSONObject;
@@ -49,7 +50,9 @@ public class POsTest extends OrdersStorageTest {
       Response response = postData(PO_ENDPOINT, purchaseOrderSample);
 
       logger.info("--- mod-orders-storage PO test: Creating purchase order with the same po_number ... ");
-      Response samePoNumberErrorResponse = postData(PO_ENDPOINT, purchaseOrderSample);
+      JsonObject jsonSample = new JsonObject(purchaseOrderSample);
+      jsonSample.remove("id");
+      Response samePoNumberErrorResponse = postData(PO_ENDPOINT, jsonSample.toString());
       testPoNumberUniqness(samePoNumberErrorResponse);
 
       sampleId = response.then().extract().path("id");

--- a/src/test/java/org/folio/rest/impl/ReceivingHistoryTest.java
+++ b/src/test/java/org/folio/rest/impl/ReceivingHistoryTest.java
@@ -1,35 +1,45 @@
 package org.folio.rest.impl;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.rest.jaxrs.model.Details;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.ReceivingHistory;
 import org.folio.rest.jaxrs.model.ReceivingHistoryCollection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 @RunWith(VertxUnitRunner.class)
 public class ReceivingHistoryTest extends OrdersStorageTest {
 
-  private final Logger logger = LoggerFactory.getLogger("okapi");
+  private final Logger logger = LoggerFactory.getLogger(ReceivingHistoryTest.class);
 
-  private static String piecesSampleId; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
-  private static String detailSampleId; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
-  private static String poLineSampleId; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
-  private static String piecesSampleId2; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
-  private static String detailSampleId2; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
-  private static String poLineSampleId2; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
+  private String piecesSampleId; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
+  private String detailSampleId; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
+  private String poLineSampleId; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
+  private String purchaseOrderSampleId;
+  private String piecesSampleId2; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
+  private String detailSampleId2; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
+  private String poLineSampleId2; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
+  private String purchaseOrderSampleId2;
 
   private static final String RECEIVING_HISTORY_ENDPOINT = "/orders-storage/receiving-history";
   private static final String PIECES_ENDPOINT = "/orders-storage/pieces";
   private static final String PO_LINE_ENDPOINT = "/orders-storage/po_lines";
   private static final String DETAILS_ENDPOINT = "/orders-storage/details";
+  private static final String PURCHASE_ORDER_ENDPOINT = "/orders-storage/purchase_orders";
 
   private final String detailSample = getFile("details.sample");
   private final String detailSample2 = getFile("detail_for_view.sample");
@@ -37,7 +47,12 @@ public class ReceivingHistoryTest extends OrdersStorageTest {
   private final String poLineSample2 = getFile("po_line_for_view.sample");
   private final String pieceSample = getFile("pieces.sample");
   private final String pieceSample2 = getFile("piece_for_view.sample");
+  private final String purchaseOrderSample = getFile("purchase_order.sample");
+  private final String purchaseOrderSample2 = getFile("purchase_order_for_view.sample");
   private static final String APPLICATION_JSON = "application/json";
+
+  private static final Integer CREATED_ENTITIES_QUANTITY = 2;
+
 
   @Test
   public void testReceivingHistory() {
@@ -67,9 +82,14 @@ public class ReceivingHistoryTest extends OrdersStorageTest {
       detailSampleId2 = testCreateDetail(detailSample2);
       testVerifyDetailCreated();
 
+      logger.info("--- mod-orders-storage receiving_history test: Creating Purchase Order 1...");
+      purchaseOrderSampleId = testCreatePurchaseOrder(purchaseOrderSample);
+      logger.info("--- mod-orders-storage receiving_history test: Creating Purchase Order 2...");
+      purchaseOrderSampleId2 = testCreatePurchaseOrder(purchaseOrderSample2);
+      testVerifyPurchaseOrdersCreated();
 
       logger.info("--- mod-orders-storage pieces test: After receiving_history View created ...");
-      verifyViewCollectionAfter(RECEIVING_HISTORY_ENDPOINT, 2);
+      verifyViewCollectionAfter(RECEIVING_HISTORY_ENDPOINT);
 
     } catch (Exception e) {
       logger.error("--- mod-orders-storage-test: receiving_history API ERROR: " + e.getMessage(), e);
@@ -82,7 +102,15 @@ public class ReceivingHistoryTest extends OrdersStorageTest {
       testDeleteDetail(detailSampleId2);
       testDeletePoLine(poLineSampleId2);
       testDeletePieces(piecesSampleId2);
+      testDeletePurchaseOrder(purchaseOrderSampleId);
+      testDeletePurchaseOrder(purchaseOrderSampleId2);
+
     }
+  }
+
+  private void testDeletePurchaseOrder(String purchaseOrderSampleId) {
+    deleteData(PURCHASE_ORDER_ENDPOINT, purchaseOrderSampleId).then()
+      .statusCode(204);
   }
 
   private void testDeleteDetail(String detailSampleId) {
@@ -113,6 +141,11 @@ public class ReceivingHistoryTest extends OrdersStorageTest {
     return detailResponse.then().extract().path("id");
   }
 
+  private String testCreatePurchaseOrder(String purchaseOrderSample) {
+    Response response = postData(PURCHASE_ORDER_ENDPOINT, purchaseOrderSample);
+    return response.then().extract().path("id");
+  }
+
   private String testCreatePiece(String pieceSample) {
     Response response = postData(PIECES_ENDPOINT, pieceSample);
     return response.then().extract().path("id");
@@ -131,6 +164,12 @@ public class ReceivingHistoryTest extends OrdersStorageTest {
     .body("total_records", equalTo(18));
   }
 
+  private void testVerifyPurchaseOrdersCreated() {
+    getData(PURCHASE_ORDER_ENDPOINT).then()
+      .statusCode(200)
+      .body("total_records", equalTo(16));
+  }
+
   private void testVerifyPoLineCreated() {
     getData(PO_LINE_ENDPOINT).then()
     .statusCode(200)
@@ -143,45 +182,46 @@ public class ReceivingHistoryTest extends OrdersStorageTest {
     .body("total_records", equalTo(2));
   }
 
-  private void verifyViewCollectionAfter(String endpoint, int expectedCount) {
+  private void verifyViewCollectionAfter(String endpoint) {
+    Piece[] pieces = new Piece[] {new JsonObject(pieceSample).mapTo(Piece.class), new JsonObject(pieceSample2).mapTo(Piece.class)};
+    PoLine[] poLines = new PoLine[] {new JsonObject(poLineSample).mapTo(PoLine.class), new JsonObject(poLineSample2).mapTo(PoLine.class)};
+    Details[] details = new Details[] {new JsonObject(detailSample).mapTo(Details.class), new JsonObject(detailSample2).mapTo(Details.class)};
+    PurchaseOrder[] purchaseOrders = new PurchaseOrder[] {new JsonObject(purchaseOrderSample).mapTo(PurchaseOrder.class), new JsonObject(purchaseOrderSample2).mapTo(PurchaseOrder.class)};
 
-   final ReceivingHistoryCollection receivingHistory = RestAssured
-       .with()
+    final ReceivingHistoryCollection receivingHistory = RestAssured
+      .with()
         .header(TENANT_HEADER)
-        .get(endpoint)
-       .then()
-       .contentType(APPLICATION_JSON)
-       .log().all()
-       .statusCode(200)
-       .extract()
-        .response()
-         .as(ReceivingHistoryCollection.class);
+      .get(endpoint)
+        .then()
+          .contentType(APPLICATION_JSON)
+          .log().all()
+          .statusCode(200)
+          .extract()
+            .response()
+              .as(ReceivingHistoryCollection.class);
 
-       assertEquals(expectedCount, receivingHistory.getReceivingHistory().size());
-
-       for(ReceivingHistory history:receivingHistory.getReceivingHistory()) {
-         if(history.getItemId().equals("522a501a-56b5-48d9-b28a-3a8f02482d97")) {
-           assertEquals("Tutorial Volume 5", history.getCaption());
-           assertEquals("Special Edition", history.getComment());
-           assertEquals(true, history.getSupplement());
-           assertEquals("Kayak Fishing in the Northern Gulf Coast", history.getTitle());
-           assertEquals("d471d766-8dbb-4609-999a-02681dea6c22", history.getPoLineId());
-           assertEquals("268758-03", history.getPoLineNumber());
-           assertEquals( "ABCDEFGHIJKL", history.getReceivingNote());
-         }
-
-         if(history.getItemId().equals("15447c41-bc6a-4600-96a4-a1ce7f44c62a")) {
-           assertEquals("Tutorial Volume 6", history.getCaption());
-           assertEquals("Limited Edition", history.getComment());
-           assertEquals(false, history.getSupplement());
-           assertEquals("Skiing in the Colorado", history.getTitle());
-           assertEquals("2fe6c2dd-3700-4a53-a624-1159cfd7f8ce", history.getPoLineId());
-           assertEquals("268500-03", history.getPoLineNumber());
-           assertEquals("details for view", history.getReceivingNote());
-         }
-       }
+    assertEquals(CREATED_ENTITIES_QUANTITY, receivingHistory.getTotalRecords());
+    List<ReceivingHistory> receivingHistories = receivingHistory.getReceivingHistory();
+    for (int i = 0; i < receivingHistories.size(); i++) {
+      if (receivingHistories.get(i).getId().equals(pieces[i].getId())) {
+        verifyFields(pieces[i], poLines[i], details[i], purchaseOrders[i], receivingHistories.get(i));
+      } else {
+        verifyFields(pieces[i], poLines[i], details[i], purchaseOrders[i], receivingHistories.get(receivingHistories.size() - i -1));
+      }
+    }
   }
 
-
+  private void verifyFields(Piece pieces, PoLine poLines, Details details, PurchaseOrder purchaseOrders, ReceivingHistory receivingHistories) {
+    assertEquals(receivingHistories.getCaption(), pieces.getCaption());
+    assertEquals(receivingHistories.getComment(), pieces.getComment());
+    assertEquals(receivingHistories.getItemId(), pieces.getItemId());
+    assertEquals(receivingHistories.getSupplement(), pieces.getSupplement());
+    assertEquals(receivingHistories.getTitle(), poLines.getTitle());
+    assertEquals(receivingHistories.getPoLineId(), pieces.getPoLineId());
+    assertEquals(receivingHistories.getPoLineNumber(), poLines.getPoLineNumber());
+    assertEquals(receivingHistories.getReceivingNote(), details.getReceivingNote());
+    assertEquals(receivingHistories.getPurchaseOrderId(), poLines.getPurchaseOrderId());
+    assertEquals(receivingHistories.getDateOrdered(), purchaseOrders.getDateOrdered());
+  }
 
 }

--- a/src/test/resources/po_line.sample
+++ b/src/test/resources/po_line.sample
@@ -34,7 +34,8 @@
   "po_line_number": "268758-03",
   "publication_date": "2017",
   "publisher": "Schiffer Publishing",
-  "receipt_date": "2018-10-09T00:00:00.000Z",
+  "purchase_order_id": "1ba7ef6a-d1d4-4a4f-90a2-882aed18af16",
+  "receipt_date": "2018-10-09T00:00:00.000+0000",
   "receipt_status": "Awaiting Receipt",
   "reporting_codes": [
     "5926dcd7-85f5-4504-8283-712595ebc38b",

--- a/src/test/resources/po_line_for_view.sample
+++ b/src/test/resources/po_line_for_view.sample
@@ -34,7 +34,8 @@
   "po_line_number": "268500-03",
   "publication_date": "2017",
   "publisher": "Schiffer Publishing",
-  "receipt_date": "2018-10-09T00:00:00.000Z",
+  "purchase_order_id": "2ba7ef6a-d1d4-4a4f-90a2-882aed18af16",
+  "receipt_date": "2018-10-09T00:00:00.000+0000",
   "receipt_status": "Awaiting Receipt",
   "reporting_codes": [
     "07c03c98-0feb-4042-8be8-f5b9c18706f4",

--- a/src/test/resources/purchase_order.sample
+++ b/src/test/resources/purchase_order.sample
@@ -1,4 +1,5 @@
 {
+  "id": "1ba7ef6a-d1d4-4a4f-90a2-882aed18af16",
   "adjustment": "9b3be694-6716-4e14-b81d-8d76f0ae4146",
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
@@ -15,14 +16,11 @@
      "cycle": "6 Months",
      "interval": 182,
      "manual_renewal": true,
-     "review_period": 30,
-     "renewal_date": "2019-04-09T00:00:00.000Z"
+     "renewal_date": "2019-04-09T00:00:00.000+0000",
+     "review_period": 30
   },
   "total_estimated_price": 49.98,
   "total_items": 2,
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
-  "metadata": {
-    "createdDate": "2018-07-19T00:00:00.000+0000",
-    "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
-  }
+  "workflow_status": "Pending"
 }

--- a/src/test/resources/purchase_order_for_view.sample
+++ b/src/test/resources/purchase_order_for_view.sample
@@ -1,0 +1,15 @@
+{
+  "id": "2ba7ef6a-d1d4-4a4f-90a2-882aed18af16",
+  "approved": true,
+  "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "dateOrdered": "2018-09-09T00:00:00.000",
+  "manual_po": true,
+  "notes": [],
+  "order_type": "One-Time",
+  "po_number": "268500",
+  "re_encumber": false,
+  "total_estimated_price": 49.98,
+  "total_items": 2,
+  "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "workflow_status": "Open"
+}


### PR DESCRIPTION
## Purpose
[MODORDSTOR-51](https://issues.folio.org/browse/MODORDSTOR-51) Add 'purchase_order_id' and "dateOrdered" to the receiving_history_view

## Approach
- added 'purchase_order_id'  and 'dateOrdered' to the receiving_history_view with [folio-org/acq-models#84](https://github.com/folio-org/acq-models/pull/84)
- updated sample data, including for [MODORDERS-147](https://issues.folio.org/browse/MODORDERS-147)
- updated receiving_history_view creation snippet
- unit tests are updated to test the functionality

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards ([sonar PR#80](https://sonarcloud.io/project/issues?id=org.folio%3Amod-orders-storage&pullRequest=80&resolved=false))?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
