### PR TITLE
MODORDSTOR-66 / MODORDSTOR-67- Removing adjustment and add new fields to Cost

### DIFF
--- a/src/main/resources/data/po-lines/101101-1_pending_physical_checkin-true.json
+++ b/src/main/resources/data/po-lines/101101-1_pending_physical_checkin-true.json
@@ -6,17 +6,6 @@
   "agreementId": "d4225afd-c449-4034-9847-1a43aa35d78e",
   "purchaseOrderId": "589a6016-3463-49f6-8aa2-dc315d0665fd",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "aa730047-6dd1-4a59-9396-5e5d69085c23",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 900.00,
     "currency": "USD",
+    "discount": 37,
+    "discountType": "percentage",
+    "listUnitPrice": 900.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 1,
     "quantityElectronic": 0,
-    "poLineEstimatedPrice": 900.00
+    "poLineEstimatedPrice": 567.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/101113-1_pending_physical.json
+++ b/src/main/resources/data/po-lines/101113-1_pending_physical.json
@@ -6,17 +6,6 @@
   "agreementId": "6bbc890c-0fa9-4ab3-802a-471ee18f72d5",
   "purchaseOrderId": "55b97a4a-6601-4488-84e1-8b0d47a3f523",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "86948b53-1e52-4024-b48a-cb70b2b35238",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 240.00,
     "currency": "USD",
-    "quantityPhysical": 1,
+    "discount": 14.1,
+    "discountType": "percentage",
+    "listUnitPrice": 240.00,
+    "listUnitPriceElectronic": 0.00,
+    "quantityPhysical": 2,
     "quantityElectronic": 0,
-    "poLineEstimatedPrice": 240.00
+    "poLineEstimatedPrice": 412.32
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/101125-1_pending_physical.json
+++ b/src/main/resources/data/po-lines/101125-1_pending_physical.json
@@ -6,17 +6,6 @@
   "agreementId": "0a79add6-f1a3-44f8-b75d-092c0b729286",
   "purchaseOrderId": "9447d062-89ec-486e-a14b-572f3efb9f8c",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "d30da72a-4969-4cbd-a256-3c65e8bd74c4",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 200.00,
     "currency": "USD",
+    "discount": 21,
+    "discountType": "percentage",
+    "listUnitPrice": 200.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 2,
     "quantityElectronic": 0,
-    "poLineEstimatedPrice": 200.00
+    "poLineEstimatedPrice": 316.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/14383007-1_pending_physical_gift.json
+++ b/src/main/resources/data/po-lines/14383007-1_pending_physical_gift.json
@@ -6,17 +6,6 @@
   "agreementId": "e4b9bd57-c5be-4772-ba1c-9e693a81147b",
   "purchaseOrderId": "8c328a18-5761-4329-95f6-599412c32310",
   "acquisitionMethod": "Gift",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "11619764-ed1d-4cc7-b850-36f770f99e16",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,8 +17,11 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 0.00,
     "currency": "USD",
+    "discount": 2,
+    "discountType": "amount",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 1,
     "quantityElectronic": 0,
     "poLineEstimatedPrice": 0.00

--- a/src/main/resources/data/po-lines/268758-01_awaiting_receipt_physical.json
+++ b/src/main/resources/data/po-lines/268758-01_awaiting_receipt_physical.json
@@ -6,17 +6,6 @@
   "agreementId": "05da8d23-d630-44ed-b61d-e780665c9efb",
   "purchaseOrderId": "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "3d6d495c-c237-476f-aa48-50f7cbf74ca4",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 34.95,
     "currency": "USD",
+    "discount": 1,
+    "discountType": "percentage",
+    "listUnitPrice": 34.95,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 1,
     "quantityElectronic": 0,
-    "poLineEstimatedPrice": 34.95
+    "poLineEstimatedPrice": 34.60
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/268758-02_awaiting_receipt_physical.json
+++ b/src/main/resources/data/po-lines/268758-02_awaiting_receipt_physical.json
@@ -6,17 +6,6 @@
   "agreementId": "7324c8eb-5e81-4109-812b-411c26ef09f2",
   "purchaseOrderId": "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "2d6d495c-c237-476f-aa48-50f7cbf74ca4",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 68.00,
     "currency": "USD",
+    "discount": 47.4,
+    "discountType": "percentage",
+    "listUnitPrice": 68.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 1,
     "quantityElectronic": 0,
