### PR TITLE
MODORDSTOR-158: Retreiving order collection in descending order fails

### DIFF
--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -27,7 +27,7 @@ public class HelperUtils {
 
   private static final String POL_NUMBER_PREFIX = "polNumber_";
   private static final String QUOTES_SYMBOL = "\"";
-  private static final Pattern orderBy = Pattern.compile("(?<=ORDER BY).*?(?=$|DESC.*$|LIMIT.*$|OFFSET.*$)");
+  private static final Pattern orderBy = Pattern.compile("(?<=ORDER BY).*?(?=$|LIMIT.*$|OFFSET.*$)");
 
   public static final String JSONB = "jsonb";
   public static final String METADATA = "metadata";
@@ -42,8 +42,9 @@ public class HelperUtils {
     Method respond400 = getRespond400(entitiesMetadataHolder, asyncResultHandler);
     try {
       Matcher matcher = orderBy.matcher(queryHolder.buildCQLQuery().toString());
+      String orderByFields = matcher.find() ? matcher.group(0).replaceAll(" DESC\\b", "") + ", " : "";  // \b = word boundary
       String inLowerUnaccentSortField = wrapInLowerUnaccent(String.format("%s->>'%s'", queryHolder.getSearchField(), sortField));
-      String distinctOn = matcher.find() ? matcher.group(0) + ", " + inLowerUnaccentSortField : inLowerUnaccentSortField;
+      String distinctOn = orderByFields + inLowerUnaccentSortField;
       PostgresClient postgresClient = PgUtil.postgresClient(vertxContext, okapiHeaders);
       postgresClient.get(queryHolder.getTable(), entitiesMetadataHolder.getClazz(), JSONB, queryHolder.buildCQLQuery(), true, false, null, distinctOn,
         reply -> processDbReply(entitiesMetadataHolder, asyncResultHandler, respond500, respond400, reply));

--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -102,6 +102,12 @@ public class OrdersAPITest extends TestBase {
       assertThat(ordersWithTag, hasSize(1));
       assertThat("important", isIn(ordersWithTag.get(0).getTags().getTagList()));
 
+      logger.info("--- mod-orders-storage Orders API test: Verifying entities filtering by tags, sort.descending... ");
+      List<PurchaseOrder> ordersWithTagDescending = getViewCollection(ORDERS_ENDPOINT + "?query=tags.tagList=important sortBy dateOrdered/sort.descending");
+
+      assertThat(ordersWithTagDescending, hasSize(1));
+      assertThat("important", isIn(ordersWithTagDescending.get(0).getTags().getTagList()));
+
       logger.info("--- mod-orders-storage Orders API test: Verifying entities filtering by PO and POLine fields... ");
       List<PurchaseOrder> filteredByPoAndP0LineFields = getViewCollection(ORDERS_ENDPOINT + "?query=workflowStatus==Pending AND orderType==One-Time");
       assertThat(filteredByPoAndP0LineFields, hasSize(2));


### PR DESCRIPTION
Fix HelperUtils orderBy RegExp Pattern that correctly handles
multiple fields with multiple DESC keywords.