### PR TITLE
MODORDSTOR-106 - Create order-templates API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -232,6 +232,37 @@
       ]
     },
     {
+      "id": "orders-storage.order-templates",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/orders-storage/order-templates",
+          "permissionsRequired": ["orders-storage.order-templates.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/orders-storage/order-templates",
+          "permissionsRequired": ["orders-storage.order-templates.item.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/orders-storage/order-templates/{id}",
+          "permissionsRequired": ["orders-storage.order-templates.item.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/orders-storage/order-templates/{id}",
+          "permissionsRequired": ["orders-storage.order-templates.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/orders-storage/order-templates/{id}",
+          "permissionsRequired": ["orders-storage.order-templates.item.delete"]
+        }
+      ]
+    },
+    {
       "id": "acquisitions-units-storage.units",
       "version": "1.0",
       "handlers": [
@@ -568,6 +599,43 @@
       ]
     },
     {
+      "permissionName" : "orders-storage.order-templates.collection.get",
+      "displayName" : "order-order-templates-collection get",
+      "description" : "Get a collection of order templates"
+    },
+    {
+      "permissionName" : "orders-storage.order-templates.item.post",
+      "displayName" : "order-templates post",
+      "description" : "Create a new order template"
+    },
+    {
+      "permissionName" : "orders-storage.order-templates.item.get",
+      "displayName" : "order-templates-item get",
+      "description" : "Fetch an order templates"
+    },
+    {
+      "permissionName" : "orders-storage.order-templates.item.put",
+      "displayName" : "order-templates-item put",
+      "description" : "Update an order template"
+    },
+    {
+      "permissionName" : "orders-storage.order-templates.item.delete",
+      "displayName" : "order-templates-item delete",
+      "description" : "Delete an order template"
+    },
+    {
+      "permissionName" : "orders-storage.order-templates.all",
+      "displayName" : "All order-templates perms",
+      "description" : "All permissions for the order-templates",
+      "subPermissions" : [
+        "orders-storage.order-templates.collection.get",
+        "orders-storage.order-templates.item.post",
+        "orders-storage.order-templates.item.get",
+        "orders-storage.order-templates.item.put",
+        "orders-storage.order-templates.item.delete"
+      ]
+    },
+    {
       "permissionName" : "acquisitions-units-storage.units.collection.get",
       "displayName" : "acquisitions-units-collection get",
       "description" : "Get a collection of acquisitions units"
@@ -655,6 +723,7 @@
         "orders-storage.receiving-history.all",
         "orders-storage.reporting-codes.all",
         "orders-storage.order-invoice-relationships.all",
+        "orders-storage.order-templates.all",
         "acquisitions-units-storage.units.all",
         "acquisitions-units-storage.memberships.all"
       ]

--- a/ramls/order-templates.raml
+++ b/ramls/order-templates.raml
@@ -29,7 +29,7 @@ resourceTypes:
   type:
     collection:
       exampleCollection: !include acq-models/mod-orders-storage/examples/order_template_collection.sample
-      exampleItem: !include acq-models/mod-orders-storage/examples/order_template_get.sample
+      exampleItem: !include acq-models/mod-orders-storage/examples/order_template_post.sample
       schemaCollection: order-template-collection
       schemaItem: order-template
   post:
@@ -48,7 +48,7 @@ resourceTypes:
         type: UUID
     type:
       collection-item:
-        exampleItem: !include acq-models/mod-orders-storage/examples/order_template_post.sample
+        exampleItem: !include acq-models/mod-orders-storage/examples/order_template_get.sample
         schema: order-template
     put:
       description: Update order template

--- a/ramls/order-templates.raml
+++ b/ramls/order-templates.raml
@@ -1,0 +1,48 @@
+#%RAML 1.0
+title: "mod-orders"
+baseUri: http://github.com/folio-org/mod-orders-storage
+version: v1
+
+documentation:
+  - title: Order Templates
+    content: <b>This module implements the CRUD interface for Order Templates API. This API is intended for internal use only.</b>
+
+types:
+    order-template: !include acq-models/mod-orders-storage/schemas/order_template.json
+    order-template-collection: !include acq-models/mod-orders-storage/schemas/order_template_collection.json
+    UUID:
+     type: string
+     pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
+
+traits:
+    orderable: !include raml-util/traits/orderable.raml
+    pageable:  !include raml-util/traits/pageable.raml
+    searchable: !include raml-util/traits/searchable.raml
+    language: !include raml-util/traits/language.raml
+
+resourceTypes:
+    collection: !include raml-util/rtypes/collection.raml
+    collection-item: !include raml-util/rtypes/item-collection.raml
+
+/orders-storage/order-templates:
+  type:
+    collection:
+      exampleCollection: !include acq-models/mod-orders-storage/examples/order_template_collection.sample
+      exampleItem: !include acq-models/mod-orders-storage/examples/order_template_get.sample
+      schemaCollection: order-template-collection
+      schemaItem: order-template
+  get:
+    description: Get list of order templates
+    is: [
+      searchable: {description: "with valid searchable fields: for example templateCode", example: "[\"templateCode\", \"Amazon\", \"=\"]"},
+      pageable
+    ]
+  /{id}:
+    uriParameters:
+      id:
+        description: The UUID of an Order Template
+        type: UUID
+    type:
+      collection-item:
+        exampleItem: !include acq-models/mod-orders-storage/examples/order_template_get.sample
+        schema: order-template

--- a/ramls/order-templates.raml
+++ b/ramls/order-templates.raml
@@ -10,12 +10,13 @@ documentation:
 types:
     order-template: !include acq-models/mod-orders-storage/schemas/order_template.json
     order-template-collection: !include acq-models/mod-orders-storage/schemas/order_template_collection.json
+    errors: !include raml-util/schemas/errors.schema
     UUID:
      type: string
      pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
 
 traits:
-    orderable: !include raml-util/traits/orderable.raml
+    validate: !include raml-util/traits/validation.raml
     pageable:  !include raml-util/traits/pageable.raml
     searchable: !include raml-util/traits/searchable.raml
     language: !include raml-util/traits/language.raml
@@ -31,6 +32,9 @@ resourceTypes:
       exampleItem: !include acq-models/mod-orders-storage/examples/order_template_get.sample
       schemaCollection: order-template-collection
       schemaItem: order-template
+  post:
+    description: Create new order template
+    is: [validate]
   get:
     description: Get list of order templates
     is: [
@@ -44,5 +48,8 @@ resourceTypes:
         type: UUID
     type:
       collection-item:
-        exampleItem: !include acq-models/mod-orders-storage/examples/order_template_get.sample
+        exampleItem: !include acq-models/mod-orders-storage/examples/order_template_post.sample
         schema: order-template
+    put:
+      description: Update order template
+      is: [validate]

--- a/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
+++ b/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
@@ -1,0 +1,49 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.OrderTemplate;
+import org.folio.rest.jaxrs.model.OrderTemplateCollection;
+import org.folio.rest.jaxrs.resource.OrdersStorageOrderTemplates;
+import org.folio.rest.persist.PgUtil;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class OrderTemplatesAPI implements OrdersStorageOrderTemplates {
+
+  private static final String ORDER_TEMPLATES_TABLE = "order_templates";
+
+  @Override
+  @Validate
+  public void getOrdersStorageOrderTemplates(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.get(ORDER_TEMPLATES_TABLE, OrderTemplate.class, OrderTemplateCollection.class, query, offset, limit, okapiHeaders, vertxContext,
+      GetOrdersStorageOrderTemplatesResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  @Validate
+  public void postOrdersStorageOrderTemplates(String lang, OrderTemplate entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.post(ORDER_TEMPLATES_TABLE, entity, okapiHeaders, vertxContext, PostOrdersStorageOrderTemplatesResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  @Validate
+  public void getOrdersStorageOrderTemplatesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.getById(ORDER_TEMPLATES_TABLE, OrderTemplate.class, id, okapiHeaders,vertxContext, GetOrdersStorageOrderTemplatesByIdResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  @Validate
+  public void deleteOrdersStorageOrderTemplatesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.deleteById(ORDER_TEMPLATES_TABLE, id, okapiHeaders, vertxContext, DeleteOrdersStorageOrderTemplatesByIdResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  @Validate
+  public void putOrdersStorageOrderTemplatesById(String id, String lang, OrderTemplate entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.put(ORDER_TEMPLATES_TABLE, entity, id, okapiHeaders, vertxContext, PutOrdersStorageOrderTemplatesByIdResponse.class, asyncResultHandler);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -67,6 +67,7 @@ public class TenantReferenceAPI extends TenantAPI {
         .add("po-lines", "orders-storage/po-lines")
         .add("pieces", "orders-storage/pieces")
         .add("order-invoice-relationships", "orders-storage/order-invoice-relns")
+        .add("order-templates", "orders-storage/order-templates")
         .add("acquisitions-units", "acquisitions-units-storage/units")
         .add("acquisitions-units-memberships", "acquisitions-units-storage/memberships");
       loadData = true;

--- a/src/main/resources/data/order-templates/order-template.json
+++ b/src/main/resources/data/order-templates/order-template.json
@@ -1,0 +1,6 @@
+{
+   "id": "4dee318b-f5b3-40dc-be93-cc89b8c45b6f",
+   "templateName": "Amazon book orders",
+   "templateCode": "Amazon-B",
+   "templateDescription": "Use to create orders in FOLIO after they are placed on Amazon"
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -361,7 +361,12 @@
      {
       "tableName": "order_templates",
       "fromModuleVersion": 7.0,
-      "withMetadata": false
+      "withMetadata": false,
+      "uniqueIndex": [
+         {
+           "fieldName" : "templateName"
+         }
+       ]
      }
   ]
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -357,6 +357,11 @@
             "fieldName" : "acquisitionsUnitId"
          }
        ]
+     },
+     {
+      "tableName": "order_templates",
+      "fromModuleVersion": 7.0,
+      "withMetadata": false
      }
   ]
 }

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -27,7 +27,7 @@ public class EntitiesCrudTest extends TestBase {
 
   public static Stream<TestEntities> deleteOrder() {
     return Stream.of(TestEntities.ORDER_INVOICE_RELNS, TestEntities.PO_LINE,
-        TestEntities.PURCHASE_ORDER, TestEntities.ALERT, TestEntities.REPORTING_CODE, TestEntities.ACQUISITIONS_UNIT_MEMBERSHIPS,
+        TestEntities.PURCHASE_ORDER, TestEntities.ALERT, TestEntities.REPORTING_CODE, TestEntities.ORDER_TEMPLATE, TestEntities.ACQUISITIONS_UNIT_MEMBERSHIPS,
         TestEntities.ACQUISITIONS_UNIT);
   }
 

--- a/src/test/java/org/folio/rest/utils/TestEntities.java
+++ b/src/test/java/org/folio/rest/utils/TestEntities.java
@@ -4,6 +4,7 @@ import org.folio.rest.jaxrs.model.AcquisitionsUnit;
 import org.folio.rest.jaxrs.model.AcquisitionsUnitMembership;
 import org.folio.rest.jaxrs.model.Alert;
 import org.folio.rest.jaxrs.model.OrderInvoiceRelationship;
+import org.folio.rest.jaxrs.model.OrderTemplate;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
@@ -17,6 +18,7 @@ public enum TestEntities {
   PO_LINE("/orders-storage/po-lines", PoLine.class, "data/po-lines/313000-1_awaiting_receipt_mix-format.json", "description", "Gift", 16),
   PIECE("/orders-storage/pieces", Piece.class, "data/pieces/313000-03_created_by_item.json", "comment", "Update Comment", 18),
   ORDER_INVOICE_RELNS("/orders-storage/order-invoice-relns", OrderInvoiceRelationship.class, "data/order-invoice-relationships/313000_123invoicenumber45.json", "invoiceId", "e41e0161-2bc6-41f3-a6e7-34fc13250bf1", 9),
+  ORDER_TEMPLATE("/orders-storage/order-templates", OrderTemplate.class, "data/order-templates/order-template.json", "templateCode", "Amazon-A", 1),
   ACQUISITIONS_UNIT("/acquisitions-units-storage/units", AcquisitionsUnit.class, "data/acquisitions-units/acquisitions-unit.json", "name", "met", 1),
   ACQUISITIONS_UNIT_MEMBERSHIPS("/acquisitions-units-storage/memberships", AcquisitionsUnitMembership.class, "data/acquisitions-units-memberships/acquisition_unit_membership.json", "userId", "f8e41958-a378-4051-ae6e-429d231acb66", 1);
 


### PR DESCRIPTION
[MODORDSTOR-106](https://issues.folio.org/browse/MODORDSTOR-106) - Create order-templates API.

## Purpose
Implementation of order templates API according to requirements: https://docs.google.com/spreadsheets/d/1se-a2owRfHLG5eaAZglx4vLvRClCKGp2wZCfD39ZJRY/edit#gid=894044560.

## Approach
Order templates API implemented, schemas introduced in scope of PR [#182](https://github.com/folio-org/acq-models/pull/182).

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
 