### PR TITLE
MODORDSTOR-231: Okapi path for fund code migration

### DIFF
--- a/src/main/java/org/folio/rest/core/RestClient.java
+++ b/src/main/java/org/folio/rest/core/RestClient.java
@@ -5,6 +5,7 @@ import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.persist.HelperUtils.verifyAndExtractBody;
 
 import io.vertx.core.http.HttpMethod;
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
@@ -27,9 +28,19 @@ public class RestClient {
         return get(requestEntry, requestContext, responseType);
     }
 
+    static String endpoint(RequestEntry requestEntry, RequestContext requestContext) {
+        final String okapiURL = requestContext.getHeaders().getOrDefault(RestClient.OKAPI_URL, "");
+        final String okapiPath = URI.create(okapiURL).getPath();
+        final String apiPath = requestEntry.buildEndpoint();
+        if (okapiPath == null) {
+          return apiPath;
+        }
+        return okapiPath + apiPath;
+    }
+
     public <S> CompletableFuture<S> get(RequestEntry requestEntry, RequestContext requestContext, Class<S> responseType) {
         CompletableFuture<S> future = new CompletableFuture<>();
-        String endpoint = requestEntry.buildEndpoint();
+        String endpoint = endpoint(requestEntry, requestContext);
         HttpClientInterface client = getHttpClient(requestContext.getHeaders());
         if (logger.isDebugEnabled()) {
             logger.debug("Calling GET {}", endpoint);

--- a/src/main/java/org/folio/rest/core/RestClient.java
+++ b/src/main/java/org/folio/rest/core/RestClient.java
@@ -7,6 +7,7 @@ import static org.folio.rest.persist.HelperUtils.verifyAndExtractBody;
 import io.vertx.core.http.HttpMethod;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,10 +33,7 @@ public class RestClient {
         final String okapiURL = requestContext.getHeaders().getOrDefault(RestClient.OKAPI_URL, "");
         final String okapiPath = URI.create(okapiURL).getPath();
         final String apiPath = requestEntry.buildEndpoint();
-        if (okapiPath == null) {
-          return apiPath;
-        }
-        return okapiPath + apiPath;
+        return Objects.requireNonNullElse(okapiPath, "") + apiPath;
     }
 
     public <S> CompletableFuture<S> get(RequestEntry requestEntry, RequestContext requestContext, Class<S> responseType) {

--- a/src/test/java/org/folio/rest/core/RestClientTest.java
+++ b/src/test/java/org/folio/rest/core/RestClientTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,11 +49,16 @@ public class RestClientTest {
   public void initMocks(){
     MockitoAnnotations.openMocks(this);
     okapiHeaders = new HashMap<>();
-    okapiHeaders.put(OKAPI_URL, "http://localhost:" + 8081);
+    okapiHeaders.put(OKAPI_URL, "http://localhost:" + 8081 + "/okapi");
     okapiHeaders.put(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue());
     okapiHeaders.put(X_OKAPI_TENANT.getName(), X_OKAPI_TENANT.getValue());
     okapiHeaders.put(X_OKAPI_USER_ID.getName(), X_OKAPI_USER_ID.getValue());
     requestContext = new RequestContext(ctxMock, okapiHeaders);
+  }
+
+  @Test
+  void testEndpoint() {
+    assertThat(RestClient.endpoint(new RequestEntry("/foo/bar"), requestContext), equalTo("/okapi/foo/bar"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/core/RestClientTest.java
+++ b/src/test/java/org/folio/rest/core/RestClientTest.java
@@ -59,6 +59,8 @@ public class RestClientTest {
   @Test
   void testEndpoint() {
     assertThat(RestClient.endpoint(new RequestEntry("/foo/bar"), requestContext), equalTo("/okapi/foo/bar"));
+    okapiHeaders.put(OKAPI_URL, "http://localhost");
+    assertThat(RestClient.endpoint(new RequestEntry("/foo/bar"), requestContext), equalTo("/foo/bar"));
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Fond code migration fails because RestClient drops the OkapiURL path.

## Approach

Keep the OkapiURL path.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
