### PR TITLE
MODORDSTOR-22 - Implement GET /orders w/ search and filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,18 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.3</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -2,7 +2,6 @@ package org.folio.rest.persist;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -84,11 +83,6 @@ public class HelperUtils {
       log.error(e.getMessage(), e);
       asyncResultHandler.handle(response(e.getMessage(), respond500, respond500));
     }
-  }
-
-  public static void respond(Handler<AsyncResult<Response>> handler, Response response) {
-    AsyncResult<Response> result = Future.succeededFuture(response);
-    handler.handle(result);
   }
 
   private static Method getRespond500(EntitiesMetadataHolder entitiesMetadataHolder, Handler<AsyncResult<Response>> asyncResultHandler) {

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -27,7 +27,7 @@ public class HelperUtilsTest extends TestBase {
   public void getEntitiesCollectionWithDistinctOnFailNpExTest() throws Exception {
     PowerMockito.spy(PgUtil.class);
     PowerMockito.doThrow(new NullPointerException()).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
-    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
@@ -49,7 +49,7 @@ public class HelperUtilsTest extends TestBase {
     EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
     PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond400WithTextPlainMethod();
     PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
-    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
@@ -57,7 +57,7 @@ public class HelperUtilsTest extends TestBase {
     EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
     PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond200WithApplicationJson();
     PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
-    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   private ValidatableResponse get(URL endpoint) {

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -53,6 +53,14 @@ public class HelperUtilsTest extends TestBase {
   }
 
   @Test
+  public void entitiesMetadataHolderRespond500FailTest() throws Exception {
+    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
+    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond500WithTextPlainMethod();
+    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
+  }
+
+  @Test
   public void entitiesMetadataHolderRespond200FailTest() throws Exception {
     EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
     PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond200WithApplicationJson();

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -1,0 +1,70 @@
+package org.folio.rest.impl;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.vertx.core.Context;
+import org.folio.HttpStatus;
+import org.folio.rest.persist.EntitiesMetadataHolder;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.cql.CQLQueryValidationException;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.net.URL;
+import java.util.Map;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+import static org.mockito.ArgumentMatchers.any;
+
+public class HelperUtilsTest extends TestBase {
+
+  private static final String EXCEPTIONAL_METHOD_NAME = "postgresClient";
+  private static final String ORDERS_ENDPOINT = "/orders-storage/orders";
+  private static final String RECEIVING_HISTORY_ENDPOINT = "/orders-storage/receiving-history";
+
+  @Test
+  public void getEntitiesCollectionWithDistinctOnFailNpExTest() throws Exception {
+    PowerMockito.spy(PgUtil.class);
+    PowerMockito.doThrow(new NullPointerException()).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
+  }
+
+  @Test
+  public void getEntitiesCollectionWithDistinctOnFailCqlExTest() throws Exception {
+    PowerMockito.spy(PgUtil.class);
+    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
+  }
+
+  @Test
+  public void getEntitiesCollectionFailTest() throws Exception {
+    PowerMockito.spy(PgUtil.class);
+    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    get(storageUrl(RECEIVING_HISTORY_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
+  }
+
+  @Test
+  public void entitiesMetadataHolderRespond400FailTest() throws Exception {
+    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
+    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond400WithTextPlainMethod();
+    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
+  }
+
+  @Test
+  public void entitiesMetadataHolderRespond200FailTest() throws Exception {
+    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
+    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond200WithApplicationJson();
+    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
+  }
+
+  private ValidatableResponse get(URL endpoint) {
+    return RestAssured
+      .with()
+        .header(TENANT_HEADER)
+        .get(endpoint)
+          .then();
+  }
+}

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -7,6 +7,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.persist.EntitiesMetadataHolder;
+import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -14,6 +16,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -29,7 +35,10 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 
 
-@RunWith(Suite.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Suite.class)
+@PowerMockIgnore({"javax.net.ssl.*", "org.apache.logging.log4j.*"})
+@PrepareForTest({PgUtil.class, EntitiesMetadataHolder.class, OrdersAPI.class})
 
 @Suite.SuiteClasses({
   EntitiesCrudTest.class,
@@ -38,7 +47,8 @@ import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
   PurchaseOrderLineNumberTest.class,
   PurchaseOrderNumberUniquenessTest.class,
   ReceivingHistoryTest.class,
-  TenantSampleDataTest.class
+  TenantSampleDataTest.class,
+  HelperUtilsTest.class
 })
 
 public class StorageTestSuite {


### PR DESCRIPTION
PowerMockito included for covering failed API paths in PR [#102](https://github.com/folio-org/mod-orders-storage/pull/102).