### PR TITLE
MODORDSTOR-105 - Populate sample data for Order templates

### DIFF
--- a/src/main/resources/data/order-templates/amazon_book_orders.json
+++ b/src/main/resources/data/order-templates/amazon_book_orders.json
@@ -28,7 +28,7 @@
     "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892"
   },
   "shipTo" : "f7c36792-05f7-4c8c-969d-103ac6763187",
-  "tags": {
+  "poTags": {
     "tagList": [
       "amazon"
     ]

--- a/src/main/resources/data/order-templates/amazon_book_orders.json
+++ b/src/main/resources/data/order-templates/amazon_book_orders.json
@@ -1,0 +1,37 @@
+{
+  "id": "4dee318b-f5b3-40dc-be93-cc89b8c45b6f",
+  "templateCode": "Amazon-B",
+  "templateDescription": "Use to create orders in FOLIO after they are placed on Amazon",
+  "templateName": "Amazon book orders",
+  "acquisitionMethod": "Purchase At Vendor System",
+  "approved": true,
+  "billTo" : "5f8a321e-6b38-4d90-92d4-bf08f91a2242",
+  "cancellationRestriction": true,
+  "cost": {
+    "currency": "USD",
+    "quantityPhysical": 1
+  },
+  "locations": [
+    {
+      "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+      "quantityPhysical": 1
+    }
+  ],
+  "notes": [
+    "Check credit card statement to make sure payment shows up"
+  ],
+  "orderFormat": "Physical Resource",
+  "orderType": "One-Time",
+  "physical": {
+    "createInventory": "Instance, Holding, Item",
+    "materialSupplier": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
+    "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892"
+  },
+  "shipTo" : "f7c36792-05f7-4c8c-969d-103ac6763187",
+  "tags": {
+    "tagList": [
+      "amazon"
+    ]
+  },
+  "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1"
+}

--- a/src/main/resources/data/order-templates/e_books.json
+++ b/src/main/resources/data/order-templates/e_books.json
@@ -32,5 +32,10 @@
   "physical": {
     "createInventory": "Instance, Holding, Item"
   },
+  "polTags": {
+    "tagList": [
+      "dissert-2020"
+    ]
+  },
   "receiptStatus": "Receipt Not Required"
 }

--- a/src/main/resources/data/order-templates/e_books.json
+++ b/src/main/resources/data/order-templates/e_books.json
@@ -1,0 +1,36 @@
+{
+  "id": "2cec3275-a5c7-4ba1-afab-905ada8c5b65",
+  "templateCode": "Individual eBooks",
+  "templateDescription": "Be sure to fill in the proper vendor",
+  "templateName": "eBooks",
+  "acqUnitIds": [
+    "0ebb1f7d-983f-3026-8a4c-5318e0ebc041"
+  ],
+  "acquisitionMethod": "Purchase At Vendor System",
+  "approved": true,
+  "billTo" : "103c7625-0142-42f9-896e-cb51dd94a322",
+  "cancellationRestriction": true,
+  "cost": {
+    "currency": "USD",
+    "listUnitPriceElectronic": 1
+  },
+  "eresource": {
+    "createInventory": "Instance, Holding",
+    "materialType": "615b8413-82d5-4203-aa6e-e37984cb5ac3"
+  },
+  "locations": [
+    {
+      "locationId": "184aae84-a5bf-4c6a-85ba-4a7c73026cd5",
+      "quantityElectronic": 1
+    }
+  ],
+  "notes": [
+    "Check for activation & discovery"
+  ],
+  "orderFormat": "Electronic Resource",
+  "orderType": "One-Time",
+  "physical": {
+    "createInventory": "Instance, Holding, Item"
+  },
+  "receiptStatus": "Receipt Not Required"
+}

--- a/src/main/resources/data/order-templates/e_books.json
+++ b/src/main/resources/data/order-templates/e_books.json
@@ -29,12 +29,9 @@
   ],
   "orderFormat": "Electronic Resource",
   "orderType": "One-Time",
-  "physical": {
-    "createInventory": "Instance, Holding, Item"
-  },
   "polTags": {
     "tagList": [
-      "dissert-2020"
+      "e-book"
     ]
   },
   "receiptStatus": "Receipt Not Required"