-    "poLineEstimatedPrice": 68.00
+    "poLineEstimatedPrice": 35.768
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/268758-03_fully_received_electronic_resource.json
+++ b/src/main/resources/data/po-lines/268758-03_fully_received_electronic_resource.json
@@ -6,17 +6,6 @@
   "agreementId": "4f8f02af-ca34-46aa-b62c-42409a24b6ab",
   "purchaseOrderId": "1ab7ef6a-d1d4-4a4f-90a2-882aed18af14",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "2d6d495c-c237-476f-aa48-57f7cbf744a4",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 342.00,
     "currency": "USD",
+    "discount": 20,
+    "discountType": "amount",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 342.00,
     "quantityPhysical": 0,
     "quantityElectronic": 1,
-    "poLineEstimatedPrice": 342.00
+    "poLineEstimatedPrice": 322.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/268879-1_fully_received_electronic.json
+++ b/src/main/resources/data/po-lines/268879-1_fully_received_electronic.json
@@ -6,17 +6,6 @@
   "agreementId": "291e4a33-fc84-49c5-beac-661fc8bdd55e",
   "purchaseOrderId": "e5ae4afd-3fa9-494e-a972-f541df9b877e",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "91a6af2e-491e-422a-8f52-dd86dc033ab2",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 75.22,
     "currency": "USD",
+    "discount": 5.1,
+    "discountType": "amount",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 75.22,
     "quantityPhysical": 0,
     "quantityElectronic": 1,
