### PR TITLE
MODORDSTOR-94/95 Add acq unit assignments to orders/lines views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.1</version>
         <configuration>
+          <systemPropertyVariables>
+            <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.Log4j2LogDelegateFactory</vertx.logger-delegate-factory-class-name>
+          </systemPropertyVariables>
           <argLine>
             @{argLine} -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
           </argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
             </goals>
             <configuration>
               <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <!-- <executable>java</executable> -->
               <cleanupDaemonThreads>false</cleanupDaemonThreads>
               <systemProperties>
                 <systemProperty>
@@ -186,7 +185,6 @@
             </goals>
             <configuration>
               <mainClass>org.folio.rest.tools.ClientGenerator</mainClass>
-              <!-- <executable>java</executable> -->
               <cleanupDaemonThreads>false</cleanupDaemonThreads>
               <systemProperties>
                 <systemProperty>

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitAssignmentAPI.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitAssignmentAPI.java
@@ -20,7 +20,7 @@ import io.vertx.core.Handler;
 
 public class AcquisitionsUnitAssignmentAPI implements OrdersStorageAcquisitionsUnitAssignments {
 
-  private static final String ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE = "acquisitions_unit_assignments";
+  static final String ACQUISITIONS_UNIT_ASSIGNMENTS_TABLE = "acquisitions_unit_assignments";
 
   @Override
   @Validate

--- a/src/main/java/org/folio/rest/impl/OrderLines.java
+++ b/src/main/java/org/folio/rest/impl/OrderLines.java
@@ -1,7 +1,8 @@
 package org.folio.rest.impl;
 
+import static org.folio.rest.persist.HelperUtils.ID_FIELD_NAME;
 import static org.folio.rest.persist.HelperUtils.METADATA;
-import static org.folio.rest.persist.HelperUtils.getEntitiesCollection;
+import static org.folio.rest.persist.HelperUtils.getEntitiesCollectionWithDistinctOn;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -29,7 +30,7 @@ public class OrderLines implements OrdersStorageOrderLines {
     vertxContext.runOnContext((Void v) -> {
       EntitiesMetadataHolder<PoLine, PoLineCollection> entitiesMetadataHolder = new EntitiesMetadataHolder<>(PoLine.class, PoLineCollection.class, GetOrdersStoragePoLinesResponse.class);
       QueryHolder cql = new QueryHolder(POLINE_VIEW, METADATA, query, offset, limit, lang);
-      getEntitiesCollection(entitiesMetadataHolder, cql, asyncResultHandler, vertxContext, okapiHeaders);
+      getEntitiesCollectionWithDistinctOn(entitiesMetadataHolder, cql, ID_FIELD_NAME, asyncResultHandler, vertxContext, okapiHeaders);
     });
   }
 }

--- a/src/main/java/org/folio/rest/impl/PoLinesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoLinesAPI.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import static org.folio.rest.persist.HelperUtils.ID_FIELD_NAME;
 import static org.folio.rest.persist.HelperUtils.METADATA;
+import static org.folio.rest.persist.HelperUtils.getCriterionByFieldNameAndValue;
 import static org.folio.rest.persist.HelperUtils.getEntitiesCollectionWithDistinctOn;
 
 import java.util.Map;
@@ -17,7 +18,6 @@ import org.folio.rest.persist.EntitiesMetadataHolder;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.QueryHolder;
-import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 
 import io.vertx.core.AsyncResult;
@@ -176,7 +176,7 @@ public class PoLinesAPI implements OrdersStoragePoLines {
       if (reply.failed()) {
         future.completeExceptionally(new HttpStatusException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), reply.cause().getMessage()));
       } else {
-        log.info("{} pieces of POLine with id={} successfully deleted", tx.getId(), reply.result().getUpdated());
+        log.info("{} pieces of POLine with id={} successfully deleted", reply.result().getUpdated(), tx.getId());
         future.complete(tx);
       }
     });
