### PR TITLE
Release 3.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+## 4.0.0 - Unreleased
+
 ## 3.0.0 - Released
 
 ### Stories

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
-## 3.0.0 - Unreleased
+## 3.0.0 - Released
 
-* [MODORDSTOR-46](https://issues.folio.org/browse/MODORDSTOR-46) - Schema po_number.json changed to sequence_number.json. PONumber endpoint interface should be increased to v2.
+* [MODORDSTOR-41](https://issues.folio.org/browse/MODORDSTOR-41) - Fix sample data UUID references
+* [MODORDSTOR-42](https://issues.folio.org/browse/MODORDSTOR-42) - Add unique constraint and index for PO number field in DB
 * [MODORDSTOR-45](https://issues.folio.org/browse/MODORDSTOR-45) - Build API for PO line numbers.
+* [MODORDSTOR-46](https://issues.folio.org/browse/MODORDSTOR-46) - PO Number endpoint: schema po_number.json changed to sequence_number.json.
+* [MODORDSTOR-48](https://issues.folio.org/browse/MODORDSTOR-48) - Rework how sample data is loaded
+* [MODORDSTOR-53](https://issues.folio.org/browse/MODORDSTOR-53) - PO Line's `location` property is changed to `locations` i.e. from string to array of strings
+* [MODORDSTOR-55](https://issues.folio.org/browse/MODORDSTOR-55) - Remove `first`/`last` fields in all collection schemas and all APIs
 
 ## 2.0.2 - Released
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 3.0.0 - Released
 
+### Stories
 * [MODORDSTOR-41](https://issues.folio.org/browse/MODORDSTOR-41) - Fix sample data UUID references
 * [MODORDSTOR-42](https://issues.folio.org/browse/MODORDSTOR-42) - Add unique constraint and index for PO number field in DB
 * [MODORDSTOR-45](https://issues.folio.org/browse/MODORDSTOR-45) - Build API for PO line numbers.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "orders-storage.adjustments",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -35,7 +35,7 @@
     },
     {
       "id": "orders-storage.alerts",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -66,7 +66,7 @@
     },
     {
       "id": "orders-storage.claims",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -97,7 +97,7 @@
     },
     {
       "id": "orders-storage.costs",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -128,7 +128,7 @@
     },
     {
       "id": "orders-storage.fund-distributions",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -159,7 +159,7 @@
     },
     {
       "id": "orders-storage.details",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -190,7 +190,7 @@
     },
     {
       "id": "orders-storage.eresources",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -221,7 +221,7 @@
     },
     {
       "id": "orders-storage.licenses",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -252,7 +252,7 @@
     },
     {
       "id": "orders-storage.locations",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -283,7 +283,7 @@
     },
     {
       "id": "orders-storage.physicals",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -314,7 +314,7 @@
     },
     {
       "id": "orders-storage.pieces",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -345,7 +345,7 @@
     },
     {
       "id": "orders-storage.po_lines",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -376,7 +376,7 @@
     },
     {
       "id": "orders-storage.purchase_orders",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -412,7 +412,7 @@
     },
     {
       "id": "orders-storage.receiving-history",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -423,7 +423,7 @@
     },
     {
       "id": "orders-storage.reporting_codes",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -454,7 +454,7 @@
     },
     {
       "id": "orders-storage.sources",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -485,7 +485,7 @@
     },
     {
       "id": "orders-storage.vendor_details",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -516,7 +516,7 @@
     },
     {
       "id": "orders-storage.po_number",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -458,7 +458,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v3.0.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>3.0.0</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -458,7 +458,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v3.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/ramls/adjustment.raml
+++ b/ramls/adjustment.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Adjustment

--- a/ramls/alert.raml
+++ b/ramls/alert.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Alerts

--- a/ramls/claim.raml
+++ b/ramls/claim.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Claims

--- a/ramls/cost.raml
+++ b/ramls/cost.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Cost

--- a/ramls/details.raml
+++ b/ramls/details.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Details

--- a/ramls/eresource.raml
+++ b/ramls/eresource.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: EResources

--- a/ramls/fund_distribution.raml
+++ b/ramls/fund_distribution.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: https://github.com/folio-org/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Fund Distributions

--- a/ramls/license.raml
+++ b/ramls/license.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Licenses

--- a/ramls/location.raml
+++ b/ramls/location.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Locations

--- a/ramls/orders.raml
+++ b/ramls/orders.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders-storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Orders

--- a/ramls/physical.raml
+++ b/ramls/physical.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Physicals

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Pieces

--- a/ramls/po_line.raml
+++ b/ramls/po_line.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: PO Line
@@ -44,6 +44,6 @@ resourceTypes:
         type: UUID
     type:
       collection-item:
-        exampleItem: !include acq-models/mod-orders-storage/examples/po_line_post.sample
+        exampleItem: !include acq-models/mod-orders-storage/examples/po_line_get.sample
         schema: po_line
 

--- a/ramls/po_number.raml
+++ b/ramls/po_number.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v3
+version: v2
 
 documentation:
   - title: Purchase Order Number

--- a/ramls/po_number.raml
+++ b/ramls/po_number.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v1
+version: v3
 
 documentation:
   - title: Purchase Order Number

--- a/ramls/purchase_order.raml
+++ b/ramls/purchase_order.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders-storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Purchase Order

--- a/ramls/receiving_history.raml
+++ b/ramls/receiving_history.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders-storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v1
+version: v2
 
 documentation:
   - title: Receiving History

--- a/ramls/reporting_code.raml
+++ b/ramls/reporting_code.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Reporting Code

--- a/ramls/source.raml
+++ b/ramls/source.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Source

--- a/ramls/vendor_detail.raml
+++ b/ramls/vendor_detail.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Vendor Detail


### PR DESCRIPTION
## Purpose
[MODORDSTOR-56](https://issues.folio.org/browse/MODORDSTOR-56) Create release v3.0.0

## Approach
- The major version of the interfaces and ramls increased because of the changes done in scope of [MODORDSTOR-46](https://issues.folio.org/browse/MODORDSTOR-46), [MODORDSTOR-53](https://issues.folio.org/browse/MODORDSTOR-53) and [MODORDSTOR-55](https://issues.folio.org/browse/MODORDSTOR-55)
- News file is updates

#### TODOS and Open Questions
- [x] complete release procedure first before merging the changes to master
- [x] prepare PR for mod-orders to consume new interface versions: [mod-orders PR#108](https://github.com/folio-org/mod-orders/pull/108)
