### PR TITLE
[MODORDERS-749] Change instance updates POL details but not UUID and items not appearing

### DIFF
--- a/src/main/java/org/folio/services/piece/PieceService.java
+++ b/src/main/java/org/folio/services/piece/PieceService.java
@@ -38,7 +38,7 @@ public class PieceService {
     Criterion criterion = getCriteriaByFieldNameAndValueNotJsonb(POLINE_ID_FIELD, poLineId);
     client.getPgClient().get(PIECES_TABLE, Piece.class, criterion, false, reply -> {
       if(reply.failed()) {
-        logger.error("Retrieve Pieces failed : {}", reply);
+        logger.error("Retrieve pieces by poLineId={} failed : {}", poLineId, reply);
         httpHandleFailure(promise, reply);
       } else {
         List<Piece> result = reply.result().getResults();
@@ -62,7 +62,7 @@ public class PieceService {
       String query = buildUpdatePieceBatchQuery(pieces, client.getTenantId());
       client.getPgClient().execute(poLineTx.getConnection(), query, reply -> {
         if (reply.failed()) {
-          logger.error("Update Pieces failed : {}", reply);
+          logger.error("Update pieces with poLineId={} failed : {}", poLineId, reply);
           httpHandleFailure(promise, reply);
         } else {
           logger.info("Pieces with poLineId={} was successfully updated", poLineId);

--- a/src/main/java/org/folio/services/piece/PieceService.java
+++ b/src/main/java/org/folio/services/piece/PieceService.java
@@ -31,7 +31,7 @@ public class PieceService {
 
   private static final Logger logger = LogManager.getLogger(PieceService.class);
   private static final String POLINE_ID_FIELD = "poLineId";
-  private static final String PIECE_NOT_UPDATED = "Pieces with poLineId={} wasn't updated";
+  private static final String PIECE_NOT_UPDATED = "Pieces with poLineId={} not presented, skipping the update";
 
   public Future<List<Piece>> getPiecesByPoLineId(String poLineId, DBClient client) {
     Promise<List<Piece>> promise = Promise.promise();
@@ -43,7 +43,7 @@ public class PieceService {
       } else {
         List<Piece> result = reply.result().getResults();
         if (result.isEmpty()) {
-          logger.info(String.format("Pieces with poLineId=%s was not found", poLineId));
+          logger.info("Pieces with poLineId={} was not found", poLineId);
           promise.complete(null);
         } else {
           promise.complete(result);
@@ -56,6 +56,7 @@ public class PieceService {
 
   private Future<Tx<PoLine>> updatePieces(Tx<PoLine> poLineTx, List<Piece> pieces, DBClient client) {
     Promise<Tx<PoLine>> promise = Promise.promise();
+    String poLineId = poLineTx.getEntity().getId();
 
     if(CollectionUtils.isNotEmpty(pieces)) {
       String query = buildUpdatePieceBatchQuery(pieces, client.getTenantId());
@@ -64,12 +65,12 @@ public class PieceService {
           logger.error("Update Pieces failed : {}", reply);
           httpHandleFailure(promise, reply);
         } else {
-          logger.info("Pieces was successfully updated");
+          logger.info("Pieces with poLineId={} was successfully updated", poLineId);
           promise.complete(poLineTx);
         }
       });
     } else {
-      logger.info(PIECE_NOT_UPDATED, poLineTx.getEntity().getId());
+      logger.info(PIECE_NOT_UPDATED, poLineId);
       promise.complete(poLineTx);
     }
     return promise.future();


### PR DESCRIPTION
## Purpose
When using P_E_MIX order format OrderLineUpdateInstanceHandler trying to update holdings pieces two times. If one of them(Physical, Eresource) has piece and the other doesn't there will be a problem when updating. The problem would be to create an empty sql query to update pieces.

## Approach
- Check pieces to emptiness before update

## Learning
[MODORDERS-749](https://issues.folio.org/browse/MODORDERS-749)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [x] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [x] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
