### PR TITLE
MODORDSTOR-166: Update to RMB 30.2.4 fixing limit=0 totalRecords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>30.2.3</raml-module-builder.version>
+    <raml-module-builder.version>30.2.4</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit-jupiter-version>5.5.2</junit-jupiter-version>
     <jmockit.version>1.49</jmockit.version>


### PR DESCRIPTION
Updating to RMB 30.2.4 fixes https://issues.folio.org/browse/MODORDSTOR-165
(Cannot create POL due to POL limit bug) because it includes
https://issues.folio.org/browse/RMB-673 (totalRecords returns exact hit
count for limit=0).