-    "poLineEstimatedPrice": 75.22
+    "poLineEstimatedPrice": 70.12
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/306251-1_pending_electronic.json
+++ b/src/main/resources/data/po-lines/306251-1_pending_electronic.json
@@ -5,17 +5,6 @@
   "agreementId": "38451d3a-9e30-4eb1-be32-3fae8e349580",
   "purchaseOrderId": "e20af8c8-b07d-47a1-9ebd-f1187e9335bd",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "cc0f371f-3085-4123-96f2-00dc9fc9ea84",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -27,11 +16,14 @@
   ],
   "collection": true,
   "cost": {
-    "listPrice": 3000.00,
     "currency": "USD",
+    "discount": 50.0,
+    "discountType": "amount",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 3000.00,
     "quantityPhysical": 0,
-    "quantityElectronic": 1,
-    "poLineEstimatedPrice": 3000.00
+    "quantityElectronic": 2,
+    "poLineEstimatedPrice": 5950.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/306857-1_pending_physical.json
+++ b/src/main/resources/data/po-lines/306857-1_pending_physical.json
@@ -6,17 +6,6 @@
   "agreementId": "bfdbf5e3-8d5f-4ec0-9aed-38c68fb89254",
   "purchaseOrderId": "e41e0161-2bc6-41f3-a6e7-34fc13250bf1",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "0fc22e33-a8bb-4852-8135-ef34fcbc628c",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 800.00,
     "currency": "USD",
+    "discount": 20,
+    "discountType": "amount",
+    "listUnitPrice": 800.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 1,
     "quantityElectronic": 0,
-    "poLineEstimatedPrice": 800.00
+    "poLineEstimatedPrice": 780.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/312325-1_fully_received_electronic_method-purchase_at_vendor_system.json
+++ b/src/main/resources/data/po-lines/312325-1_fully_received_electronic_method-purchase_at_vendor_system.json
@@ -5,17 +5,6 @@
   "agreementId": "7cd9210e-c871-4421-8d37-b8603be6d037",
   "purchaseOrderId": "f4dc647c-ec82-442e-b13d-f9505b7ce8e9",
   "acquisitionMethod": "Purchase At Vendor System",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "86948b53-1e52-4024-b48a-cb70b2b35238",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -27,11 +16,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 150.00,
     "currency": "USD",
+    "discount": 21,
+    "discountType": "amount",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 150.00,
     "quantityPhysical": 0,
     "quantityElectronic": 1,
-    "poLineEstimatedPrice": 150.00
+    "poLineEstimatedPrice": 129.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/313000-1_awaiting_receipt_mix-format.json
+++ b/src/main/resources/data/po-lines/313000-1_awaiting_receipt_mix-format.json
@@ -6,17 +6,6 @@
   "agreementId": "e332be88-2ba3-43f7-a245-f5136bf2ffce",
   "purchaseOrderId": "05bdf3c8-01f0-4ddb-bd6c-6efd465f9e33",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "e493e18e-9147-4d6c-860e-2a8a9adac815",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 500.00,
     "currency": "USD",
+    "discount": 20,
+    "discountType": "amount",
+    "listUnitPrice": 500.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 6,
     "quantityElectronic": 1,
-    "poLineEstimatedPrice": 500.00
+    "poLineEstimatedPrice": 2980.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/36547-1_awaiting_receipt_physical_checkin-true.json
+++ b/src/main/resources/data/po-lines/36547-1_awaiting_receipt_physical_checkin-true.json
@@ -6,17 +6,6 @@
   "agreementId": "44683de8-e2cf-42bc-af9e-7eca992934b6",
   "purchaseOrderId": "1d6a455f-29c5-4e51-84d9-e28450ef86ad",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "366d495c-c237-476f-aa48-50f7cbf74ca4",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,11 +17,14 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 24.99,
     "currency": "USD",
+    "discount": 2,
+    "discountType": "percentage",
+    "listUnitPrice": 24.99,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 1,
     "quantityElectronic": 0,
-    "poLineEstimatedPrice": 24.99
+    "poLineEstimatedPrice": 24.49
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/po-lines/38434-1_pending_fomat-other.json
+++ b/src/main/resources/data/po-lines/38434-1_pending_fomat-other.json
@@ -6,17 +6,6 @@
   "agreementId": "09c6ed1b-3984-4d9a-8f9b-e1200b68b61c",
   "purchaseOrderId": "c27e60f9-6361-44c1-976e-0c4821a33a7d",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "86948b53-1e52-4024-b48a-cb70b2b35238",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,8 +17,11 @@
   ],
   "collection": false,
   "cost": {
-    "listPrice": 0.00,
     "currency": "USD",
+    "discount": 0,
+    "discountType": "percentage",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 2,
     "quantityElectronic": 0,
     "poLineEstimatedPrice": 0.00

--- a/src/main/resources/data/po-lines/52590-1_pending_physical.json
+++ b/src/main/resources/data/po-lines/52590-1_pending_physical.json
@@ -6,17 +6,6 @@
   "agreementId": "800b2f19-7134-4408-8145-3b04697b7de7",
   "purchaseOrderId": "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "2bfcc7bc-f64d-441b-ae2d-844eff8d5992",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -28,8 +17,11 @@
   ],
   "collection": true,
   "cost": {
-    "listPrice": 0.00,
     "currency": "USD",
+    "discount": 0.00,
+    "discountType": "percentage",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 0.00,
     "quantityPhysical": 1,
     "quantityElectronic": 0,
     "poLineEstimatedPrice": 0.00

--- a/src/main/resources/data/po-lines/S60402-80_electronic_receipt_status-absent.json
+++ b/src/main/resources/data/po-lines/S60402-80_electronic_receipt_status-absent.json
@@ -5,17 +5,6 @@
   "agreementId": "6af52c00-23ee-4460-a80b-027b4d61785d",
   "purchaseOrderId": "07f65192-44a4-483d-97aa-b137bbd96390",
   "acquisitionMethod": "Purchase",
-  "adjustment": {
-    "credit": 0.0,
-    "discount": 0.0,
-    "insurance": 0.0,
-    "invoiceId": "2d6dc95c-c237-476f-aa48-57f7cbf74ca4",
-    "overhead": 0.0,
-    "shipment": 0.0,
-    "tax1": 0.0,
-    "tax2": 0.0,
-    "useProRate": false
-  },
   "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
@@ -27,11 +16,14 @@
   ],
   "collection": true,
   "cost": {
-    "listPrice": 200000.00,
     "currency": "USD",
+    "discount": 200,
+    "discountType": "amount",
+    "listUnitPrice": 0.00,
+    "listUnitPriceElectronic": 200000.00,
     "quantityPhysical": 0,
     "quantityElectronic": 1,
-    "poLineEstimatedPrice": 200000.00
+    "poLineEstimatedPrice": 199800.00
   },
   "description": "",
   "details": {

--- a/src/main/resources/data/purchase-orders/101101_ongoing_pending.json
+++ b/src/main/resources/data/purchase-orders/101101_ongoing_pending.json
@@ -12,8 +12,6 @@
     "reviewPeriod": 30,
     "renewalDate": "2019-04-09T00:00:00.000Z"
   },
-  "totalEstimatedPrice": 900.00,
-  "totalItems": 1,
   "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/101113_ongoing_pending.json
+++ b/src/main/resources/data/purchase-orders/101113_ongoing_pending.json
@@ -12,8 +12,6 @@
     "reviewPeriod": 30,
     "renewalDate": "2019-04-09T00:00:00.000Z"
   },
-  "totalEstimatedPrice": 240.00,
-  "totalItems": 1,
   "vendor": "50fb8da4-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/101125_one-time_pending.json