@@ -199,14 +199,6 @@ public class PoLinesAPI implements OrdersStoragePoLines {
     CompletableFuture<TxWithId> future = new CompletableFuture<>();
     pgClient.endTx(tx.getConnection(), v -> future.complete(tx));
     return future;
-  }
-
-  private Criterion getCriterionByFieldNameAndValue(String filedName, String fieldValue) {
-    Criteria a = new Criteria();
-    a.addField("'" + filedName + "'");
-    a.setOperation("=");
-    a.setVal(fieldValue);
-    return new Criterion(a);
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/PoLinesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoLinesAPI.java
@@ -1,6 +1,8 @@
 package org.folio.rest.impl;
 
-import static org.folio.rest.persist.HelperUtils.getEntitiesCollection;
+import static org.folio.rest.persist.HelperUtils.ID_FIELD_NAME;
+import static org.folio.rest.persist.HelperUtils.METADATA;
+import static org.folio.rest.persist.HelperUtils.getEntitiesCollectionWithDistinctOn;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -29,10 +31,10 @@ import io.vertx.ext.sql.SQLConnection;
 import io.vertx.ext.web.handler.impl.HttpStatusException;
 
 public class PoLinesAPI implements OrdersStoragePoLines {
-  private static final Logger log = LoggerFactory.getLogger(OrdersStoragePoLines.class);
+  private static final Logger log = LoggerFactory.getLogger(PoLinesAPI.class);
 
   private static final String POLINE_TABLE = "po_line";
-  private static final String ID_FIELD_NAME = "id";
+  private static final String PO_LINES_VIEW = "po_lines_view";
   private static final String POLINE_ID_FIELD = "poLineId";
 
   private PostgresClient pgClient;
@@ -48,8 +50,8 @@ public class PoLinesAPI implements OrdersStoragePoLines {
     vertxContext.runOnContext((Void v) -> {
       EntitiesMetadataHolder<PoLine, PoLineCollection> entitiesMetadataHolder = new EntitiesMetadataHolder<>(PoLine.class,
           PoLineCollection.class, GetOrdersStoragePoLinesResponse.class);
-      QueryHolder cql = new QueryHolder(POLINE_TABLE, query, offset, limit, lang);
-      getEntitiesCollection(entitiesMetadataHolder, cql, asyncResultHandler, vertxContext, okapiHeaders);
+      QueryHolder cql = new QueryHolder(PO_LINES_VIEW, METADATA, query, offset, limit, lang);
+      getEntitiesCollectionWithDistinctOn(entitiesMetadataHolder, cql, ID_FIELD_NAME, asyncResultHandler, vertxContext, okapiHeaders);
     });
   }
 

--- a/src/main/java/org/folio/rest/impl/PurchaseOrdersAPI.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrdersAPI.java
@@ -23,14 +23,17 @@ import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.folio.rest.persist.HelperUtils.ID_FIELD_NAME;
+import static org.folio.rest.persist.HelperUtils.METADATA;
 import static org.folio.rest.persist.HelperUtils.SequenceQuery.CREATE_SEQUENCE;
 import static org.folio.rest.persist.HelperUtils.SequenceQuery.DROP_SEQUENCE;
-import static org.folio.rest.persist.HelperUtils.getEntitiesCollection;
+import static org.folio.rest.persist.HelperUtils.getEntitiesCollectionWithDistinctOn;
 
 public class PurchaseOrdersAPI implements OrdersStoragePurchaseOrders {
 
   private static final Logger log = LoggerFactory.getLogger(PurchaseOrdersAPI.class);
   static final String PURCHASE_ORDER_TABLE = "purchase_order";
+  private static final String PURCHASE_ORDERS_VIEW = "purchase_orders_view";
   private static final String PURCHASE_ORDER_LOCATION_PREFIX = "/orders-storage/purchase-orders/";
   private PostgresClient pgClient;
 
@@ -46,8 +49,8 @@ public class PurchaseOrdersAPI implements OrdersStoragePurchaseOrders {
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext((Void v) -> {
       EntitiesMetadataHolder<PurchaseOrder, PurchaseOrderCollection> entitiesMetadataHolder = new EntitiesMetadataHolder<>(PurchaseOrder.class, PurchaseOrderCollection.class, GetOrdersStoragePurchaseOrdersResponse.class);
-      QueryHolder cql = new QueryHolder(PURCHASE_ORDER_TABLE, query, offset, limit, lang);
-      getEntitiesCollection(entitiesMetadataHolder, cql, asyncResultHandler, vertxContext, okapiHeaders);
+      QueryHolder cql = new QueryHolder(PURCHASE_ORDERS_VIEW, METADATA, query, offset, limit, lang);
+      getEntitiesCollectionWithDistinctOn(entitiesMetadataHolder, cql, ID_FIELD_NAME, asyncResultHandler, vertxContext, okapiHeaders);
     });
   }
 

--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -26,6 +26,7 @@ public class HelperUtils {
 
   public static final String JSONB = "jsonb";
   public static final String METADATA = "metadata";
+  public static final String ID_FIELD_NAME = "id";
 
   private HelperUtils() {
     throw new UnsupportedOperationException("Cannot instantiate utility class.");

--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -5,6 +5,9 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.folio.rest.persist.interfaces.Results;
 
@@ -63,6 +66,14 @@ public class HelperUtils {
       log.error(e.getMessage(), e);
       asyncResultHandler.handle(response(e.getMessage(), respond500, respond500));
     }
+  }
+
+  public static Criterion getCriterionByFieldNameAndValue(String filedName, String fieldValue) {
+    Criteria a = new Criteria();
+    a.addField("'" + filedName + "'");
+    a.setOperation("=");
+    a.setVal(fieldValue);
+    return new Criterion(a);
   }
 
   private static <T, E> void processDbReply(EntitiesMetadataHolder<T, E> entitiesMetadataHolder, Handler<AsyncResult<Response>> asyncResultHandler, Method respond500, Method respond400, AsyncResult<Results<T>> reply) {

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -7,13 +7,23 @@
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW orders_view AS SELECT purchase_order.id AS id, purchase_order.jsonb AS jsonb, COALESCE(po_line.jsonb, '{}'::jsonb) || purchase_order.jsonb AS metadata FROM purchase_order LEFT JOIN po_line ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
+      "snippet": "CREATE OR REPLACE VIEW orders_view AS SELECT purchase_order.id AS id, purchase_order.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || COALESCE(po_line.jsonb, '{}'::jsonb) || purchase_order.jsonb AS metadata FROM purchase_order LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (purchase_order.jsonb -> 'id'::text) LEFT JOIN po_line ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
       "fromModuleVersion": "5.0"
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW order_lines_view AS SELECT po_line.id AS id, po_line.jsonb AS jsonb, COALESCE(purchase_order.jsonb, '{}'::jsonb)||po_line.jsonb AS metadata FROM po_line LEFT JOIN purchase_order ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
+      "snippet": "CREATE OR REPLACE VIEW order_lines_view AS SELECT po_line.id AS id, po_line.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || COALESCE(purchase_order.jsonb, '{}'::jsonb) || po_line.jsonb AS metadata FROM po_line LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (po_line.jsonb -> 'purchaseOrderId'::text) LEFT JOIN purchase_order ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
       "fromModuleVersion": "5.0"
+    },
+    {
+      "run": "after",
+      "snippet": "CREATE OR REPLACE VIEW purchase_orders_view AS SELECT purchase_order.id AS id, purchase_order.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || purchase_order.jsonb AS metadata FROM purchase_order LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (purchase_order.jsonb -> 'id'::text);",
+      "fromModuleVersion": "6.1"
+    },
+    {
+      "run": "after",
+      "snippet": "CREATE OR REPLACE VIEW po_lines_view AS SELECT po_line.id AS id, po_line.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || po_line.jsonb AS metadata FROM po_line LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (po_line.jsonb -> 'purchaseOrderId'::text);",
+      "fromModuleVersion": "6.1"
     }
   ],
   "tables": [

--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -5,6 +5,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.folio.rest.jaxrs.model.AcquisitionsUnit;
+import org.folio.rest.jaxrs.model.AcquisitionsUnitAssignment;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.PurchaseOrderCollection;
 import org.junit.jupiter.api.Test;
@@ -16,10 +18,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.folio.rest.impl.StorageTestSuite.storageUrl;
+import static org.folio.rest.utils.TestEntities.ACQUISITIONS_UNIT;
+import static org.folio.rest.utils.TestEntities.ACQUISITIONS_UNIT_ASSIGNMENTS;
 import static org.folio.rest.utils.TestEntities.PO_LINE;
 import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -28,12 +34,6 @@ import static org.junit.Assert.fail;
 
 public class OrdersAPITest extends TestBase {
   private final Logger logger = LoggerFactory.getLogger(OrdersAPITest.class);
-
-  private String poLineSampleId; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
-  private String poLineSampleId2; // "2303926f-0ef7-4063-9039-07c0e7fae77d"
-  private String purchaseOrderSampleId;
-  private String purchaseOrderSampleId2;
-  private String purchaseOrderWithoutPOLinesId;
 
   private static final String ORDERS_ENDPOINT = "/orders-storage/orders";
 
@@ -50,13 +50,36 @@ public class OrdersAPITest extends TestBase {
   @Test
   public void testGetPurchaseOrders() throws MalformedURLException {
 
+    String purchaseOrderSampleId = null;
+    String purchaseOrderSampleId2 = null;
+    String purchaseOrderWithoutPOLinesId = null;
+    String poLineSampleId = null;
+    String poLineSampleId2 = null;
+
+    String acqUnitId1 = null;
+    String acqUnitId2 = null;
+    String acqUnitPo1AssignmentId1 = null;
+    String acqUnitPo1AssignmentId2 = null;
+    String acqUnitPo2AssignmentId = null;
     try {
+      acqUnitId1 = createEntity(ACQUISITIONS_UNIT.getEndpoint(), buildAcqUnit("Test unit"));
+      acqUnitId2 = createEntity(ACQUISITIONS_UNIT.getEndpoint(), buildAcqUnit("Test unit 2"));
+
+      AcquisitionsUnitAssignment acqUnitAssignment1 = new AcquisitionsUnitAssignment().withAcquisitionsUnitId(acqUnitId1);
+      AcquisitionsUnitAssignment acqUnitAssignment2 = new AcquisitionsUnitAssignment().withAcquisitionsUnitId(acqUnitId2);
 
       logger.info("--- mod-orders-storage orders test: Creating Purchase order 1...");
       purchaseOrderSampleId = createEntity(PURCHASE_ORDER.getEndpoint(), purchaseOrderSample);
+
+      // assign 2 units
+      acqUnitPo1AssignmentId1 = createAcqUnitAssignment(acqUnitAssignment1.withRecordId(purchaseOrderSampleId));
+      acqUnitPo1AssignmentId2 = createAcqUnitAssignment(acqUnitAssignment2.withRecordId(purchaseOrderSampleId));
+
       expectedOrders.put(purchaseOrderSampleId, new JsonObject(purchaseOrderSample).mapTo(PurchaseOrder.class));
       logger.info("--- mod-orders-storage orders test: Creating Purchase order 2...");
       purchaseOrderSampleId2 = createEntity(PURCHASE_ORDER.getEndpoint(), purchaseOrderSample2);
+      acqUnitPo2AssignmentId = createAcqUnitAssignment(acqUnitAssignment1.withRecordId(purchaseOrderSampleId2));
+
       expectedOrders.put(purchaseOrderSampleId2, new JsonObject(purchaseOrderSample2).mapTo(PurchaseOrder.class));
       logger.info("--- mod-orders-storage orders test: Creating Purchase order without PoLines...");
       purchaseOrderWithoutPOLinesId = createEntity(PURCHASE_ORDER.getEndpoint(), purchaseOrderWithoutPOLines);
@@ -99,17 +122,55 @@ public class OrdersAPITest extends TestBase {
       assertThat(filteredByPoAndP0LineFields.get(0).getWorkflowStatus(), is(PurchaseOrder.WorkflowStatus.OPEN));
       assertThat(filteredByPoAndP0LineFields.get(0).getOrderType(), is(PurchaseOrder.OrderType.ONE_TIME));
 
+      logger.info("--- mod-orders-storage Orders API test: Verifying entities filtering by Acquisitions unit... ");
+      String acqUnitQuery = "?query=acquisitionsUnitId==" + acqUnitId1;
+      List<PurchaseOrder> filteredByUnit = getViewCollection(storageUrl(ORDERS_ENDPOINT + acqUnitQuery));
+      // Only to PO's have assignments to acquisition unit
+      verifyExpectedOrders(filteredByUnit, purchaseOrderSampleId, purchaseOrderSampleId2);
+
+      // Check that acq units can be used as search query for `purchase-orders` endpoint
+      filteredByUnit = getViewCollection(storageUrl(PURCHASE_ORDER.getEndpoint() + acqUnitQuery));
+      verifyExpectedOrders(filteredByUnit, purchaseOrderSampleId, purchaseOrderSampleId2);
     } catch (Exception e) {
       logger.error("--- mod-orders-storage-test: orders API ERROR: " + e.getMessage(), e);
       fail(e.getMessage());
     } finally {
-      logger.info("--- mod-orders-storage orders test: Clean-up Detail, PoLine and Pieces ...");
+      logger.info("--- mod-orders-storage orders test: Clean-up acq units, PoLine and orders...");
+
+      // acq units assignments
+      deleteDataSuccess(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpointWithId(), acqUnitPo1AssignmentId1);
+      deleteDataSuccess(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpointWithId(), acqUnitPo1AssignmentId2);
+      deleteDataSuccess(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpointWithId(), acqUnitPo2AssignmentId);
+
+      // PO lines and PO
       deleteDataSuccess(PO_LINE.getEndpointWithId(), poLineSampleId);
       deleteDataSuccess(PO_LINE.getEndpointWithId(), poLineSampleId2);
       deleteDataSuccess(PURCHASE_ORDER.getEndpointWithId(), purchaseOrderSampleId);
       deleteDataSuccess(PURCHASE_ORDER.getEndpointWithId(), purchaseOrderSampleId2);
       deleteDataSuccess(PURCHASE_ORDER.getEndpointWithId(), purchaseOrderWithoutPOLinesId);
+
+      // acq unit
+      deleteDataSuccess(ACQUISITIONS_UNIT.getEndpointWithId(), acqUnitId1);
+      deleteDataSuccess(ACQUISITIONS_UNIT.getEndpointWithId(), acqUnitId2);
     }
+  }
+
+  private String buildAcqUnit(String name) {
+    return JsonObject.mapFrom(new AcquisitionsUnit().withName(name)).encode();
+  }
+
+  private void verifyExpectedOrders(List<PurchaseOrder> filteredOrders, String... poIds) {
+    assertThat(filteredOrders, hasSize(poIds.length));
+
+    List<String> orderIds = filteredOrders.stream()
+      .map(PurchaseOrder::getId)
+      .collect(Collectors.toList());
+
+    assertThat(orderIds, containsInAnyOrder(poIds));
+  }
+
+  private String createAcqUnitAssignment(AcquisitionsUnitAssignment acqUnitAssignment) throws MalformedURLException {
+    return createEntity(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpoint(), JsonObject.mapFrom(acqUnitAssignment).encode());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -58,9 +58,6 @@ public class OrdersAPITest extends TestBase {
 
     String acqUnitId1 = null;
     String acqUnitId2 = null;
-    String acqUnitPo1AssignmentId1 = null;
-    String acqUnitPo1AssignmentId2 = null;
-    String acqUnitPo2AssignmentId = null;
     try {
       acqUnitId1 = createEntity(ACQUISITIONS_UNIT.getEndpoint(), buildAcqUnit("Test unit"));
       acqUnitId2 = createEntity(ACQUISITIONS_UNIT.getEndpoint(), buildAcqUnit("Test unit 2"));
@@ -70,15 +67,14 @@ public class OrdersAPITest extends TestBase {
 
       logger.info("--- mod-orders-storage orders test: Creating Purchase order 1...");
       purchaseOrderSampleId = createEntity(PURCHASE_ORDER.getEndpoint(), purchaseOrderSample);
-
       // assign 2 units
-      acqUnitPo1AssignmentId1 = createAcqUnitAssignment(acqUnitAssignment1.withRecordId(purchaseOrderSampleId));
-      acqUnitPo1AssignmentId2 = createAcqUnitAssignment(acqUnitAssignment2.withRecordId(purchaseOrderSampleId));
+      createAcqUnitAssignment(acqUnitAssignment1.withRecordId(purchaseOrderSampleId));
+      createAcqUnitAssignment(acqUnitAssignment2.withRecordId(purchaseOrderSampleId));
 
       expectedOrders.put(purchaseOrderSampleId, new JsonObject(purchaseOrderSample).mapTo(PurchaseOrder.class));
       logger.info("--- mod-orders-storage orders test: Creating Purchase order 2...");
       purchaseOrderSampleId2 = createEntity(PURCHASE_ORDER.getEndpoint(), purchaseOrderSample2);
-      acqUnitPo2AssignmentId = createAcqUnitAssignment(acqUnitAssignment1.withRecordId(purchaseOrderSampleId2));
+      createAcqUnitAssignment(acqUnitAssignment1.withRecordId(purchaseOrderSampleId2));
 
       expectedOrders.put(purchaseOrderSampleId2, new JsonObject(purchaseOrderSample2).mapTo(PurchaseOrder.class));
       logger.info("--- mod-orders-storage orders test: Creating Purchase order without PoLines...");
@@ -135,13 +131,7 @@ public class OrdersAPITest extends TestBase {
       logger.error("--- mod-orders-storage-test: orders API ERROR: " + e.getMessage(), e);
       fail(e.getMessage());
     } finally {
-      logger.info("--- mod-orders-storage orders test: Clean-up acq units, PoLine and orders...");
-
-      // acq units assignments
-      deleteDataSuccess(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpointWithId(), acqUnitPo1AssignmentId1);
-      deleteDataSuccess(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpointWithId(), acqUnitPo1AssignmentId2);
-      deleteDataSuccess(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpointWithId(), acqUnitPo2AssignmentId);
-
+      logger.info("--- mod-orders-storage orders test: Clean-up PO lines, orders and acq units...");
       // PO lines and PO
       deleteDataSuccess(PO_LINE.getEndpointWithId(), poLineSampleId);
       deleteDataSuccess(PO_LINE.getEndpointWithId(), poLineSampleId2);
@@ -169,8 +159,8 @@ public class OrdersAPITest extends TestBase {
     assertThat(orderIds, containsInAnyOrder(poIds));
   }
 
-  private String createAcqUnitAssignment(AcquisitionsUnitAssignment acqUnitAssignment) throws MalformedURLException {
-    return createEntity(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpoint(), JsonObject.mapFrom(acqUnitAssignment).encode());
+  private void createAcqUnitAssignment(AcquisitionsUnitAssignment acqUnitAssignment) throws MalformedURLException {
+    createEntity(ACQUISITIONS_UNIT_ASSIGNMENTS.getEndpoint(), JsonObject.mapFrom(acqUnitAssignment).encode());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -105,8 +105,12 @@ public abstract class TestBase {
   }
 
   Response postData(String endpoint, String input) throws MalformedURLException {
+    return postData(endpoint, input, TENANT_HEADER);
+  }
+
+  Response postData(String endpoint, String input, Header tenant) throws MalformedURLException {
     return given()
-      .header(TENANT_HEADER)
+      .header(tenant)
       .accept(ContentType.JSON)
       .contentType(ContentType.JSON)
       .body(input)
@@ -116,7 +120,11 @@ public abstract class TestBase {
   }
 
   String createEntity(String endpoint, String entity) throws MalformedURLException {
-    return postData(endpoint, entity)
+    return createEntity(endpoint, entity, TENANT_HEADER);
+  }
+
+  String createEntity(String endpoint, String entity, Header tenant) throws MalformedURLException {
+    return postData(endpoint, entity, tenant)
       .then().log().all()
         .statusCode(201)
         .extract()


### PR DESCRIPTION
## Purpose
[MODORDSTOR-94](https://issues.folio.org/browse/MODORDSTOR-94) Add acquisitions-unit-assignments.recordId to orders views
[MODORDSTOR-95](https://issues.folio.org/browse/MODORDSTOR-95) Add acquisitions-unit-assignments.recordId to poLine views

## Approach
- Creating `purchase_orders_view` and using it for `GET /orders-storage/purchase-orders` requests
- Creating `po_lines_view` and using it for `GET /orders-storage/po-lines` requests
- Updating `orders_view` and `order_lines_view` to join `acquisitions_unit_assignments` table
- Bonus: updating PO deletion logic to delete acq units assignments and POL number sequence along with order deletion in one transaction

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.