--- a/src/main/resources/data/order-templates/e_journal_packages.json
+++ b/src/main/resources/data/order-templates/e_journal_packages.json
@@ -1,0 +1,35 @@
+{
+  "id": "43bb8a31-4e4b-463c-95c5-e163760f0092",
+  "receiptStatus": "Receipt Not Required",
+  "templateCode": "Packages: eJournals",
+  "templateName": "eJournal packages",
+  "acqUnitIds": [
+    "0ebb1f7d-983f-3026-8a4c-5318e0ebc041"
+  ],
+  "acquisitionMethod": "Purchase At Vendor System",
+  "approved": true,
+  "billTo" : "103c7625-0142-42f9-896e-cb51dd94a322",
+  "cancellationRestriction": true,
+  "collection": true,
+  "cost": {
+    "currency": "USD",
+    "quantityElectronic": 1
+  },
+  "eresource": {
+    "createInventory": "None",
+    "materialType": "615b8413-82d5-4203-aa6e-e37984cb5ac3"
+  },
+  "locations": [
+    {
+      "locationId": "184aae84-a5bf-4c6a-85ba-4a7c73026cd5",
+      "quantityElectronic": 1
+    }
+  ],
+  "manualPo": true,
+  "orderFormat": "Electronic Resource",
+  "orderType": "Ongoing",
+  "physical": {
+    "createInventory": "Instance, Holding, Item"
+  },
+  "reEncumber": true
+}

--- a/src/main/resources/data/order-templates/e_journal_packages.json
+++ b/src/main/resources/data/order-templates/e_journal_packages.json
@@ -31,5 +31,10 @@
   "physical": {
     "createInventory": "Instance, Holding, Item"
   },
+  "polTags": {
+    "tagList": [
+      "e-journal"
+    ]
+  },
   "reEncumber": true
 }

--- a/src/main/resources/data/order-templates/e_journal_packages.json
+++ b/src/main/resources/data/order-templates/e_journal_packages.json
@@ -28,9 +28,6 @@
   "manualPo": true,
   "orderFormat": "Electronic Resource",
   "orderType": "Ongoing",
-  "physical": {
-    "createInventory": "Instance, Holding, Item"
-  },
   "polTags": {
     "tagList": [
       "e-journal"

--- a/src/main/resources/data/order-templates/german_sound_recordings.json
+++ b/src/main/resources/data/order-templates/german_sound_recordings.json
@@ -39,7 +39,8 @@
   },
   "polTags": {
     "tagList": [
-      "german, music"
+      "german",
+      "music"
     ]
   },
   "vendor": "c0fb5956-cdf1-11e8-a8d5-f2801f1b9fd1"

--- a/src/main/resources/data/order-templates/german_sound_recordings.json
+++ b/src/main/resources/data/order-templates/german_sound_recordings.json
@@ -1,0 +1,41 @@
+{
+  "id": "cc637c23-d1fb-47b9-bcda-1d6f0812dc01",
+  "templateCode": "German music",
+  "templateName": "German sound recordings",
+  "acqUnitIds": [
+    "0ebb1f7d-983f-3026-8a4c-5318e0ebc041"
+  ],
+  "acquisitionMethod": "Purchase",
+  "approved": true,
+  "billTo" : "103c7625-0142-42f9-896e-cb51dd94a322",
+  "cost": {
+    "currency": "USD",
+    "quantityPhysical": 1
+  },
+  "fundDistribution": [
+    {
+      "fundId": "e9285a1c-1dfc-4380-868c-e74073003f43",
+      "percentage": 100
+    }
+  ],
+  "locations": [
+    {
+      "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
+      "quantityPhysical": 1
+    }
+  ],
+  "orderFormat": "Physical Resource",
+  "orderType": "One-Time",
+  "physical": {
+    "createInventory": "Instance, Holding, Item",
+    "materialSupplier": "c0fb5956-cdf1-11e8-a8d5-f2801f1b9fd1"
+  },
+  "selector": "Music Librarian",
+  "shipTo" : "a3a02de3-c31a-4c2b-a2ce-8db9590ea90c",
+  "tags": {
+    "tagList": [
+      "music"
+    ]
+  },
+  "vendor": "c0fb5956-cdf1-11e8-a8d5-f2801f1b9fd1"
+}

--- a/src/main/resources/data/order-templates/german_sound_recordings.json
+++ b/src/main/resources/data/order-templates/german_sound_recordings.json
@@ -32,9 +32,14 @@
   },
   "selector": "Music Librarian",
   "shipTo" : "a3a02de3-c31a-4c2b-a2ce-8db9590ea90c",
