### PR TITLE
MODORDSTOR-97 - Randomly failing HelperUtilsTest unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,15 +109,9 @@
       <version>4.5.3</version>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.2</version>
+      <groupId>org.jmockit</groupId>
+      <artifactId>jmockit</artifactId>
+      <version>1.41</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -2,68 +2,102 @@ package org.folio.rest.impl;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
-import static org.mockito.ArgumentMatchers.any;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import io.vertx.core.Context;
+
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Map;
+
+import mockit.Mock;
+import mockit.MockUp;
+
+import mockit.integration.junit4.JMockit;
 import org.folio.HttpStatus;
 import org.folio.rest.persist.EntitiesMetadataHolder;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
+import org.junit.runner.RunWith;
 
+@RunWith(JMockit.class)
 public class HelperUtilsTest extends TestBase {
 
-  private static final String EXCEPTIONAL_METHOD_NAME = "postgresClient";
   private static final String ORDERS_ENDPOINT = "/orders-storage/orders";
   private static final String RECEIVING_HISTORY_ENDPOINT = "/orders-storage/receiving-history";
 
   @Test
   public void getEntitiesCollectionWithDistinctOnFailCqlExTest() throws Exception {
-    PowerMockito.spy(PgUtil.class);
-    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    new MockUp<PgUtil>()
+    {
+      @Mock
+      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
+        throw new CQLQueryValidationException(null);
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void getEntitiesCollectionFailTest() throws Exception {
-    PowerMockito.spy(PgUtil.class);
-    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    new MockUp<PgUtil>()
+    {
+      @Mock
+      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
+        throw new CQLQueryValidationException(null);
+      }
+    };
     get(storageUrl(RECEIVING_HISTORY_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond400FailTest() throws Exception {
-    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
-    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond400WithTextPlainMethod();
-    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    new MockUp<EntitiesMetadataHolder>()
+    {
+      @Mock
+      Method getRespond400WithTextPlainMethod() throws NoSuchMethodException {
+        throw new NoSuchMethodException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond500FailTest() throws Exception {
-    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
-    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond500WithTextPlainMethod();
-    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    new MockUp<EntitiesMetadataHolder>()
+    {
+      @Mock
+      Method getRespond500WithTextPlainMethod() throws NoSuchMethodException {
+        throw new NoSuchMethodException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond200FailTest() throws Exception {
-    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
-    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond200WithApplicationJson();
-    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    new MockUp<EntitiesMetadataHolder>()
+    {
+      @Mock
+      Method getRespond200WithApplicationJson() throws NoSuchMethodException {
+        throw new NoSuchMethodException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void getEntitiesCollectionWithDistinctOnFailNpExTest() throws Exception {
-    PowerMockito.spy(PgUtil.class);
-    PowerMockito.doThrow(new NullPointerException()).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    new MockUp<PgUtil>()
+    {
+      @Mock
+      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
+        throw new NullPointerException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -7,8 +7,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.RestVerticle;
-import org.folio.rest.persist.EntitiesMetadataHolder;
-import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -16,10 +14,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -35,10 +29,7 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 
 
-@RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(Suite.class)
-@PowerMockIgnore({"javax.net.ssl.*", "org.apache.logging.log4j.*"})
-@PrepareForTest({PgUtil.class, EntitiesMetadataHolder.class, OrdersAPI.class})
+@RunWith(Suite.class)
 
 @Suite.SuiteClasses({
   EntitiesCrudTest.class,


### PR DESCRIPTION
[MODORDSTOR-97](https://issues.folio.org/browse/MODORDSTOR-97) - Randomly failing HelperUtilsTest unit tests

## Purpose
For fixing random HelperUtilsTest fails after migration to junit5.

## Approach
Migration PowerMockito -> JMockit.
At the present moment JMockit 1.41 is used https://jmockit.github.io/changes.html#1.41 because higher versions require "-javaagent" JVM initialization parameter. Current JMockit functionality is enough for actual tasks. In the future we can consider migrating to more recent versions if needed.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
 