### PR TITLE
Document that this module is intended for internal use only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 This is the Orders storage module.
 
-## PREPARATION
+*NOTE*: This module is intended for internal use only.  Please use the APIs provided by mod-orders instead.  There is a lot of business logic in mod-orders that will be bypassed if talking directly to the storage layer. While this is mainly important for create/update/delete operations, it also includes get operations as well. For instance, summary information is calculated in the business logic module (mod-orders).
 
-### SAMPLE DATA LOAD
+## Preparation
+
+### Sample Data Loading
 
 Sample data can be optionally loaded during tenant initialization. By default, if no parameters are passed the sample data will not be loaded. 
 
@@ -50,7 +52,7 @@ DATA SOURCE
 The sample data lives in /resources/data folder. Each folder is named identical to the endpoint the data has to be loaded to. The TenantReferenceAPI will then be able to load data into the corresponding table using a POST to the endpoint
 
 
-### MODIFY DEFAULT SAMPLE DATA LOAD BEHAVIOR
+### Modifying default sample data loading behavior
 Sample data load behavior can be modified by passing a command line argument loadSample
 Unlike the tenant parameters the command Line argument will be applicable for all the tenants.
 

--- a/ramls/orders.raml
+++ b/ramls/orders.raml
@@ -5,7 +5,7 @@ version: v2
 
 documentation:
   - title: Orders
-    content: <b>Get list of purchase orders API</b>
+    content: <b>Get list of purchase orders API.  This API is intended for internal use only.  Please use the /orders/composite-orders API provided by mod-orders instead.</b>
 
 types:
     purchase_order: !include acq-models/mod-orders-storage/schemas/purchase_order.json

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -5,7 +5,7 @@ version: v2
 
 documentation:
   - title: Pieces
-    content: <b>CRUD API to manage Pieces</b>
+    content: <b>CRUD API to manage Pieces.  This API is intended for internal use only.  Please use the /orders/pieces, /orders/receiving, /orders/check-in, and /orders/receiving-history APIs provided by mod-orders instead.</b>
 
 types:
     piece: !include acq-models/mod-orders-storage/schemas/piece.json

--- a/ramls/po-line-number.raml
+++ b/ramls/po-line-number.raml
@@ -5,7 +5,7 @@ version: v1
 
 documentation:
   - title: Purchase Order Line Number
-    content: <b>API used to manage Purchase Order Line number.</b>
+    content: <b>API used to manage Purchase Order Line number.  This API is intended for internal use only</b>
 
 types:
   po-line-number: !include acq-models/common/schemas/sequence_number.json

--- a/ramls/po-line.raml
+++ b/ramls/po-line.raml
@@ -5,7 +5,7 @@ version: v3
 
 documentation:
   - title: PO Line
-    content: <b>This module implements the CRUD interface</b>
+    content: <b>This module implements the CRUD interface.  This API is intended for internal use only.  Please use the /orders/order-lines API provided by mod-orders instead.</b>
 
 types:
     po-line: !include acq-models/mod-orders-storage/schemas/po_line.json

--- a/ramls/po-number.raml
+++ b/ramls/po-number.raml
@@ -5,7 +5,7 @@ version: v2
 
 documentation:
   - title: Purchase Order Number
-    content: <b>API used to manage PO number.</b>
+    content: <b>API used to manage PO number.  This API is intended for internal use only.  Please use the /orders/po-number API provided by mod-orders instead.</b>
 
 types:
   po-number: !include acq-models/common/schemas/sequence_number.json

--- a/ramls/purchase-order.raml
+++ b/ramls/purchase-order.raml
@@ -5,7 +5,7 @@ version: v3
 
 documentation:
   - title: Purchase Order
-    content: <b>This module implements the CRUD interface</b>
+    content: <b>This module implements the CRUD interface.  This API is intended for internal use only.  Please use the /orders/composite-orders API provided by mod-orders instead.</b>
 
 types:
     purchase-order: !include acq-models/mod-orders-storage/schemas/purchase_order.json

--- a/ramls/receiving-history.raml
+++ b/ramls/receiving-history.raml
@@ -5,7 +5,7 @@ version: v2
 
 documentation:
   - title: Receiving History
-    content: <b>Get list of receiving history API</b>
+    content: <b>Get list of receiving history API.  This API is intended for internal use only.  Please use the /orders/receiving-history API provided by mod-orders instead.</b>
 
 types:
     receiving-history: !include acq-models/mod-orders-storage/schemas/receiving_history.json


### PR DESCRIPTION
## Purpose
Clearly document that the mod-orders-storage APIs are intended for internal use only.  When applicable, suggest an appropriate API to use instead.

## Approach
Add notes to the README and RAML files