-  "tags": {
+  "poTags": {
     "tagList": [
       "music"
+    ]
+  },
+  "polTags": {
+    "tagList": [
+      "german, music"
     ]
   },
   "vendor": "c0fb5956-cdf1-11e8-a8d5-f2801f1b9fd1"

--- a/src/main/resources/data/order-templates/order-template.json
+++ b/src/main/resources/data/order-templates/order-template.json
@@ -1,6 +1,0 @@
-{
-   "id": "4dee318b-f5b3-40dc-be93-cc89b8c45b6f",
-   "templateName": "Amazon book orders",
-   "templateCode": "Amazon-B",
-   "templateDescription": "Use to create orders in FOLIO after they are placed on Amazon"
-}

--- a/src/main/resources/data/order-templates/our_dissertations.json
+++ b/src/main/resources/data/order-templates/our_dissertations.json
@@ -1,0 +1,35 @@
+{
+  "id": "5c56e4f6-1296-4b5f-a6dc-8309d9983a16",
+  "templateCode": "Dissert",
+  "templateDescription": "Use to create orders for our dissertations going to the archives; change the pub year each year",
+  "templateName": "Our dissertations",
+  "acquisitionMethod": "Gift",
+  "approved": true,
+  "cost": {
+    "listUnitPrice": 0,
+    "quantityPhysical": 1
+  },
+  "instanceId": null,
+  "locations": [
+    {
+      "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
+      "quantityPhysical": 1
+    }
+  ],
+  "manualPo": true,
+  "orderFormat": "Physical Resource",
+  "orderType": "One-Time",
+  "paymentStatus": "Payment Not Required",
+  "physical": {
+    "createInventory": "Instance, Holding, Item",
+    "materialType": "d9acad2f-2aac-4b48-9097-e6ab85906b25"
+  },
+  "publicationDate": "2020",
+  "publisher": "Important University",
+  "shipTo": "a3a02de3-c31a-4c2b-a2ce-8db9590ea90c",
+  "tags": {
+    "tagList": [
+      "dissertation"
+    ]
+  }
+}

--- a/src/main/resources/data/order-templates/our_dissertations.json
+++ b/src/main/resources/data/order-templates/our_dissertations.json
@@ -26,10 +26,16 @@
   },
   "publicationDate": "2020",
   "publisher": "Important University",
-  "shipTo": "a3a02de3-c31a-4c2b-a2ce-8db9590ea90c",
-  "tags": {
+  "poTags": {
     "tagList": [
       "dissertation"
     ]
-  }
+  },
+  "polTags": {
+    "tagList": [
+      "dissert-2020"
+    ]
+  },
+  "shipTo": "a3a02de3-c31a-4c2b-a2ce-8db9590ea90c"
+
 }

--- a/src/test/java/org/folio/rest/utils/TestEntities.java
+++ b/src/test/java/org/folio/rest/utils/TestEntities.java
@@ -18,7 +18,7 @@ public enum TestEntities {
   PO_LINE("/orders-storage/po-lines", PoLine.class, "data/po-lines/313000-1_awaiting_receipt_mix-format.json", "description", "Gift", 16),
   PIECE("/orders-storage/pieces", Piece.class, "data/pieces/313000-03_created_by_item.json", "comment", "Update Comment", 18),
   ORDER_INVOICE_RELNS("/orders-storage/order-invoice-relns", OrderInvoiceRelationship.class, "data/order-invoice-relationships/313000_123invoicenumber45.json", "invoiceId", "e41e0161-2bc6-41f3-a6e7-34fc13250bf1", 9),
-  ORDER_TEMPLATE("/orders-storage/order-templates", OrderTemplate.class, "data/order-templates/order-template.json", "templateCode", "Amazon-A", 1),
+  ORDER_TEMPLATE("/orders-storage/order-templates", OrderTemplate.class, "data/order-templates/amazon_book_orders.json", "templateCode", "Amazon-A", 5),
   ACQUISITIONS_UNIT("/acquisitions-units-storage/units", AcquisitionsUnit.class, "data/acquisitions-units/acquisitions-unit.json", "name", "met", 1),
   ACQUISITIONS_UNIT_MEMBERSHIPS("/acquisitions-units-storage/memberships", AcquisitionsUnitMembership.class, "data/acquisitions-units-memberships/acquisition_unit_membership.json", "userId", "f8e41958-a378-4051-ae6e-429d231acb66", 1);
 


### PR DESCRIPTION
[MODORDSTOR-105](https://issues.folio.org/browse/MODORDSTOR-105) - Populate sample data for Order templates

## Purpose
One need to populate sample data for order templates. Order templates API introduced in [MODORDSTOR-106](https://issues.folio.org/browse/MODORDSTOR-106).

## Approach
Sample Order Template data tab in this spreadsheet for the 5 sample templates: https://docs.google.com/spreadsheets/d/1N23t8OB0rn0Kl7Qp-09iMW_FnjJYhrDgQUziEetjn8Y/edit#gid=1650451138

#### TODOS and Open Questions
One need to coordinate tenant addresses IDs will be implemented in [MODCONF-32](https://issues.folio.org/browse/MODCONF-32).

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.