### PR TITLE
MODORDSTOR-108 Add qualifier field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>25.0.1</raml-module-builder.version>
+    <raml-module-builder.version>25.0.2</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <postgres.driver.version>9.4.1212</postgres.driver.version>
     <junit-jupiter-version>5.4.2</junit-jupiter-version>
@@ -364,40 +364,18 @@
           <execution>
             <phase>prepare-package</phase>
             <configuration>
-              <tasks>
+              <target>
                 <replace token="baseUri: http://github.com/org/folio/lsp-apis" value="baseUri: http://localhost:${http.port}/apis" dir="${basedir}/target/classes/apidocs/raml">
                   <include name="**/*.raml" />
                 </replace>
                 <replace token="protocols: [ HTTPS ]" value="protocols: [ HTTP ]" dir="${basedir}/target/classes/apidocs/raml">
                   <include name="**/*.raml" />
                 </replace>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0.0</version>
-        <executions>
-          <execution>
-            <id>set-system-properties</id>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <property>
-                  <name>log4j.configuration</name>
-                  <value>${project.baseUri}src/main/resources/log4j.properties</value>
-                </property>
-              </properties>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -423,7 +423,7 @@
               </transformers>
               <filters>
                 <filter>
-                  <artifact>org.folio:raml-module-builder</artifact>
+                  <artifact>org.folio:domain-models*</artifact>
                   <excludes>
                     <exclude>**/log4j2.properties</exclude>
                   </excludes>
@@ -456,7 +456,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>2.22.2</version>
         <configuration>
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.Log4j2LogDelegateFactory</vertx.logger-delegate-factory-class-name>
@@ -464,12 +464,8 @@
           <argLine>
             @{argLine} -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
           </argLine>
-          <excludes>
-            <exclude>org/folio/rest/impl/*Test.java</exclude>
-          </excludes>
           <includes>
             <include>org/folio/rest/impl/StorageTestSuite.java</include>
-            <include>org/folio/rest/**</include>
           </includes>
           <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
                https://issues.folio.org/browse/FOLIO-1609

--- a/src/main/resources/data/po-lines/101125-1_pending_physical.json
+++ b/src/main/resources/data/po-lines/101125-1_pending_physical.json
@@ -33,7 +33,8 @@
       },
       {
         "productId": "9780262012102",
-        "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422"
+        "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422",
+        "qualifier": "(hardcover)"
       }
     ],
     "receivingNote": "2 copies",


### PR DESCRIPTION
## Purpose
[MODORDSTOR-108](https://issues.folio.org/browse/MODORDSTOR-108) Add qualifier field to `poLine->details->productIds[]`

## Approach
- Updating the acq-models
- Updating one sample PO line adding product qualifier
- Updating RMB to 25.0.2 (not related to jira requirements)

#### TODOS and Open Questions
- [x] Point to master commit of acq-models
- [ ] Merge together with https://github.com/folio-org/mod-orders/pull/225

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
