### PR TITLE
MODORDERS-280: Change PO and PO line views to avoid collision between tags attributes

### DIFF
--- a/src/main/resources/data/po-lines/14383007-1_awaiting_receipt_gift.json
+++ b/src/main/resources/data/po-lines/14383007-1_awaiting_receipt_gift.json
@@ -87,7 +87,8 @@
   "source": "User",
   "tags": {
     "tagList": [
-        "giftsubscription"
+        "giftsubscription",
+        "important"
      ]
   },
   "title": "The American Journal of Medicine",

--- a/src/main/resources/data/purchase-orders/268758_one-time_open.json
+++ b/src/main/resources/data/purchase-orders/268758_one-time_open.json
@@ -7,5 +7,10 @@
   "poNumber": "268758",
   "reEncumber": false,
   "vendor": "15fb695a-cdf1-11e8-a8d5-f2801f1b9fd1",
-  "workflowStatus": "Open"
+  "workflowStatus": "Open",
+  "tags" : {
+    "tagList" : [
+      "important"
+    ]
+  }
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -7,12 +7,12 @@
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW orders_view AS SELECT purchase_order.id AS id, purchase_order.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || COALESCE(po_line.jsonb, '{}'::jsonb) || purchase_order.jsonb AS metadata FROM purchase_order LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (purchase_order.jsonb -> 'id'::text) LEFT JOIN po_line ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
+      "snippet": "CREATE OR REPLACE VIEW orders_view AS SELECT purchase_order.id AS id, purchase_order.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || (COALESCE(po_line.jsonb, '{}'::jsonb) - 'tags') || purchase_order.jsonb AS metadata FROM purchase_order LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (purchase_order.jsonb -> 'id'::text) LEFT JOIN po_line ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
       "fromModuleVersion": "5.0"
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW order_lines_view AS SELECT po_line.id AS id, po_line.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || COALESCE(purchase_order.jsonb, '{}'::jsonb) || po_line.jsonb AS metadata FROM po_line LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (po_line.jsonb -> 'purchaseOrderId'::text) LEFT JOIN purchase_order ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
+      "snippet": "CREATE OR REPLACE VIEW order_lines_view AS SELECT po_line.id AS id, po_line.jsonb AS jsonb, COALESCE(acquisitions_unit_assignments.jsonb, '{}'::jsonb) || (COALESCE(purchase_order.jsonb, '{}'::jsonb) - 'tags') || po_line.jsonb AS metadata FROM po_line LEFT JOIN acquisitions_unit_assignments ON (acquisitions_unit_assignments.jsonb -> 'recordId'::text) = (po_line.jsonb -> 'purchaseOrderId'::text) LEFT JOIN purchase_order ON (po_line.jsonb -> 'purchaseOrderId'::text) = (purchase_order.jsonb -> 'id'::text);",
       "fromModuleVersion": "5.0"
     },
     {
@@ -328,7 +328,7 @@
         {
             "fieldName" : "name"
         }
-      ] 
+      ]
     },
     {
       "tableName": "acquisitions_unit_assignments",
@@ -351,7 +351,7 @@
         {
           "fieldName": "acquisitionsUnitId"
         }
-      ]     
+      ]
     },
     {
     "tableName": "acquisitions_unit_membership",

--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -110,9 +110,9 @@ public class OrdersAPITest extends TestBase {
 
       logger.info("--- mod-orders-storage Orders API test: Verifying entities filtering by tags... ");
       List<PurchaseOrder> ordersWithTag = getViewCollection(storageUrl(ORDERS_ENDPOINT + "?query=tags.tagList=important sortBy dateOrdered/sort.ascending"));
-      for(int i = 0; i < ordersWithTag.size() - 1; i++) {
-        assertThat("important", isIn(ordersWithTag.get(i).getTags().getTagList()));
-      }
+
+      assertThat(ordersWithTag, hasSize(1));
+      assertThat("important", isIn(ordersWithTag.get(0).getTags().getTagList()));
 
       List<PurchaseOrder> orderedByDescOrders = getViewCollection(storageUrl(ORDERS_ENDPOINT + "?query=workflowStatus==Open sortBy dateOrdered/sort.descending"));
       for(int i = 0; i < orderedByDescOrders.size() - 1; i++) {

--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -28,6 +28,7 @@ import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -105,6 +106,12 @@ public class OrdersAPITest extends TestBase {
       List<PurchaseOrder> orderedByAscOrders = getViewCollection(storageUrl(ORDERS_ENDPOINT + "?query=workflowStatus==Open sortBy dateOrdered/sort.ascending"));
       for(int i = 0; i < orderedByAscOrders.size() - 1; i++) {
         assertThat(orderedByAscOrders.get(i + 1).getDateOrdered().after(orderedByAscOrders.get(i).getDateOrdered()), is(true));
+      }
+
+      logger.info("--- mod-orders-storage Orders API test: Verifying entities filtering by tags... ");
+      List<PurchaseOrder> ordersWithTag = getViewCollection(storageUrl(ORDERS_ENDPOINT + "?query=tags.tagList=important sortBy dateOrdered/sort.ascending"));
+      for(int i = 0; i < ordersWithTag.size() - 1; i++) {
+        assertThat("important", isIn(ordersWithTag.get(i).getTags().getTagList()));
       }
 
       List<PurchaseOrder> orderedByDescOrders = getViewCollection(storageUrl(ORDERS_ENDPOINT + "?query=workflowStatus==Open sortBy dateOrdered/sort.descending"));

--- a/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
@@ -9,6 +9,8 @@ import static org.folio.rest.utils.TestEntities.PO_LINE;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.isIn;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import io.restassured.http.Header;
@@ -76,6 +78,14 @@ public class SearchOrderLinesTest extends TestBase {
     logger.info("--- mod-orders-storage po-lines: Verify the limit parameter");
     List<PoLine> filteredByPoAndP0LineFields = queryAndGetPOLines(ORDER_LINES_ENDPOINT + "?limit=5");
     assertThat(filteredByPoAndP0LineFields, hasSize(5));
+  }
+
+  @Test
+  public void testGetPoLinesWithTags() throws MalformedURLException {
+    logger.info("--- mod-orders-storage po-lines: Verify query PO Lines by tags");
+    List<PoLine> poLines = queryAndGetPOLines(ORDER_LINES_ENDPOINT + "?query=tags.tagList=important");
+    poLines.forEach(poLine ->
+      assertThat("important", isIn(poLine.getTags().getTagList())));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.isIn;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import io.restassured.http.Header;
@@ -84,8 +83,8 @@ public class SearchOrderLinesTest extends TestBase {
   public void testGetPoLinesWithTags() throws MalformedURLException {
     logger.info("--- mod-orders-storage po-lines: Verify query PO Lines by tags");
     List<PoLine> poLines = queryAndGetPOLines(ORDER_LINES_ENDPOINT + "?query=tags.tagList=important");
-    poLines.forEach(poLine ->
-      assertThat("important", isIn(poLine.getTags().getTagList())));
+    assertThat(poLines, hasSize(1));
+    assertThat("important", isIn(poLines.get(0).getTags().getTagList()));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Exclude POL tags from PO view, and exclude PO tags from POL view, 
Without this change filtering by tags would check both Purchase Order and Purchase Order Line tags,
and according to comments on [MODORDERS-280](https://issues.folio.org/browse/MODORDERS-280,) PO and POL tags should be searched/filtered separately.
## Approach
Change views to delete tags before merging PO and POL json objects

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.