### PR TITLE
MODORDSTOR-97 - Randomly failing HelperUtilsTest unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <postgres.driver.version>9.4.1212</postgres.driver.version>
     <junit-jupiter-version>5.4.2</junit-jupiter-version>
+    <jmockit.version>1.46</jmockit.version>
   </properties>
 
   <repositories>
@@ -103,15 +104,9 @@
       <version>4.5.3</version>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.2</version>
+      <groupId>org.jmockit</groupId>
+      <artifactId>jmockit</artifactId>
+      <version>${jmockit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -446,6 +441,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.1</version>
         <configuration>
+          <argLine>
+            -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+          </argLine>
           <excludes>
             <exclude>org/folio/rest/impl/*Test.java</exclude>
           </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
@@ -109,9 +103,15 @@
       <version>4.5.3</version>
     </dependency>
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
-      <version>1.41</version>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonObject;
@@ -19,7 +17,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@RunWith(JUnitPlatform.class)
 public class EntitiesCrudTest extends TestBase {
 
   private final Logger logger = LoggerFactory.getLogger(EntitiesCrudTest.class);

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -2,68 +2,100 @@ package org.folio.rest.impl;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
-import static org.mockito.ArgumentMatchers.any;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import io.vertx.core.Context;
+
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Map;
+
+import mockit.Mock;
+import mockit.MockUp;
+
 import org.folio.HttpStatus;
 import org.folio.rest.persist.EntitiesMetadataHolder;
 import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
-import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
+
+import org.junit.jupiter.api.Test;
 
 public class HelperUtilsTest extends TestBase {
 
-  private static final String EXCEPTIONAL_METHOD_NAME = "postgresClient";
   private static final String ORDERS_ENDPOINT = "/orders-storage/orders";
   private static final String RECEIVING_HISTORY_ENDPOINT = "/orders-storage/receiving-history";
 
   @Test
   public void getEntitiesCollectionWithDistinctOnFailCqlExTest() throws Exception {
-    PowerMockito.spy(PgUtil.class);
-    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    new MockUp<PgUtil>()
+    {
+      @Mock
+      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
+        throw new CQLQueryValidationException(null);
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void getEntitiesCollectionFailTest() throws Exception {
-    PowerMockito.spy(PgUtil.class);
-    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    new MockUp<PgUtil>()
+    {
+      @Mock
+      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
+        throw new CQLQueryValidationException(null);
+      }
+    };
     get(storageUrl(RECEIVING_HISTORY_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond400FailTest() throws Exception {
-    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
-    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond400WithTextPlainMethod();
-    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    new MockUp<EntitiesMetadataHolder>()
+    {
+      @Mock
+      Method getRespond400WithTextPlainMethod() throws NoSuchMethodException {
+        throw new NoSuchMethodException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond500FailTest() throws Exception {
-    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
-    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond500WithTextPlainMethod();
-    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    new MockUp<EntitiesMetadataHolder>()
+    {
+      @Mock
+      Method getRespond500WithTextPlainMethod() throws NoSuchMethodException {
+        throw new NoSuchMethodException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond200FailTest() throws Exception {
-    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
-    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond200WithApplicationJson();
-    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
+    new MockUp<EntitiesMetadataHolder>()
+    {
+      @Mock
+      Method getRespond200WithApplicationJson() throws NoSuchMethodException {
+        throw new NoSuchMethodException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void getEntitiesCollectionWithDistinctOnFailNpExTest() throws Exception {
-    PowerMockito.spy(PgUtil.class);
-    PowerMockito.doThrow(new NullPointerException()).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
+    new MockUp<PgUtil>()
+    {
+      @Mock
+      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
+        throw new NullPointerException();
+      }
+    };
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -13,7 +13,7 @@ import org.folio.HttpStatus;
 import org.folio.rest.persist.EntitiesMetadataHolder;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -13,16 +13,9 @@ import org.folio.HttpStatus;
 import org.folio.rest.persist.EntitiesMetadataHolder;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.net.ssl.*", "org.apache.logging.log4j.*"})
-@PrepareForTest({PgUtil.class, EntitiesMetadataHolder.class, OrdersAPI.class})
 public class HelperUtilsTest extends TestBase {
 
   private static final String EXCEPTIONAL_METHOD_NAME = "postgresClient";

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -2,102 +2,75 @@ package org.folio.rest.impl;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+import static org.mockito.ArgumentMatchers.any;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import io.vertx.core.Context;
-
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Map;
-
-import mockit.Mock;
-import mockit.MockUp;
-
-import mockit.integration.junit4.JMockit;
 import org.folio.HttpStatus;
 import org.folio.rest.persist.EntitiesMetadataHolder;
 import org.folio.rest.persist.PgUtil;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(JMockit.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.net.ssl.*", "org.apache.logging.log4j.*"})
+@PrepareForTest({PgUtil.class, EntitiesMetadataHolder.class, OrdersAPI.class})
 public class HelperUtilsTest extends TestBase {
 
+  private static final String EXCEPTIONAL_METHOD_NAME = "postgresClient";
   private static final String ORDERS_ENDPOINT = "/orders-storage/orders";
   private static final String RECEIVING_HISTORY_ENDPOINT = "/orders-storage/receiving-history";
 
   @Test
   public void getEntitiesCollectionWithDistinctOnFailCqlExTest() throws Exception {
-    new MockUp<PgUtil>()
-    {
-      @Mock
-      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
-        throw new CQLQueryValidationException(null);
-      }
-    };
+    PowerMockito.spy(PgUtil.class);
+    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_BAD_REQUEST.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void getEntitiesCollectionFailTest() throws Exception {
-    new MockUp<PgUtil>()
-    {
-      @Mock
-      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
-        throw new CQLQueryValidationException(null);
-      }
-    };
+    PowerMockito.spy(PgUtil.class);
+    PowerMockito.doThrow(new CQLQueryValidationException(null)).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
     get(storageUrl(RECEIVING_HISTORY_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond400FailTest() throws Exception {
-    new MockUp<EntitiesMetadataHolder>()
-    {
-      @Mock
-      Method getRespond400WithTextPlainMethod() throws NoSuchMethodException {
-        throw new NoSuchMethodException();
-      }
-    };
+    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
+    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond400WithTextPlainMethod();
+    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond500FailTest() throws Exception {
-    new MockUp<EntitiesMetadataHolder>()
-    {
-      @Mock
-      Method getRespond500WithTextPlainMethod() throws NoSuchMethodException {
-        throw new NoSuchMethodException();
-      }
-    };
+    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
+    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond500WithTextPlainMethod();
+    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void entitiesMetadataHolderRespond200FailTest() throws Exception {
-    new MockUp<EntitiesMetadataHolder>()
-    {
-      @Mock
-      Method getRespond200WithApplicationJson() throws NoSuchMethodException {
-        throw new NoSuchMethodException();
-      }
-    };
+    EntitiesMetadataHolder holder = PowerMockito.mock(EntitiesMetadataHolder.class);
+    PowerMockito.doThrow(new NoSuchMethodException()).when(holder).getRespond200WithApplicationJson();
+    PowerMockito.whenNew(EntitiesMetadataHolder.class).withAnyArguments().thenReturn(holder);
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 
   @Test
   public void getEntitiesCollectionWithDistinctOnFailNpExTest() throws Exception {
-    new MockUp<PgUtil>()
-    {
-      @Mock
-      PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
-        throw new NullPointerException();
-      }
-    };
+    PowerMockito.spy(PgUtil.class);
+    PowerMockito.doThrow(new NullPointerException()).when(PgUtil.class, EXCEPTIONAL_METHOD_NAME, any(Context.class), any(Map.class));
     get(storageUrl(ORDERS_ENDPOINT)).statusCode(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()).contentType(TEXT_PLAIN);
   }
 

--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -7,7 +7,7 @@ import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.PurchaseOrderCollection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;

--- a/src/test/java/org/folio/rest/impl/PoNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/PoNumberTest.java
@@ -2,7 +2,7 @@ package org.folio.rest.impl;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 
@@ -13,7 +13,6 @@ public class PoNumberTest extends TestBase {
   private final Logger logger = LoggerFactory.getLogger(PoNumberTest.class);
 
   private static final String PO_NUMBER_ENDPOINT = "/orders-storage/po-number";
-
 
   @Test
   public void testGetPoNumberOk() throws MalformedURLException {

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLineNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLineNumberTest.java
@@ -6,11 +6,9 @@ import io.vertx.core.Vertx;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.rest.persist.PostgresClient;
 import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 import java.util.HashMap;
@@ -21,7 +19,6 @@ import java.util.concurrent.TimeUnit;
 import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(VertxUnitRunner.class)
 public class PurchaseOrderLineNumberTest extends TestBase {
 
   private final Logger logger = LoggerFactory.getLogger(PurchaseOrderLineNumberTest.class);

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
@@ -5,7 +5,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.utils.TestEntities;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderNumberUniquenessTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderNumberUniquenessTest.java
@@ -5,7 +5,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 

--- a/src/test/java/org/folio/rest/impl/ReceivingHistoryTest.java
+++ b/src/test/java/org/folio/rest/impl/ReceivingHistoryTest.java
@@ -15,7 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import org.folio.rest.jaxrs.model.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ReceivingHistoryTest extends TestBase {

--- a/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
@@ -16,9 +16,9 @@ import org.folio.rest.jaxrs.model.Physical;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLine.OrderFormat;
 import org.folio.rest.jaxrs.model.PoLineCollection;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class SearchOrderLinesTest extends TestBase {
   private static final Logger logger = LoggerFactory.getLogger(SearchOrderLinesTest.class);
@@ -27,13 +27,13 @@ public class SearchOrderLinesTest extends TestBase {
   private static final String TENANT_NAME = "polinesearch";
   static final Header NEW_TENANT = new Header(OKAPI_HEADER_TENANT, TENANT_NAME);
 
-  @BeforeClass
+  @BeforeAll
   public static void before() throws MalformedURLException {
     logger.info("Create a new tenant loading the sample data");
     prepareTenant(NEW_TENANT, true);
   }
 
-  @AfterClass
+  @AfterAll
   public static void after() throws MalformedURLException {
     logger.info("Delete the created \"polinesearch\" tenant");
     deleteTenant(NEW_TENANT);

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -7,19 +7,14 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.RestVerticle;
-import org.folio.rest.persist.EntitiesMetadataHolder;
-import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -35,22 +30,7 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 
 
-@RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(Suite.class)
-@PowerMockIgnore({"javax.net.ssl.*", "org.apache.logging.log4j.*"})
-@PrepareForTest({PgUtil.class, EntitiesMetadataHolder.class, OrdersAPI.class})
-
-@Suite.SuiteClasses({
-  EntitiesCrudTest.class,
-  OrdersAPITest.class,
-  PoNumberTest.class,
-  PurchaseOrderLineNumberTest.class,
-  PurchaseOrderNumberUniquenessTest.class,
-  ReceivingHistoryTest.class,
-  SearchOrderLinesTest.class,
-  TenantSampleDataTest.class,
-  HelperUtilsTest.class
-})
+@RunWith(JUnitPlatform.class)
 
 public class StorageTestSuite {
   private static final Logger logger = LoggerFactory.getLogger(StorageTestSuite.class);
@@ -69,7 +49,7 @@ public class StorageTestSuite {
     return vertx;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void before() throws IOException, InterruptedException, ExecutionException, TimeoutException {
 
     // tests expect English error messages only, no Danish/German/...
@@ -92,7 +72,7 @@ public class StorageTestSuite {
     prepareTenant(TENANT_HEADER, false);
   }
 
-  @AfterClass
+  @AfterAll
   public static void after() throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
     logger.info("Delete tenant");
     deleteTenant(TENANT_HEADER);
@@ -131,5 +111,24 @@ public class StorageTestSuite {
 
     deploymentComplete.get(60, TimeUnit.SECONDS);
   }
+
+  @Nested
+  class EntitiesCrudTestNested extends EntitiesCrudTest{}
+  @Nested
+  class OrdersAPITestNested extends OrdersAPITest{}
+  @Nested
+  class PoNumberTestNested extends PoNumberTest{}
+  @Nested
+  class PurchaseOrderLineNumberTestNested extends PurchaseOrderLineNumberTest{}
+  @Nested
+  class PurchaseOrderNumberUniquenessTestNested extends PurchaseOrderNumberUniquenessTest{}
+  @Nested
+  class ReceivingHistoryTestNested extends ReceivingHistoryTest{}
+  @Nested
+  class SearchOrderLinesTestNested extends SearchOrderLinesTest{}
+  @Nested
+  class TenantSampleDataTestNested extends TenantSampleDataTest{}
+  @Nested
+  class HelperUtilsTestNested extends HelperUtilsTest{}
 
 }

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -10,10 +10,11 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -29,19 +30,7 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 
 
-@RunWith(Suite.class)
-
-@Suite.SuiteClasses({
-  EntitiesCrudTest.class,
-  OrdersAPITest.class,
-  PoNumberTest.class,
-  PurchaseOrderLineNumberTest.class,
-  PurchaseOrderNumberUniquenessTest.class,
-  ReceivingHistoryTest.class,
-  SearchOrderLinesTest.class,
-  TenantSampleDataTest.class,
-  HelperUtilsTest.class
-})
+@RunWith(JUnitPlatform.class)
 
 public class StorageTestSuite {
   private static final Logger logger = LoggerFactory.getLogger(StorageTestSuite.class);
@@ -60,7 +49,7 @@ public class StorageTestSuite {
     return vertx;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void before() throws IOException, InterruptedException, ExecutionException, TimeoutException {
 
     // tests expect English error messages only, no Danish/German/...
@@ -83,7 +72,7 @@ public class StorageTestSuite {
     prepareTenant(TENANT_HEADER, false);
   }
 
-  @AfterClass
+  @AfterAll
   public static void after() throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
     logger.info("Delete tenant");
     deleteTenant(TENANT_HEADER);
@@ -122,5 +111,24 @@ public class StorageTestSuite {
 
     deploymentComplete.get(60, TimeUnit.SECONDS);
   }
+
+  @Nested
+  class EntitiesCrudTestNested extends EntitiesCrudTest{}
+  @Nested
+  class OrdersAPITestNested extends OrdersAPITest{}
+  @Nested
+  class PoNumberTestNested extends PoNumberTest{}
+  @Nested
+  class PurchaseOrderLineNumberTestNested extends PurchaseOrderLineNumberTest{}
+  @Nested
+  class PurchaseOrderNumberUniquenessTestNested extends PurchaseOrderNumberUniquenessTest{}
+  @Nested
+  class ReceivingHistoryTestNested extends ReceivingHistoryTest{}
+  @Nested
+  class SearchOrderLinesTestNested extends SearchOrderLinesTest{}
+  @Nested
+  class TenantSampleDataTestNested extends TenantSampleDataTest{}
+  @Nested
+  class HelperUtilsTestNested extends HelperUtilsTest{}
 
 }

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -7,14 +7,19 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.persist.EntitiesMetadataHolder;
+import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.platform.runner.JUnitPlatform;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -30,7 +35,22 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 
 
-@RunWith(JUnitPlatform.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Suite.class)
+@PowerMockIgnore({"javax.net.ssl.*", "org.apache.logging.log4j.*"})
+@PrepareForTest({PgUtil.class, EntitiesMetadataHolder.class, OrdersAPI.class})
+
+@Suite.SuiteClasses({
+  EntitiesCrudTest.class,
+  OrdersAPITest.class,
+  PoNumberTest.class,
+  PurchaseOrderLineNumberTest.class,
+  PurchaseOrderNumberUniquenessTest.class,
+  ReceivingHistoryTest.class,
+  SearchOrderLinesTest.class,
+  TenantSampleDataTest.class,
+  HelperUtilsTest.class
+})
 
 public class StorageTestSuite {
   private static final Logger logger = LoggerFactory.getLogger(StorageTestSuite.class);
@@ -49,7 +69,7 @@ public class StorageTestSuite {
     return vertx;
   }
 
-  @BeforeAll
+  @BeforeClass
   public static void before() throws IOException, InterruptedException, ExecutionException, TimeoutException {
 
     // tests expect English error messages only, no Danish/German/...
@@ -72,7 +92,7 @@ public class StorageTestSuite {
     prepareTenant(TENANT_HEADER, false);
   }
 
-  @AfterAll
+  @AfterClass
   public static void after() throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
     logger.info("Delete tenant");
     deleteTenant(TENANT_HEADER);
@@ -111,24 +131,5 @@ public class StorageTestSuite {
 
     deploymentComplete.get(60, TimeUnit.SECONDS);
   }
-
-  @Nested
-  class EntitiesCrudTestNested extends EntitiesCrudTest{}
-  @Nested
-  class OrdersAPITestNested extends OrdersAPITest{}
-  @Nested
-  class PoNumberTestNested extends PoNumberTest{}
-  @Nested
-  class PurchaseOrderLineNumberTestNested extends PurchaseOrderLineNumberTest{}
-  @Nested
-  class PurchaseOrderNumberUniquenessTestNested extends PurchaseOrderNumberUniquenessTest{}
-  @Nested
-  class ReceivingHistoryTestNested extends ReceivingHistoryTest{}
-  @Nested
-  class SearchOrderLinesTestNested extends SearchOrderLinesTest{}
-  @Nested
-  class TenantSampleDataTestNested extends TenantSampleDataTest{}
-  @Nested
-  class HelperUtilsTestNested extends HelperUtilsTest{}
 
 }

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -8,7 +8,6 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.postToTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 import static org.folio.rest.utils.TestEntities.PO_LINE;
-import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 
@@ -16,18 +15,16 @@ import java.net.MalformedURLException;
 
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PoLineCollection;
-import org.folio.rest.jaxrs.model.PurchaseOrder;
-import org.folio.rest.jaxrs.model.PurchaseOrderCollection;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.utils.TenantApiTestUtil;
 import org.folio.rest.utils.TestEntities;
-import org.junit.Test;
 
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.junit.jupiter.api.Test;
 
 
 public class TenantSampleDataTest extends TestBase{

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -14,8 +14,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.IOUtils;
 import org.folio.rest.utils.TestEntities;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -39,18 +37,15 @@ public abstract class TestBase {
   private static boolean invokeStorageTestSuiteAfter = false;
 
   @BeforeAll
-  @BeforeClass
   public static void testBaseBeforeClass() throws InterruptedException, ExecutionException, TimeoutException, IOException {
     Vertx vertx = StorageTestSuite.getVertx();
     if (vertx == null) {
       invokeStorageTestSuiteAfter = true;
       StorageTestSuite.before();
     }
-
   }
 
   @AfterAll
-  @AfterClass
   public static void testBaseAfterClass()
     throws InterruptedException,
     ExecutionException,


### PR DESCRIPTION
[MODORDSTOR-97](https://issues.folio.org/browse/MODORDSTOR-97) - Randomly failing HelperUtilsTest unit tests (in addition to [#133](https://github.com/folio-org/mod-orders-storage/pull/133))

## Purpose
For fixing random HelperUtilsTest fails after migration to junit5.

## Approach

Full migration to JUnit 5, updating JMockit to 1.46.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
 