### PR TITLE
MODORDSTOR-231: Upgrade test (fund code migration) with Okapi path

### DIFF
--- a/src/test/java/org/folio/rest/core/RestClientTest.java
+++ b/src/test/java/org/folio/rest/core/RestClientTest.java
@@ -7,6 +7,7 @@ import static org.folio.rest.util.TestConstants.X_OKAPI_TOKEN;
 import static org.folio.rest.util.TestConstants.X_OKAPI_USER_ID;
 import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -88,10 +89,16 @@ public class RestClientTest {
   void testShouldThrowNullPointerExceptionOnEmptyResult() throws Exception {
     RestClient restClient = Mockito.spy(new RestClient());
     doReturn(httpClient).when(restClient).getHttpClient(okapiHeaders);
-    doReturn(completedFuture(null)).when(httpClient).request(eq(HttpMethod.GET), anyString(), eq(okapiHeaders));
+
+    Response response = new Response();
+    response.setBody(null);
+    response.setCode(200);
+    doReturn(completedFuture(response)).when(httpClient).request(eq(HttpMethod.GET), anyString(), eq(okapiHeaders));
+
     CompletableFuture<Transaction> result = restClient.get(new RequestEntry("/"), requestContext, Transaction.class);
     var e = assertThrows(CompletionException.class, result::join);
     assertThat(e.getCause(), instanceOf(NullPointerException.class));
+    assertThat(e.getCause().getMessage(), is("Expected JSON but got null from GET /"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/core/RestClientTest.java
+++ b/src/test/java/org/folio/rest/core/RestClientTest.java
@@ -7,6 +7,7 @@ import static org.folio.rest.util.TestConstants.X_OKAPI_TOKEN;
 import static org.folio.rest.util.TestConstants.X_OKAPI_USER_ID;
 import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,6 +85,16 @@ public class RestClientTest {
   }
 
   @Test
+  void testShouldThrowNullPointerExceptionOnEmptyResult() throws Exception {
+    RestClient restClient = Mockito.spy(new RestClient());
+    doReturn(httpClient).when(restClient).getHttpClient(okapiHeaders);
+    doReturn(completedFuture(null)).when(httpClient).request(eq(HttpMethod.GET), anyString(), eq(okapiHeaders));
+    CompletableFuture<Transaction> result = restClient.get(new RequestEntry("/"), requestContext, Transaction.class);
+    var e = assertThrows(CompletionException.class, result::join);
+    assertThat(e.getCause(), instanceOf(NullPointerException.class));
+  }
+
+  @Test
   void testShouldReturnHttpClient() {
     RestClient restClient = Mockito.spy(new RestClient());
     HashMap<String, String> headers = new HashMap<>();
@@ -91,5 +103,3 @@ public class RestClientTest {
     assertThat(httpClient, notNullValue());
   }
 }
-
-

--- a/src/test/java/org/folio/services/migration/UpgradeTenantTest.java
+++ b/src/test/java/org/folio/services/migration/UpgradeTenantTest.java
@@ -1,0 +1,136 @@
+package org.folio.services.migration;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.tools.ClientHelpers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+public
+class UpgradeTenantTest {
+    private static final Logger log = LogManager.getLogger(UpgradeTenantTest.class);
+    private int okapiPort;
+    private Vertx vertx;
+    private WebClient webClient;
+
+    @BeforeEach
+    void setUp(Vertx vertx) {
+        this.vertx = vertx;
+        webClient = WebClient.create(vertx);
+    }
+
+    /**
+     * Deploy our Okapi mock on a random free port. Save that port to okapiPort.
+     *
+     * <p>It also mocks an nginx that translates /okapi/foo/bar to /foo/bar
+     */
+    Future<Void> deployOkapiMock() {
+        return vertx.createHttpServer()
+                .requestHandler(httpServerRequest -> {
+                    String method = httpServerRequest.method().name();
+                    String path = httpServerRequest.path();
+                    log.debug("method {} path {}", method, path);
+                    if (path.equals("/okapi/finance-storage/funds") && method.equals("GET")) {
+                        var json = new JsonObject()
+                                .put("totalRecords", 2)
+                                .put("funds", new JsonArray()
+                                        .add(new JsonObject().put("id", "12345678-51ea-49ad-b8f7-02890dee8711"))
+                                        .add(new JsonObject().put("id", "23456789-51ea-49ad-b8f7-02890dee8722")));
+                        httpServerRequest.response().setStatusCode(200).end(json.encode());
+                        return;
+                    }
+                    if (path.startsWith("/okapi/orders-storage/configuration/reasons-for-closure/") &&
+                            httpServerRequest.method().name().equals("PUT")) {
+                        httpServerRequest.response().setStatusCode(201).end("{}");
+                        return;
+                    }
+                    String msg = "Okapi Mock got unexpected " + method + " " + path;
+                    log.error(msg);
+                    httpServerRequest.response().setStatusCode(404).setStatusMessage(msg).end();
+                })
+                .listen(0)
+                .onSuccess(httpServer -> okapiPort = httpServer.actualPort())
+                .mapEmpty();
+    }
+
+    HttpRequest<Buffer> withHeaders(HttpRequest<Buffer> httpRequest) {
+        httpRequest.putHeader("Content-type", "application/json");
+        httpRequest.putHeader("Accept", "application/json,text/plain");
+        httpRequest.putHeader("x-okapi-tenant", "diku");
+        httpRequest.putHeader("X-Okapi-Url", "http://localhost:" + okapiPort + "/okapi");
+        return httpRequest;
+    }
+
+    String pojo2json(Object entity) {
+        try {
+            return ClientHelpers.pojo2json(entity);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * call POST at mod-orders-storage /_/tenant
+     */
+    Future<Void> postTenant(TenantAttributes tenantAttributes) {
+        var post = webClient.requestAbs(HttpMethod.POST, "http://localhost:8081/_/tenant");
+        return withHeaders(post).sendBuffer(Buffer.buffer(pojo2json(tenantAttributes)))
+                .compose(httpResponse -> {
+                    if (httpResponse.statusCode() != 201) {
+                        return Future.failedFuture(new AssertionError("status code " + httpResponse.statusCode()));
+                    }
+                    var id = httpResponse.bodyAsJsonObject().getString("id");
+                    var get = webClient.requestAbs(HttpMethod.GET, "http://localhost:8081/_/tenant/" + id + "?wait=60000");
+                    return withHeaders(get).send();
+                }).map(httpResponse -> {
+                    if (httpResponse.statusCode() != 200) {
+                        throw new AssertionError("status code " + httpResponse.statusCode());
+                    }
+                    var jsonObject = httpResponse.bodyAsJsonObject();
+                    if (! jsonObject.getBoolean("complete")) {
+                        throw new AssertionError("not complete: " + jsonObject.encodePrettily());
+                    }
+                    var messages = jsonObject.getJsonArray("messages");
+                    if (! messages.isEmpty()) {
+                        throw new AssertionError("errors: " + messages.encodePrettily());
+                    }
+                    return null;
+                });
+    }
+
+    Future<Void> initTenant() {
+        var tenantAttributes = new TenantAttributes();
+        tenantAttributes.setModuleTo("mod-orders-storage-99.99.99");
+        return postTenant(tenantAttributes);
+    }
+
+    Future<Void> upgradeTenant() {
+        var tenantAttributes = new TenantAttributes();
+        tenantAttributes.setModuleFrom("mod-orders-storage-0.0.0");
+        tenantAttributes.setModuleTo("mod-orders-storage-99.99.99");
+        return postTenant(tenantAttributes);
+    }
+
+    @Test
+    void test(VertxTestContext vtc) {
+        vertx.deployVerticle(new RestVerticle())  // start at default port 8081
+        .compose(x -> deployOkapiMock())
+        .compose(x -> initTenant())
+        .compose(x -> upgradeTenant())
+        .onComplete(vtc.succeedingThenComplete());
+    }
+}

--- a/src/test/java/org/folio/services/migration/UpgradeTenantTest.java
+++ b/src/test/java/org/folio/services/migration/UpgradeTenantTest.java
@@ -22,115 +22,115 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(VertxExtension.class)
 public
 class UpgradeTenantTest {
-    private static final Logger log = LogManager.getLogger(UpgradeTenantTest.class);
-    private int okapiPort;
-    private Vertx vertx;
-    private WebClient webClient;
+  private static final Logger log = LogManager.getLogger(UpgradeTenantTest.class);
+  private int okapiPort;
+  private Vertx vertx;
+  private WebClient webClient;
 
-    @BeforeEach
-    void setUp(Vertx vertx) {
-        this.vertx = vertx;
-        webClient = WebClient.create(vertx);
-    }
+  @BeforeEach
+  void setUp(Vertx vertx) {
+    this.vertx = vertx;
+    webClient = WebClient.create(vertx);
+  }
 
-    /**
-     * Deploy our Okapi mock on a random free port. Save that port to okapiPort.
-     *
-     * <p>It also mocks an nginx that translates /okapi/foo/bar to /foo/bar
-     */
-    Future<Void> deployOkapiMock() {
-        return vertx.createHttpServer()
-                .requestHandler(httpServerRequest -> {
-                    String method = httpServerRequest.method().name();
-                    String path = httpServerRequest.path();
-                    log.debug("method {} path {}", method, path);
-                    if (path.equals("/okapi/finance-storage/funds") && method.equals("GET")) {
-                        var json = new JsonObject()
-                                .put("totalRecords", 2)
-                                .put("funds", new JsonArray()
-                                        .add(new JsonObject().put("id", "12345678-51ea-49ad-b8f7-02890dee8711"))
-                                        .add(new JsonObject().put("id", "23456789-51ea-49ad-b8f7-02890dee8722")));
-                        httpServerRequest.response().setStatusCode(200).end(json.encode());
-                        return;
-                    }
-                    if (path.startsWith("/okapi/orders-storage/configuration/reasons-for-closure/") &&
-                            httpServerRequest.method().name().equals("PUT")) {
-                        httpServerRequest.response().setStatusCode(201).end("{}");
-                        return;
-                    }
-                    String msg = "Okapi Mock got unexpected " + method + " " + path;
-                    log.error(msg);
-                    httpServerRequest.response().setStatusCode(404).setStatusMessage(msg).end();
-                })
-                .listen(0)
-                .onSuccess(httpServer -> okapiPort = httpServer.actualPort())
-                .mapEmpty();
-    }
+  /**
+   * Deploy our Okapi mock on a random free port. Save that port to okapiPort.
+   *
+   * <p>It also mocks an nginx that translates /okapi/foo/bar to /foo/bar
+   */
+  Future<Void> deployOkapiMock() {
+    return vertx.createHttpServer()
+        .requestHandler(httpServerRequest -> {
+          String method = httpServerRequest.method().name();
+          String path = httpServerRequest.path();
+          log.debug("method {} path {}", method, path);
+          if (path.equals("/okapi/finance-storage/funds") && method.equals("GET")) {
+            var json = new JsonObject()
+                .put("totalRecords", 2)
+                .put("funds", new JsonArray()
+                    .add(new JsonObject().put("id", "12345678-51ea-49ad-b8f7-02890dee8711"))
+                    .add(new JsonObject().put("id", "23456789-51ea-49ad-b8f7-02890dee8722")));
+            httpServerRequest.response().setStatusCode(200).end(json.encode());
+            return;
+          }
+          if (path.startsWith("/okapi/orders-storage/configuration/reasons-for-closure/") &&
+              httpServerRequest.method().name().equals("PUT")) {
+            httpServerRequest.response().setStatusCode(201).end("{}");
+            return;
+          }
+          String msg = "Okapi Mock got unexpected " + method + " " + path;
+          log.error(msg);
+          httpServerRequest.response().setStatusCode(404).setStatusMessage(msg).end();
+        })
+        .listen(0)
+        .onSuccess(httpServer -> okapiPort = httpServer.actualPort())
+        .mapEmpty();
+  }
 
-    HttpRequest<Buffer> withHeaders(HttpRequest<Buffer> httpRequest) {
-        httpRequest.putHeader("Content-type", "application/json");
-        httpRequest.putHeader("Accept", "application/json,text/plain");
-        httpRequest.putHeader("x-okapi-tenant", "diku");
-        httpRequest.putHeader("X-Okapi-Url", "http://localhost:" + okapiPort + "/okapi");
-        return httpRequest;
-    }
+  HttpRequest<Buffer> withHeaders(HttpRequest<Buffer> httpRequest) {
+    httpRequest.putHeader("Content-type", "application/json");
+    httpRequest.putHeader("Accept", "application/json,text/plain");
+    httpRequest.putHeader("x-okapi-tenant", "diku");
+    httpRequest.putHeader("X-Okapi-Url", "http://localhost:" + okapiPort + "/okapi");
+    return httpRequest;
+  }
 
-    String pojo2json(Object entity) {
-        try {
-            return ClientHelpers.pojo2json(entity);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+  String pojo2json(Object entity) {
+    try {
+      return ClientHelpers.pojo2json(entity);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    /**
-     * call POST at mod-orders-storage /_/tenant
-     */
-    Future<Void> postTenant(TenantAttributes tenantAttributes) {
-        var post = webClient.requestAbs(HttpMethod.POST, "http://localhost:8081/_/tenant");
-        return withHeaders(post).sendBuffer(Buffer.buffer(pojo2json(tenantAttributes)))
-                .compose(httpResponse -> {
-                    if (httpResponse.statusCode() != 201) {
-                        return Future.failedFuture(new AssertionError("status code " + httpResponse.statusCode()));
-                    }
-                    var id = httpResponse.bodyAsJsonObject().getString("id");
-                    var get = webClient.requestAbs(HttpMethod.GET, "http://localhost:8081/_/tenant/" + id + "?wait=60000");
-                    return withHeaders(get).send();
-                }).map(httpResponse -> {
-                    if (httpResponse.statusCode() != 200) {
-                        throw new AssertionError("status code " + httpResponse.statusCode());
-                    }
-                    var jsonObject = httpResponse.bodyAsJsonObject();
-                    if (! jsonObject.getBoolean("complete")) {
-                        throw new AssertionError("not complete: " + jsonObject.encodePrettily());
-                    }
-                    var messages = jsonObject.getJsonArray("messages");
-                    if (! messages.isEmpty()) {
-                        throw new AssertionError("errors: " + messages.encodePrettily());
-                    }
-                    return null;
-                });
-    }
+  /**
+   * call POST at mod-orders-storage /_/tenant
+   */
+  Future<Void> postTenant(TenantAttributes tenantAttributes) {
+    var post = webClient.requestAbs(HttpMethod.POST, "http://localhost:8081/_/tenant");
+    return withHeaders(post).sendBuffer(Buffer.buffer(pojo2json(tenantAttributes)))
+        .compose(httpResponse -> {
+          if (httpResponse.statusCode() != 201) {
+            return Future.failedFuture(new AssertionError("status code " + httpResponse.statusCode()));
+          }
+          var id = httpResponse.bodyAsJsonObject().getString("id");
+          var get = webClient.requestAbs(HttpMethod.GET, "http://localhost:8081/_/tenant/" + id + "?wait=60000");
+          return withHeaders(get).send();
+        }).map(httpResponse -> {
+          if (httpResponse.statusCode() != 200) {
+            throw new AssertionError("status code " + httpResponse.statusCode());
+          }
+          var jsonObject = httpResponse.bodyAsJsonObject();
+          if (! jsonObject.getBoolean("complete")) {
+            throw new AssertionError("not complete: " + jsonObject.encodePrettily());
+          }
+          var messages = jsonObject.getJsonArray("messages");
+          if (! messages.isEmpty()) {
+            throw new AssertionError("errors: " + messages.encodePrettily());
+          }
+          return null;
+        });
+  }
 
-    Future<Void> initTenant() {
-        var tenantAttributes = new TenantAttributes();
-        tenantAttributes.setModuleTo("mod-orders-storage-99.99.99");
-        return postTenant(tenantAttributes);
-    }
+  Future<Void> initTenant() {
+    var tenantAttributes = new TenantAttributes();
+    tenantAttributes.setModuleTo("mod-orders-storage-99.99.99");
+    return postTenant(tenantAttributes);
+  }
 
-    Future<Void> upgradeTenant() {
-        var tenantAttributes = new TenantAttributes();
-        tenantAttributes.setModuleFrom("mod-orders-storage-0.0.0");
-        tenantAttributes.setModuleTo("mod-orders-storage-99.99.99");
-        return postTenant(tenantAttributes);
-    }
+  Future<Void> upgradeTenant() {
+    var tenantAttributes = new TenantAttributes();
+    tenantAttributes.setModuleFrom("mod-orders-storage-0.0.0");
+    tenantAttributes.setModuleTo("mod-orders-storage-99.99.99");
+    return postTenant(tenantAttributes);
+  }
 
-    @Test
-    void test(VertxTestContext vtc) {
-        vertx.deployVerticle(new RestVerticle())  // start at default port 8081
-        .compose(x -> deployOkapiMock())
-        .compose(x -> initTenant())
-        .compose(x -> upgradeTenant())
-        .onComplete(vtc.succeedingThenComplete());
-    }
+  @Test
+  void test(VertxTestContext vtc) {
+    vertx.deployVerticle(new RestVerticle())  // start at default port 8081
+    .compose(x -> deployOkapiMock())
+    .compose(x -> initTenant())
+    .compose(x -> upgradeTenant())
+    .onComplete(vtc.succeedingThenComplete());
+  }
 }


### PR DESCRIPTION
Fix null body handling in RestClient.get.

Add UpgradeTenantTest.java that runs an upgrade using POST `/_/tenant` API and with an Okapi address with path.