### PR TITLE
MODORDSTOR-72 - Release 5.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,18 @@
-## 5.0.0 - Unreleased
+## 5.1.0 - Unreleased
+
+## 5.0.0 - Released
+The primary focus of this release was to accommodate increased flexibility in inventory integration and also provide endpoints for Purchase Order and Purchase Order Lines search and filtering based on complex criteria.
+
+[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v4.0.0...v5.0.0)
+
+### Stories
+* [MODORDSTOR-73](https://issues.folio.org/browse/MODORDSTOR-73) - Implement `GET /orders-storage/order-lines` w/ search and filtering
+* [MODORDSTOR-70](https://issues.folio.org/browse/MODORDSTOR-70) - Make `poLine.checkinItems` default to `false`
+* [MODORDSTOR-69](https://issues.folio.org/browse/MODORDSTOR-69) - Need the ability to specify materialType for physical and E-resource
+* [MODORDSTOR-68](https://issues.folio.org/browse/MODORDSTOR-68) - Piece records should have format of the piece, not the poLine
+* [MODORDSTOR-65](https://issues.folio.org/browse/MODORDSTOR-65) - Update sample data to accommodate increased flexibility in inventory integration
+* [MODORDSTOR-50](https://issues.folio.org/browse/MODORDSTOR-50) - Use sample data in unit tests
+* [MODORDSTOR-22](https://issues.folio.org/browse/MODORDSTOR-22) - Implement `GET /orders-storage/orders` w/ search and filtering
 
 ## 4.0.0 - Released
 The primary focus of this release was to refactor Purchase Order Line model and related endpoints.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 5.1.0 - Unreleased
+## 6.0.0 - Unreleased
 
 ## 5.0.0 - Released
 The primary focus of this release was to accommodate increased flexibility in inventory integration and also provide endpoints for Purchase Order and Purchase Order Lines search and filtering based on complex criteria.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -35,7 +35,7 @@
     },
     {
       "id": "orders-storage.pieces",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -66,7 +66,7 @@
     },
     {
       "id": "orders-storage.po-lines",
-      "version": "4.0",
+      "version": "5.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -97,7 +97,7 @@
     },
     {
       "id": "orders-storage.purchase-orders",
-      "version": "4.0",
+      "version": "5.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -133,7 +133,7 @@
     },
     {
       "id": "orders-storage.receiving-history",
-      "version": "2.1",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.0.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -469,7 +469,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v5.0.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>5.0.0</version>
+  <version>6.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -469,7 +469,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v5.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/ramls/orders.raml
+++ b/ramls/orders.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders-storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v4
+version: v5
 
 documentation:
   - title: Orders

--- a/ramls/pieces.raml
+++ b/ramls/pieces.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
-version: v2
+version: v3
 
 documentation:
   - title: Pieces

--- a/ramls/po-line.raml
+++ b/ramls/po-line.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v4
+version: v5
 
 documentation:
   - title: PO Line

--- a/ramls/purchase-order.raml
+++ b/ramls/purchase-order.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders-storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v4
+version: v5
 
 documentation:
   - title: Purchase Order

--- a/ramls/receiving-history.raml
+++ b/ramls/receiving-history.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "mod-orders-storage"
 baseUri: http://github.com/folio-org/mod-orders-storage
-version: v2.1
+version: v3
 
 documentation:
   - title: Receiving History


### PR DESCRIPTION
## Purpose
[MODORDSTOR-72](https://issues.folio.org/browse/MODORDSTOR-72) - Release 5.0.0

## Approach
- Preparing News
- Increase following interface versions due to non-backward compatible changes
  - `orders-storage.pieces`
  - `orders-storage.po-lines`
  - `orders-storage.purchase-orders`
  - `orders-storage.receiving-history`


#### TODOS and Open Questions
- [x] Prepare release PR for mod-orders

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
