### PR TITLE
[MODORDSTOR-252] Return readable error on UI if Acquisition unit already exist

### DIFF
--- a/src/main/java/org/folio/builder/error/NameCodeConstraintErrorBuilder.java
+++ b/src/main/java/org/folio/builder/error/NameCodeConstraintErrorBuilder.java
@@ -1,0 +1,42 @@
+package org.folio.builder.error;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.HttpException;
+import org.folio.rest.persist.HelperUtils;
+import org.folio.rest.persist.PgExceptionUtil;
+
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+import static org.folio.rest.exceptions.ErrorCodes.GENERIC_ERROR_CODE;
+
+public class NameCodeConstraintErrorBuilder {
+
+  public <T> HttpException buildException(AsyncResult<T> reply, Class<?> clazz ) {
+    String error = convertExceptionToStringError(reply, clazz);
+    if (GENERIC_ERROR_CODE.getCode().equals(error)) {
+      return new HttpException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), error);
+    }
+    return new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), error);
+  }
+
+  private <T> String convertExceptionToStringError(AsyncResult<T> reply, Class<?> clazz) {
+    String msg = PgExceptionUtil.badRequestMessage(reply.cause());
+    return Optional.ofNullable(msg)
+      .map(HelperUtils::getSQLUniqueConstraintName)
+      .map(uniqueConstraintName -> buildFieldConstraintError(uniqueConstraintName, clazz))
+      .orElse(GENERIC_ERROR_CODE.getCode());
+  }
+
+  private String buildFieldConstraintError(String uniqueConstraintName, Class<?> clazz)  {
+    final String FIELD_CODE = "Code";
+    final String FIELD_NAME = "Name";
+    if (uniqueConstraintName.contains(FIELD_CODE.toLowerCase())) {
+      return JsonObject.mapFrom(HelperUtils.buildFieldConstraintError(clazz.getSimpleName(), FIELD_CODE)).encode();
+    } else if (uniqueConstraintName.contains(FIELD_NAME.toLowerCase())) {
+      return JsonObject.mapFrom(HelperUtils.buildFieldConstraintError(clazz.getSimpleName(), FIELD_NAME)).encode();
+    }
+    return JsonObject.mapFrom(GENERIC_ERROR_CODE.toError()).encode();
+  }
+}

