### PR TITLE
MODORDSTOR-98 Schema updates: filterable boolean properties to have default value

### DIFF
--- a/src/main/resources/data/po-lines/268758-01_awaiting_receipt_physical.json
+++ b/src/main/resources/data/po-lines/268758-01_awaiting_receipt_physical.json
@@ -76,7 +76,7 @@
   "receiptStatus": "Awaiting Receipt",
   "reportingCodes": [],
   "requester": "",
-  "rush": false,
+  "rush": true,
   "selector": "Brown",
   "source": {
     "code": "",

--- a/src/main/resources/data/po-lines/268758-02_awaiting_receipt_physical.json
+++ b/src/main/resources/data/po-lines/268758-02_awaiting_receipt_physical.json
@@ -76,7 +76,7 @@
   "receiptStatus": "Awaiting Receipt",
   "reportingCodes": [],
   "requester": "",
-  "rush": false,
+  "rush": true,
   "selector": "Stevens",
   "source": {
     "code": "",

--- a/src/main/resources/data/po-lines/268879-1_fully_received_electronic.json
+++ b/src/main/resources/data/po-lines/268879-1_fully_received_electronic.json
@@ -35,12 +35,12 @@
   "edition": "First edition",
   "eresource": {
     "accessProvider": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "activated": true,
+    "activated": false,
     "activationDue": 0,
     "createInventory": "None",
     "expectedActivation": "2014-07-06T00:00:00.000Z",
     "materialType": "615b8413-82d5-4203-aa6e-e37984cb5ac3",
-    "trial": false,
+    "trial": true,
     "userLimit": 1
   },
   "fundDistribution": [

--- a/src/main/resources/data/po-lines/312325-1_fully_received_electronic_method-purchase_at_vendor_system.json
+++ b/src/main/resources/data/po-lines/312325-1_fully_received_electronic_method-purchase_at_vendor_system.json
@@ -76,7 +76,7 @@
   "receiptStatus": "Fully Received",
   "reportingCodes": [],
   "requester": "msmith",
-  "rush": false,
+  "rush": true,
   "selector": "dhalling",
   "source": {
     "code": "",

--- a/src/main/resources/data/po-lines/313000-1_awaiting_receipt_mix-format.json
+++ b/src/main/resources/data/po-lines/313000-1_awaiting_receipt_mix-format.json
@@ -45,12 +45,12 @@
   "edition": "First edition",
   "eresource": {
     "accessProvider": "14fb6608-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "activated": true,
+    "activated": false,
     "activationDue": 1,
     "createInventory": "Instance, Holding",
     "expectedActivation": "2019-07-20T00:00:00.000Z",
     "materialType": "a7eb0130-7287-4485-b32c-b4b5814da0fa",
-    "trial": false,
+    "trial": true,
     "userLimit": 0
   },
   "fundDistribution": [

--- a/src/main/resources/data/purchase-orders/101113_ongoing_pending.json
+++ b/src/main/resources/data/purchase-orders/101113_ongoing_pending.json
@@ -9,7 +9,7 @@
   "renewal": {
     "cycle": "6 Months",
     "interval": 182,
-    "manualRenewal": true,
+    "manualRenewal": false,
     "renewalDate": "2019-04-09T00:00:00.000Z",
     "reviewPeriod": 30
   },

--- a/src/main/resources/data/purchase-orders/306857_ongoing_open.json
+++ b/src/main/resources/data/purchase-orders/306857_ongoing_open.json
@@ -9,11 +9,11 @@
   "orderType": "Ongoing",
   "owner": "Cushing",
   "poNumber": "306857",
-  "reEncumber": false,
+  "reEncumber": true,
   "renewal": {
     "cycle": "6 Months",
     "interval": 182,
-    "manualRenewal": true,
+    "manualRenewal": false,
     "renewalDate": "2019-04-09T00:00:00.000Z",
     "reviewPeriod": 30
   },

--- a/src/main/resources/data/purchase-orders/313110_order_without_poLines.json
+++ b/src/main/resources/data/purchase-orders/313110_order_without_poLines.json
@@ -1,5 +1,6 @@
 {
   "id": "cf4bfd64-e609-4ecb-b3e6-7a5a1ced1645",
+  "approved": false,
   "manualPo": false,
   "notes": [
     "DVD plus 3 years streaming"

--- a/src/main/resources/data/purchase-orders/38434_ongoing_pending.json
+++ b/src/main/resources/data/purchase-orders/38434_ongoing_pending.json
@@ -1,6 +1,6 @@
 {
   "id": "c27e60f9-6361-44c1-976e-0c4821a33a7d",
-  "approved": true,
+  "approved": false,
   "manualPo": true,
   "notes": [
     "Cataloging record service"
@@ -8,7 +8,7 @@
   "orderType": "Ongoing",
   "owner": "Monographs",
   "poNumber": "38434",
-  "reEncumber": false,
+  "reEncumber": true,
   "renewal": {
     "cycle": "6 Months",
     "interval": 182,

--- a/src/main/resources/data/purchase-orders/52590_one-time_pending.json
+++ b/src/main/resources/data/purchase-orders/52590_one-time_pending.json
@@ -1,6 +1,6 @@
 {
   "id": "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
-  "approved": true,
+  "approved": false,
   "manualPo": false,
   "notes": [
     "2 titles received: Publication and London topographical record"


### PR DESCRIPTION
## Purpose
[MODORDSTOR-98](https://issues.folio.org/browse/MODORDSTOR-98) filterable `boolean` properties should have default value

## Approach
- pointing to updated acq-models
- setting different values to let filtering work having just sample data

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
