### PR TITLE
MODORDSTOR-211 Cannot enable module for tenant if uuid-ossp extension installed

### DIFF
--- a/src/main/resources/templates/db_scripts/data-migration/10.0.0/po_line_table.sql
+++ b/src/main/resources/templates/db_scripts/data-migration/10.0.0/po_line_table.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 
 INSERT INTO ${myuniversity}_${mymodule}.titles
 SELECT uuid_generate_v4(), jsonb_strip_nulls(jsonb_build_object('title', po_line.jsonb -> 'title', 'poLineId', po_line.id, 'instanceId', po_line.jsonb-> 'instanceId',
@@ -11,6 +11,3 @@ WHERE po_line.jsonb ? 'title';
 UPDATE ${myuniversity}_${mymodule}.po_line
 SET jsonb = jsonb - '{title}'::text[] || jsonb_build_object('titleOrPackage', jsonb->'title', 'isPackage', false)
 WHERE jsonb ? 'title';
-
-DROP EXTENSION "uuid-ossp";
-

--- a/src/main/resources/templates/db_scripts/data-migration/10.0.0/po_line_table.sql
+++ b/src/main/resources/templates/db_scripts/data-migration/10.0.0/po_line_table.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 
 INSERT INTO ${myuniversity}_${mymodule}.titles
-SELECT uuid_generate_v4(), jsonb_strip_nulls(jsonb_build_object('title', po_line.jsonb -> 'title', 'poLineId', po_line.id, 'instanceId', po_line.jsonb-> 'instanceId',
+SELECT public.uuid_generate_v4(), jsonb_strip_nulls(jsonb_build_object('title', po_line.jsonb -> 'title', 'poLineId', po_line.id, 'instanceId', po_line.jsonb-> 'instanceId',
   'productIds', po_line.jsonb -> 'details' -> 'productIds', 'contributors', po_line.jsonb -> 'contributors', 'edition', po_line.jsonb -> 'edition',
   'publisher', po_line.jsonb -> 'publisher', 'publishedDate', po_line.jsonb -> 'publicationDate', 'subscriptionFrom', po_line.jsonb -> 'details' -> 'subscriptionFrom',
   'subscriptionTo', po_line.jsonb -> 'details' -> 'subscriptionTo', 'subscriptionInterval', po_line.jsonb -> 'details' -> 'subscriptionInterval'))


### PR DESCRIPTION
## Purpose
[MODORDSTOR-211](https://issues.folio.org/browse/MODORDSTOR-211)

## Approach
- use `CREATE IF EXIST` instead of `CREATE` to create `uuid-ossp` exstension
- do not drop extension at the end of the script

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
