### PR TITLE
MODORDSTOR-162: Update to RMB v30.2.3 fixing pg_catalog.pg_trgm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>30.0.2</raml-module-builder.version>
+    <raml-module-builder.version>30.2.3</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit-jupiter-version>5.5.2</junit-jupiter-version>
     <jmockit.version>1.49</jmockit.version>

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLineNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLineNumberTest.java
@@ -10,13 +10,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.folio.rest.persist.PostgresClient;
-import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import com.github.mauricio.async.db.postgresql.exceptions.GenericDatabaseException;
 
 import io.restassured.response.Response;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.sqlclient.Row;
@@ -71,7 +71,7 @@ public class PurchaseOrderLineNumberTest extends TestBase {
   }
 
   private void testPOEdit(String purchaseOrderSample, String sampleId) throws MalformedURLException {
-    JSONObject catJSON = new JSONObject(purchaseOrderSample);
+    JsonObject catJSON = new JsonObject(purchaseOrderSample);
     catJSON.put("id", sampleId);
     catJSON.put("poNumber", "666666");
     catJSON.put("workflowStatus", "Open");


### PR DESCRIPTION
This fixes https://issues.folio.org/browse/MODORDSTOR-161
'Upgrade issue between Q1 and Q2: "public.gin_trgm_ops" does not exist'.

Switch from outdated org.json.JSONObject to io.vertx.core.json.JsonObject
in PurchaseOrderLineNumberTest to avoid another dependency in pom.xml.