### PR TITLE
[MODORDSTOR-309] Already exported orders are included repeatedly in next exports

### DIFF
--- a/src/main/java/org/folio/event/KafkaEventUtil.java
+++ b/src/main/java/org/folio/event/KafkaEventUtil.java
@@ -12,7 +12,7 @@ public final class KafkaEventUtil {
 
   public static String extractValueFromHeaders(List<KafkaHeader> headers, String key) {
     return headers.stream()
-      .filter(header -> header.key().equals(key))
+      .filter(header -> header.key().equalsIgnoreCase(key))
       .findFirst()
       .map(header -> header.value().toString())
       .orElse(null);

--- a/src/main/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandler.java
@@ -44,6 +44,8 @@ public class EdiExportOrdersHistoryAsyncRecordHandler extends BaseAsyncRecordHan
   public Future<String> handle(KafkaConsumerRecord<String, String> kafkaRecord) {
     try {
       Promise<String> promise = Promise.promise();
+      kafkaRecord.headers().forEach(header -> logger.info("Header key: " + header.key() + ", Header value: " + header.value()));
+
       ExportHistory exportHistory = new JsonObject(kafkaRecord.value()).mapTo(ExportHistory.class);
       String tenantId = Optional.ofNullable(KafkaEventUtil.extractValueFromHeaders(kafkaRecord.headers(), OKAPI_HEADER_TENANT))
                                 .orElseThrow(() -> new IllegalStateException(TENANT_NOT_SPECIFIED_MSG));

--- a/src/main/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandler.java
@@ -44,8 +44,6 @@ public class EdiExportOrdersHistoryAsyncRecordHandler extends BaseAsyncRecordHan
   public Future<String> handle(KafkaConsumerRecord<String, String> kafkaRecord) {
     try {
       Promise<String> promise = Promise.promise();
-      kafkaRecord.headers().forEach(header -> logger.info("Header key: " + header.key() + ", Header value: " + header.value()));
-
       ExportHistory exportHistory = new JsonObject(kafkaRecord.value()).mapTo(ExportHistory.class);
       String tenantId = Optional.ofNullable(KafkaEventUtil.extractValueFromHeaders(kafkaRecord.headers(), OKAPI_HEADER_TENANT))
                                 .orElseThrow(() -> new IllegalStateException(TENANT_NOT_SPECIFIED_MSG));

--- a/src/test/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandlerTest.java
@@ -1,6 +1,5 @@
 package org.folio.event.handler;
 
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.util.TestConfig.autowireDependencies;
 import static org.folio.rest.util.TestConfig.clearVertxContext;
 import static org.folio.rest.util.TestConfig.deployVerticle;
@@ -48,6 +47,9 @@ import io.vertx.core.json.Json;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
 
 public class EdiExportOrdersHistoryAsyncRecordHandlerTest {
+
+  private static final String TENANT_KEY_LOWER_CASE = "x-okapi-tenant"; // header key for tenant comes in lower case from mod-data-export-spring
+
   @Autowired
   public EdiExportOrdersHistoryAsyncRecordHandler ediExportOrdersHistoryAsyncRecordHandler;
   @Autowired
@@ -120,7 +122,7 @@ public class EdiExportOrdersHistoryAsyncRecordHandlerTest {
       .withExportType("EDIFACT_ORDERS_EXPORT")
       .withExportedPoLineIds(List.of(lineId))
       .withExportDate(Calendar.getInstance().getTime());
-    RecordHeader header = new RecordHeader(OKAPI_HEADER_TENANT, "diku".getBytes());
+    RecordHeader header = new RecordHeader(TENANT_KEY_LOWER_CASE, "diku".getBytes());
     RecordHeaders recordHeaders = new RecordHeaders();
     recordHeaders.add(header);
     var consumerRecord = new ConsumerRecord("topic", 1, 1,
@@ -152,7 +154,7 @@ public class EdiExportOrdersHistoryAsyncRecordHandlerTest {
       .withExportType("EDIFACT_ORDERS_EXPORT")
       .withExportedPoLineIds(List.of(lineId))
       .withExportDate(Calendar.getInstance().getTime());
-    RecordHeader header = new RecordHeader(OKAPI_HEADER_TENANT, "diku".getBytes());
+    RecordHeader header = new RecordHeader(TENANT_KEY_LOWER_CASE, "diku".getBytes());
     RecordHeaders recordHeaders = new RecordHeaders();
     recordHeaders.add(header);
     var consumerRecord = new ConsumerRecord("topic", 1, 1,


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDSTOR-309

## Approach
There were 3 separate issues fixed to address MODORDSTOR-309
1. Kafka host/port were not configured on https://bulk-edit-perf.ci.folio.org/ for module mod-orders-storage. After add configuration we see that they fetched from secrets as for other modules:
![image](https://user-images.githubusercontent.com/25097693/182561238-b8612013-c957-4e8d-8144-2c8891646d05.png)
2. x-okapi-tenant has not been populated  in all cases until issues was fixed in scope of PR:
https://github.com/folio-org/mod-data-export-spring/pull/203
3. x-okapi-tenant header comes in lower case, but in order-storage its declared in mixed case like X-Okapi-Tenant. Here is list of headers coming in kafka record:
![image](https://user-images.githubusercontent.com/25097693/182562618-f5d2c026-b495-4cd9-b286-4afbc813222f.png)
This particular PR fixes issue this third issue