+++ b/src/main/resources/data/purchase-orders/101125_one-time_pending.json
@@ -5,8 +5,6 @@
   "poNumber": "101125",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 200.00,
-  "totalItems": 2,
   "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/14383007_ongoing_open.json
+++ b/src/main/resources/data/purchase-orders/14383007_ongoing_open.json
@@ -13,8 +13,6 @@
     "reviewPeriod": 30,
     "renewalDate": "2019-04-09T00:00:00.000Z"
   },
-  "totalEstimatedPrice": 0.00,
-  "totalItems": 1,
   "vendor": "50fb8c82-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Open",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/268758_one-time_open.json
+++ b/src/main/resources/data/purchase-orders/268758_one-time_open.json
@@ -6,8 +6,6 @@
   "poNumber": "268758",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 444.95,
-  "totalItems": 3,
   "vendor": "50fb88ea-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Open",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/268879_one-time_closed.json
+++ b/src/main/resources/data/purchase-orders/268879_one-time_closed.json
@@ -6,8 +6,6 @@
   "poNumber": "268879",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 75.22,
-  "totalItems": 1,
   "vendor": "50fb922c-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Closed",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/306251_one-time_closed.json
+++ b/src/main/resources/data/purchase-orders/306251_one-time_closed.json
@@ -9,8 +9,6 @@
   "poNumber": "306251",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 3000.00,
-  "totalItems": 1,
   "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Closed",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/306857_ongoing_open.json
+++ b/src/main/resources/data/purchase-orders/306857_ongoing_open.json
@@ -16,8 +16,6 @@
     "reviewPeriod": 30,
     "renewalDate": "2019-04-09T00:00:00.000Z"
   },
-  "totalEstimatedPrice": 800.00,
-  "totalItems": 1,
   "vendor": "50fb90ec-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Open",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/312325_one-time_open.json
+++ b/src/main/resources/data/purchase-orders/312325_one-time_open.json
@@ -12,8 +12,6 @@
   "poNumber": "312325",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 150.00,
-  "totalItems": 1,
   "vendor": "50fb8a2a-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Open",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/313000_one-time_open.json
+++ b/src/main/resources/data/purchase-orders/313000_one-time_open.json
@@ -9,8 +9,6 @@
   "poNumber": "313000",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 500.00,
-  "totalItems": 7,
   "vendor": "50fb8a2a-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Open",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/36547_one_time_closed.json
+++ b/src/main/resources/data/purchase-orders/36547_one_time_closed.json
@@ -6,8 +6,6 @@
   "poNumber": "36547",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 24.99,
-  "totalItems": 1,
   "vendor": "168f8a86-d26c-406e-813f-c9927f2413c3",
   "workflowStatus": "Closed",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/38434_ongoing_pending.json
+++ b/src/main/resources/data/purchase-orders/38434_ongoing_pending.json
@@ -15,8 +15,6 @@
     "reviewPeriod": 30,
     "renewalDate": "2019-04-09T00:00:00.000Z"
   },
-  "totalEstimatedPrice": 0.00,
-  "totalItems": 2,
   "vendor": "50fb922c-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/52590_one-time_pending.json
+++ b/src/main/resources/data/purchase-orders/52590_one-time_pending.json
@@ -8,8 +8,6 @@
   "poNumber": "52590",
   "orderType": "One-Time",
   "reEncumber": false,
-  "totalEstimatedPrice": 0.00,
-  "totalItems": 1,
   "vendor": "50fb8c82-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
   "metadata": {

--- a/src/main/resources/data/purchase-orders/S60402_ongoing_closed.json
+++ b/src/main/resources/data/purchase-orders/S60402_ongoing_closed.json
@@ -13,8 +13,6 @@
     "reviewPeriod": 30,
     "renewalDate": "2019-04-09T00:00:00.000Z"
   },
-  "totalEstimatedPrice": 200000.00,
-  "totalItems": 1,
   "vendor": "50fb8b56-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Closed",
   "metadata": {

--- a/src/test/resources/po-line-for-view.sample
+++ b/src/test/resources/po-line-for-view.sample
@@ -28,7 +28,7 @@
     "listUnitPriceElectronic": 15,
     "quantityPhysical": 1,
     "quantityElectronic": 1,
-    "poLineEstimatedPrice": 49.98
+    "poLineEstimatedPrice": 34.99
   },
   "checkinItems": true,
   "instanceId": "8343e5a0-fed8-11e8-8eb2-f2801f1b9fd2",