--- a/src/main/java/org/folio/builders/error/NameCodeConstraintErrorBuilder.java
+++ b/src/main/java/org/folio/builders/error/NameCodeConstraintErrorBuilder.java
@@ -1,4 +1,4 @@
-package org.folio.builder.error;
+package org.folio.builders.error;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/org/folio/rest/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/exceptions/ErrorCodes.java
@@ -5,7 +5,8 @@ import org.folio.rest.jaxrs.model.Error;
 public enum ErrorCodes {
 
   GENERIC_ERROR_CODE("genericError", "Generic error"),
-  POSTGRE_SQL_ERROR("pgException", "PostgreSQL exception");
+  POSTGRE_SQL_ERROR("pgException", "PostgreSQL exception"),
+  UNIQUE_FIELD_CONSTRAINT_ERROR("uniqueField{0}{1}Error", "Field {0} must be unique");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/rest/impl/AcquisitionsUnitsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AcquisitionsUnitsAPI.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
+import io.vertx.core.Vertx;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.AcquisitionsUnit;
 import org.folio.rest.jaxrs.model.AcquisitionsUnitCollection;
@@ -15,11 +16,18 @@ import org.folio.rest.persist.PgUtil;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import org.folio.services.acquisitions.AcquisitionService;
 
 public class AcquisitionsUnitsAPI implements AcquisitionsUnitsStorage {
 
   private static final String ACQUISITIONS_UNIT_TABLE = "acquisitions_unit";
   private static final String ACQUISITIONS_UNIT_MEMBERSHIP_TABLE = "acquisitions_unit_membership";
+
+  private AcquisitionService acquisitionService;
+
+  public AcquisitionsUnitsAPI(Vertx vertx, String tenantId) {
+    acquisitionService = new AcquisitionService(vertx, tenantId);
+  }
 
   @Override
   @Validate
@@ -32,7 +40,7 @@ public class AcquisitionsUnitsAPI implements AcquisitionsUnitsStorage {
   @Override
   @Validate
   public void postAcquisitionsUnitsStorageUnits(String lang, AcquisitionsUnit entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(ACQUISITIONS_UNIT_TABLE, entity, okapiHeaders, vertxContext, PostAcquisitionsUnitsStorageUnitsResponse.class, asyncResultHandler);
+    acquisitionService.createAcquisitionsUnit(entity, vertxContext, asyncResultHandler);
   }
 
   @Override

--- a/src/main/java/org/folio/services/acquisitions/AcquisitionService.java
+++ b/src/main/java/org/folio/services/acquisitions/AcquisitionService.java
@@ -35,10 +35,10 @@ public class AcquisitionService {
 
   public void createAcquisitionsUnit(AcquisitionsUnit acquisitionsUnit, Context vertxContext, Handler<AsyncResult<Response>> asyncResultHandler) {
     vertxContext.runOnContext(v -> createAcquisitionsUnit(acquisitionsUnit)
-      .onSuccess(group -> {
+      .onSuccess(entity -> {
         logger.debug("AcquisitionService with id {} created", acquisitionsUnit.getId());
         asyncResultHandler.handle(Future.succeededFuture(
-          AcquisitionsUnitsStorage.PostAcquisitionsUnitsStorageUnitsResponse.respond201WithApplicationJson(group, headersFor201())));
+          AcquisitionsUnitsStorage.PostAcquisitionsUnitsStorageUnitsResponse.respond201WithApplicationJson(entity, headersFor201())));
       })
       .onFailure(throwable -> {
         logger.error("AcquisitionService creation with id {} failed", acquisitionsUnit.getId(), throwable);

--- a/src/main/java/org/folio/services/acquisitions/AcquisitionService.java
+++ b/src/main/java/org/folio/services/acquisitions/AcquisitionService.java
@@ -1,0 +1,65 @@
+package org.folio.services.acquisitions;
+
+import java.util.UUID;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.builder.error.NameCodeConstraintErrorBuilder;
+import org.folio.rest.jaxrs.model.AcquisitionsUnit;
+import org.folio.rest.jaxrs.resource.AcquisitionsUnitsStorage;
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+import javax.ws.rs.core.Response;
+
+import static org.folio.rest.core.ResponseUtil.buildErrorResponse;
+import static org.folio.rest.jaxrs.resource.AcquisitionsUnitsStorage.PostAcquisitionsUnitsStorageUnitsResponse.headersFor201;
+
+public class AcquisitionService {
+
+  private final Logger logger = LogManager.getLogger(this.getClass());
+  private static final String ACQUISITIONS_UNIT_TABLE = "acquisitions_unit";
+  private final PostgresClient pgClient;
+  private final NameCodeConstraintErrorBuilder nameCodeConstraintErrorBuilder;
+
+  public AcquisitionService(Vertx vertx, String tenantId) {
+    this.pgClient = PostgresClient.getInstance(vertx, tenantId);
+    this.nameCodeConstraintErrorBuilder = new NameCodeConstraintErrorBuilder();
+  }
+
+  public void createAcquisitionsUnit(AcquisitionsUnit acquisitionsUnit, Context vertxContext, Handler<AsyncResult<Response>> asyncResultHandler) {
+    vertxContext.runOnContext(v -> createAcquisitionsUnit(acquisitionsUnit)
+      .onSuccess(group -> {
+        logger.debug("AcquisitionService with id {} created", acquisitionsUnit.getId());
+        asyncResultHandler.handle(Future.succeededFuture(
+          AcquisitionsUnitsStorage.PostAcquisitionsUnitsStorageUnitsResponse.respond201WithApplicationJson(group, headersFor201())));
+      })
+      .onFailure(throwable -> {
+        logger.error("AcquisitionService creation with id {} failed", acquisitionsUnit.getId(), throwable);
+        asyncResultHandler.handle(buildErrorResponse(throwable));
+      }));
+  }
+
+  private Future<AcquisitionsUnit> createAcquisitionsUnit(AcquisitionsUnit acquisitionsUnit) {
+    Promise<AcquisitionsUnit> promise = Promise.promise();
+    if (acquisitionsUnit.getId() == null) {
+      acquisitionsUnit.setId(UUID.randomUUID().toString());
+    }
+    pgClient.save(ACQUISITIONS_UNIT_TABLE, acquisitionsUnit.getId(), acquisitionsUnit, reply -> {
+      if (reply.failed()) {
+        promise.fail(nameCodeConstraintErrorBuilder.buildException(reply, AcquisitionsUnit.class));
+      }
+      else {
+        promise.complete(acquisitionsUnit);
+      }
+    });
+    return promise.future();
+  }
+
+}

--- a/src/main/java/org/folio/services/acquisitions/AcquisitionService.java
+++ b/src/main/java/org/folio/services/acquisitions/AcquisitionService.java
@@ -7,7 +7,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.builder.error.NameCodeConstraintErrorBuilder;
+import org.folio.builders.error.NameCodeConstraintErrorBuilder;
 import org.folio.rest.jaxrs.model.AcquisitionsUnit;
 import org.folio.rest.jaxrs.resource.AcquisitionsUnitsStorage;
 import org.folio.rest.persist.PostgresClient;

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -168,13 +168,13 @@ public class EntitiesCrudTest extends TestBase {
     JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
     duplicateEntity.remove("id");
     Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails().statusCode(201);
+    response.then().log().ifValidationFails().statusCode(400);
 
 //    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
 //    Matcher matcher = pattern.matcher(response.getBody().asString());
 //    Assertions.assertTrue(matcher.find());
 //    assertTrue(response.asString().contains("value already exists in table"));
-    assertTrue(response.asString().contains("already exists|uniqueField"));
+    assertTrue(response.asString().contains("Field Name must be unique"));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -173,7 +173,8 @@ public class EntitiesCrudTest extends TestBase {
 //    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
 //    Matcher matcher = pattern.matcher(response.getBody().asString());
 //    Assertions.assertTrue(matcher.find());
-    assertTrue(response.asString().contains("value already exists in table"));
+//    assertTrue(response.asString().contains("value already exists in table"));
+    assertTrue(response.asString().contains("already exists|uniqueField"));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -112,22 +112,7 @@ public class EntitiesCrudTest extends TestBase {
     }
 
   }
-/*
-  @ParameterizedTest
-  @Order(6)
-  @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT"}, mode = EnumSource.Mode.INCLUDE)
-  public void testUniqueKeyConstraintAcquisitionUnit(TestEntities testEntity) throws MalformedURLException {
-    logger.info(String.format("--- mod-orders-storage %s test: Cannot Create Duplicate Entry %s ... ", testEntity.name(), testEntity.name()));
-    JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
-    duplicateEntity.remove("id");
-    Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails().statusCode(400);
 
-    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
-    Matcher matcher = pattern.matcher(response.getBody().asString());
-    Assertions.assertTrue(matcher.find());
-  }
-*/
   @ParameterizedTest
   @Order(6)
   @EnumSource(value = TestEntities.class)

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -168,7 +168,7 @@ public class EntitiesCrudTest extends TestBase {
     JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
     duplicateEntity.remove("id");
     Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails().statusCode(400);
+    response.then().log().ifValidationFails().statusCode(201);
 
     Pattern pattern = Pattern.compile("(already exists|uniqueField)");
     Matcher matcher = pattern.matcher(response.getBody().asString());

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -160,7 +160,7 @@ public class EntitiesCrudTest extends TestBase {
     testVerifyEntityDeletion(testEntity.getEndpointWithId(), testEntity.getId());
   }
 
-  @ParameterizedTest
+  /*@ParameterizedTest
   @Order(11)
   @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT"}, mode = EnumSource.Mode.INCLUDE)
   public void testUniqueKeyConstraintAcquisitionUnit(TestEntities testEntity) throws MalformedURLException {
@@ -176,7 +176,7 @@ public class EntitiesCrudTest extends TestBase {
 //    assertTrue(response.asString().contains("value already exists in table"));
     //assertTrue(response.asString().contains("Field Name must be unique"));
     //assertTrue(response.asString().contains("already exists|uniqueField"));
-  }
+  }*/
 
   @ParameterizedTest
   @EnumSource(value = TestEntities.class, names = {"PO_LINE", "PIECE", "ORDER_INVOICE_RELNS"}, mode = EnumSource.Mode.INCLUDE)

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -170,9 +170,10 @@ public class EntitiesCrudTest extends TestBase {
     Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
     response.then().log().ifValidationFails().statusCode(201);
 
-    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
-    Matcher matcher = pattern.matcher(response.getBody().asString());
-    Assertions.assertTrue(matcher.find());
+//    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
+//    Matcher matcher = pattern.matcher(response.getBody().asString());
+//    Assertions.assertTrue(matcher.find());
+    assertTrue(response.asString().contains("value already exists in table"));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -93,18 +93,41 @@ public class EntitiesCrudTest extends TestBase {
 
   @ParameterizedTest
   @Order(5)
-  @EnumSource(value = TestEntities.class, names = {"REASON_FOR_CLOSURE", "PREFIX", "SUFFIX"}, mode = EnumSource.Mode.INCLUDE)
+  @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT", "REASON_FOR_CLOSURE", "PREFIX", "SUFFIX"}, mode = EnumSource.Mode.INCLUDE)
   public void testUniqueKeyConstraint(TestEntities testEntity) throws MalformedURLException {
     logger.info(String.format("--- mod-orders-storage %s test: Cannot Create Duplicate Entry %s ... ", testEntity.name(), testEntity.name()));
     JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
     duplicateEntity.remove("id");
     Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails()
-    .statusCode(422);
-    assertTrue(response.asString().contains("value already exists in table"));
+    if (testEntity.name() != "ACQUISITIONS_UNIT") {
+      response.then().log().ifValidationFails()
+        .statusCode(422);
+      assertTrue(response.asString().contains("value already exists in table"));
+    }
+    else {
+      response.then().log().ifValidationFails().statusCode(400);
+      Pattern pattern = Pattern.compile("(already exists|uniqueField)");
+      Matcher matcher = pattern.matcher(response.getBody().asString());
+      Assertions.assertTrue(matcher.find());
+    }
 
   }
+/*
+  @ParameterizedTest
+  @Order(6)
+  @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT"}, mode = EnumSource.Mode.INCLUDE)
+  public void testUniqueKeyConstraintAcquisitionUnit(TestEntities testEntity) throws MalformedURLException {
+    logger.info(String.format("--- mod-orders-storage %s test: Cannot Create Duplicate Entry %s ... ", testEntity.name(), testEntity.name()));
+    JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
+    duplicateEntity.remove("id");
+    Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
+    response.then().log().ifValidationFails().statusCode(400);
 
+    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
+    Matcher matcher = pattern.matcher(response.getBody().asString());
+    Assertions.assertTrue(matcher.find());
+  }
+*/
   @ParameterizedTest
   @Order(6)
   @EnumSource(value = TestEntities.class)
@@ -160,20 +183,7 @@ public class EntitiesCrudTest extends TestBase {
     testVerifyEntityDeletion(testEntity.getEndpointWithId(), testEntity.getId());
   }
 
-  @ParameterizedTest
-  @Order(11)
-  @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT"}, mode = EnumSource.Mode.INCLUDE)
-  public void testUniqueKeyConstraintAcquisitionUnit(TestEntities testEntity) throws MalformedURLException {
-    logger.info(String.format("--- mod-orders-storage %s test: Cannot Create Duplicate Entry %s ... ", testEntity.name(), testEntity.name()));
-    JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
-    duplicateEntity.remove("id");
-    Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails().statusCode(400);
 
-    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
-    Matcher matcher = pattern.matcher(response.getBody().asString());
-    Assertions.assertTrue(matcher.find());
-  }
 
   @ParameterizedTest
   @EnumSource(value = TestEntities.class, names = {"PO_LINE", "PIECE", "ORDER_INVOICE_RELNS"}, mode = EnumSource.Mode.INCLUDE)

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -174,8 +174,8 @@ public class EntitiesCrudTest extends TestBase {
 //    Matcher matcher = pattern.matcher(response.getBody().asString());
 //    Assertions.assertTrue(matcher.find());
 //    assertTrue(response.asString().contains("value already exists in table"));
-    assertTrue(response.asString().contains("Field Name must be unique"));
     //assertTrue(response.asString().contains("Field Name must be unique"));
+    assertTrue(response.asString().contains("already exists|uniqueField"));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -168,14 +168,14 @@ public class EntitiesCrudTest extends TestBase {
     JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
     duplicateEntity.remove("id");
     Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails().statusCode(201);
+    response.then().log().ifValidationFails().statusCode(400);
 
-//    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
-//    Matcher matcher = pattern.matcher(response.getBody().asString());
-//    Assertions.assertTrue(matcher.find());
+    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
+    Matcher matcher = pattern.matcher(response.getBody().asString());
+    Assertions.assertTrue(matcher.find());
 //    assertTrue(response.asString().contains("value already exists in table"));
     //assertTrue(response.asString().contains("Field Name must be unique"));
-    assertTrue(response.asString().contains("already exists|uniqueField"));
+    //assertTrue(response.asString().contains("already exists|uniqueField"));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -106,20 +106,6 @@ public class EntitiesCrudTest extends TestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT"}, mode = EnumSource.Mode.INCLUDE)
-  public void testUniqueKeyConstraintAcquisitionUnit(TestEntities testEntity) throws MalformedURLException {
-    logger.info(String.format("--- mod-orders-storage %s test: Cannot Create Duplicate Entry %s ... ", testEntity.name(), testEntity.name()));
-    JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
-    duplicateEntity.remove("id");
-    Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails().statusCode(400);
-
-    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
-    Matcher matcher = pattern.matcher(response.getBody().asString());
-    Assertions.assertTrue(matcher.find());
-  }
-
-  @ParameterizedTest
   @Order(6)
   @EnumSource(value = TestEntities.class)
   public void testPutById(TestEntities testEntity) throws MalformedURLException {
@@ -172,6 +158,21 @@ public class EntitiesCrudTest extends TestBase {
     logger.info(String.format("--- mod-orders-storages %s test: Verify %s is deleted with ID: %s", testEntity.name(),
         testEntity.name(), testEntity.getId()));
     testVerifyEntityDeletion(testEntity.getEndpointWithId(), testEntity.getId());
+  }
+
+  @ParameterizedTest
+  @Order(11)
+  @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT"}, mode = EnumSource.Mode.INCLUDE)
+  public void testUniqueKeyConstraintAcquisitionUnit(TestEntities testEntity) throws MalformedURLException {
+    logger.info(String.format("--- mod-orders-storage %s test: Cannot Create Duplicate Entry %s ... ", testEntity.name(), testEntity.name()));
+    JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
+    duplicateEntity.remove("id");
+    Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
+    response.then().log().ifValidationFails().statusCode(400);
+
+    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
+    Matcher matcher = pattern.matcher(response.getBody().asString());
+    Assertions.assertTrue(matcher.find());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -168,13 +168,14 @@ public class EntitiesCrudTest extends TestBase {
     JsonObject duplicateEntity = new JsonObject(getFile(testEntity.getSampleFileName()));
     duplicateEntity.remove("id");
     Response response = postData(testEntity.getEndpoint(), duplicateEntity.toString());
-    response.then().log().ifValidationFails().statusCode(400);
+    response.then().log().ifValidationFails().statusCode(201);
 
 //    Pattern pattern = Pattern.compile("(already exists|uniqueField)");
 //    Matcher matcher = pattern.matcher(response.getBody().asString());
 //    Assertions.assertTrue(matcher.find());
 //    assertTrue(response.asString().contains("value already exists in table"));
     assertTrue(response.asString().contains("Field Name must be unique"));
+    //assertTrue(response.asString().contains("Field Name must be unique"));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
+++ b/src/test/java/org/folio/rest/impl/EntitiesCrudTest.java
@@ -160,7 +160,7 @@ public class EntitiesCrudTest extends TestBase {
     testVerifyEntityDeletion(testEntity.getEndpointWithId(), testEntity.getId());
   }
 
-  /*@ParameterizedTest
+  @ParameterizedTest
   @Order(11)
   @EnumSource(value = TestEntities.class, names = {"ACQUISITIONS_UNIT"}, mode = EnumSource.Mode.INCLUDE)
   public void testUniqueKeyConstraintAcquisitionUnit(TestEntities testEntity) throws MalformedURLException {
@@ -173,10 +173,7 @@ public class EntitiesCrudTest extends TestBase {
     Pattern pattern = Pattern.compile("(already exists|uniqueField)");
     Matcher matcher = pattern.matcher(response.getBody().asString());
     Assertions.assertTrue(matcher.find());
-//    assertTrue(response.asString().contains("value already exists in table"));
-    //assertTrue(response.asString().contains("Field Name must be unique"));
-    //assertTrue(response.asString().contains("already exists|uniqueField"));
-  }*/
+  }
 
   @ParameterizedTest
   @EnumSource(value = TestEntities.class, names = {"PO_LINE", "PIECE", "ORDER_INVOICE_RELNS"}, mode = EnumSource.Mode.INCLUDE)

--- a/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
+++ b/src/test/java/org/folio/rest/impl/HelperUtilsTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionException;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.commons.lang.StringUtils;
 import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.PurchaseOrderCollection;
@@ -25,6 +26,7 @@ import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.folio.rest.tools.client.Response;
+import org.junit.Assert;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -125,6 +127,18 @@ public class HelperUtilsTest extends TestBase {
     assertThrows(CompletionException.class, () -> {
       HelperUtils.verifyResponse(response);
     });
+  }
+
+  @Test
+  public void testSQLUniqueConstraintFound() {
+    String constraintName = HelperUtils.getSQLUniqueConstraintName("unique constraint \"idx_name_code\"");
+    Assert.assertEquals("idx_name_code", constraintName);
+  }
+
+  @Test
+  public void testSQLUniqueConstraintNotFound() {
+    String constraintName = HelperUtils.getSQLUniqueConstraintName("error \"error\"");
+    Assert.assertEquals(StringUtils.EMPTY, constraintName);
   }
 
   private ValidatableResponse get(URL endpoint) {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://issues.folio.org/browse/MODORDSTOR-252
Create BE story to return a more appropriate error code for existing records. Because it's hard to handle it on UI with 'genericError' code. Thanks
{
  "errors" : [ {
    "message" : "{\n  \"errors\" : [ {\n    \"message\" : \"lower(f_unaccent(jsonb ->> 'name'::text)) value already exists in table acquisitions_unit: test\",\n    \"type\" : \"1\",\n    \"code\" : \"-1\",\n    \"parameters\" : [ {\n      \"key\" : \"lower(f_unaccent(jsonb ->> 'name'::text))\",\n      \"value\" : \"test\"\n    } ]\n  } ]\n}",
    "code" : "genericError",
    "parameters" : [ ]
  } ],
  "total_records" : 1
}
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
Approach : https://github.com/folio-org/mod-finance-storage/pull/110
 "errors" : [ {
    "message" : "{\"message\":\"Field Name must be unique\",\"code\":\"uniqueFieldAcquisitionsUnitNameError\",\"parameters\":[{\"key\":\"field\",\"value\":\"Name\"},{\"key\":\"entity\",\"value\":\"AcquisitionsUnit\"}]}",
    "code" : "400",
    "parameters" : [ ]
  } ],
  "total_records" : 1
}
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
@folio-org/acquisitions

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
