### PR TITLE
[MODORDERS-644] Fixed indices for keyword search

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -291,13 +291,16 @@
       ],
       "fullTextIndex": [
         {
-          "fieldName": "publisher"
+          "fieldName": "publisher",
+          "tOps": "DELETE"
         },
         {
-          "fieldName": "donor"
+          "fieldName": "donor",
+          "tOps": "DELETE"
         },
         {
-          "fieldName": "selector"
+          "fieldName": "selector",
+          "tOps": "DELETE"
         },
         {
           "fieldName": "vendorDetail.referenceNumbers",
@@ -329,12 +332,7 @@
           "tOps": "ADD"
         },
         {
-          "fieldName": "vendor.vendorAccount",
-          "caseSensitive": false,
-          "removeAccents": true
-        },
-        {
-          "fieldName": "vendor.refNumber",
+          "fieldName": "vendorDetail.vendorAccount",
           "caseSensitive": false,
           "removeAccents": true
         },
@@ -355,6 +353,33 @@
         },
         {
           "fieldName": "poLineNumber",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "publisher",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "donor",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "selector",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "vendorDetail.referenceNumbers",
+          "caseSensitive": false,
+          "removeAccents": true,
+          "arraySubfield": "refNumber",
+          "arrayModifiers": ["refNumberType", "vendorDetailsSource"]
+        },
+        {
+          "fieldName": "physical.volumes",
           "caseSensitive": false,
           "removeAccents": true
         }


### PR DESCRIPTION
## Purpose
[MODORDERS-644](https://issues.folio.org/browse/MODORDERS-644) - Performance Issue: GET API for order-lines is slow

## Approach
- Removed useless entries in `fullTextIndex`.
- Removed indices for non-existing fields `vendor.vendorAccount`, `vendor.refNumber`.
- Ensured all the fields used in keyword search are in `ginIndex`.

## Learning
RMB's `likeIndex` is not useful for these queries, we have to use `ginIndex`.
@folio-org/acquisitions

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