--- a/src/test/resources/po-line-for-view.sample
+++ b/src/test/resources/po-line-for-view.sample
@@ -1,17 +1,6 @@
 {
   "id": "2fe6c2dd-3700-4a53-a624-1159cfd7f8ce",
   "acquisitionMethod": "Purchase At Vendor System",
-  "adjustment": {
-    "credit": 1.0,
-    "discount": 1.0,
-    "insurance": 0.5,
-    "invoiceId": "2d6d495c-c237-476f-aa48-57f7cbf74ca4",
-    "overhead": 1.0,
-    "shipment": 1.0,
-    "tax1": 0.75,
-    "tax2": 0.75,
-    "useProRate": false
-  },
   "alerts": [
     "6c576118-3da7-4b30-b9b9-3678ac4fe9a4"
   ],
@@ -33,7 +22,10 @@
   "cost":
   {
     "currency": "USD",
-    "listPrice": 24.99,
+    "listUnitPrice": 24.99,
+    "discountType": "amount",
+    "discount": 5.00,
+    "listUnitPriceElectronic": 15,
     "quantityPhysical": 1,
     "quantityElectronic": 1,
     "poLineEstimatedPrice": 49.98

--- a/src/test/resources/po-line.sample
+++ b/src/test/resources/po-line.sample
@@ -1,17 +1,6 @@
 {
   "id": "d471d766-8dbb-4609-999a-02681dea6c22",
   "acquisitionMethod": "Purchase At Vendor System",
-  "adjustment": {
-    "credit": 1.0,
-    "discount": 1.0,
-    "insurance": 0.5,
-    "invoiceId": "2d6d495c-c237-476f-aa48-57f7cbf74ca4",
-    "overhead": 1.0,
-    "shipment": 1.0,
-    "tax1": 0.75,
-    "tax2": 0.75,
-    "useProRate": false
-  },
   "alerts": [
     "9a665b22-9fe5-4c95-b4ee-837a5433c95d"
   ],
@@ -32,7 +21,10 @@
   ],
   "cost": {
     "currency": "USD",
-    "listPrice": 24.99,
+    "listUnitPrice": 24.99,
+    "discountType": "percentage",
+    "discount": 15,
+    "listUnitPriceElectronic": 10,
     "quantityPhysical": 1,
     "quantityElectronic": 1,
     "poLineEstimatedPrice": 49.98

--- a/src/test/resources/po-line.sample
+++ b/src/test/resources/po-line.sample
@@ -24,10 +24,10 @@
     "listUnitPrice": 24.99,
     "discountType": "percentage",
     "discount": 15,
-    "listUnitPriceElectronic": 10,
+    "listUnitPriceElectronic": 10.00,
     "quantityPhysical": 1,
     "quantityElectronic": 1,
-    "poLineEstimatedPrice": 49.98
+    "poLineEstimatedPrice": 29.74
   },
   "checkinItems": false,
   "instanceId": "8343e5a0-fed8-11e8-8eb2-f2801f1b9fd1",

--- a/src/test/resources/purchase-order-for-view.sample
+++ b/src/test/resources/purchase-order-for-view.sample
@@ -8,8 +8,6 @@
   "orderType": "One-Time",
   "poNumber": "268500",
   "reEncumber": false,
-  "totalEstimatedPrice": 49.98,
-  "totalItems": 2,
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "workflowStatus": "Open"
 }

--- a/src/test/resources/purchase-order.sample
+++ b/src/test/resources/purchase-order.sample
@@ -1,6 +1,5 @@
 {
   "id": "1ba7ef6a-d1d4-4a4f-90a2-882aed18af16",
-  "adjustment": "9b3be694-6716-4e14-b81d-8d76f0ae4146",
   "approved": true,
   "assignedTo": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "dateOrdered": "2018-09-09T00:00:00.000Z",
@@ -20,8 +19,6 @@
      "renewalDate": "2019-04-09T00:00:00.000Z",
      "reviewPeriod": 30
   },
-  "totalEstimatedPrice": 49.98,
-  "totalItems": 2,
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "workflowStatus": "Pending"
 }


### PR DESCRIPTION
[MODORDSTOR-66](https://issues.folio.org/browse/MODORDSTOR-66) - Updates to poLine Cost
[MODORDSTOR-67](https://issues.folio.org/browse/MODORDSTOR-67) - Updates to PO total estimated cost

## Purpose
In conjunction with [MODORDERS-181](https://issues.folio.org/browse/MODORDERS-181), mod-orders-storage requires several changes to schemas and sample data.

## Approach
Updating schemas and sample data.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
