### PR TITLE
[MODORDSTOR-313] - Already exported order line is included repeatedly in next exports.

### DIFF
--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -192,7 +192,7 @@ public class HelperUtils {
   }
 
   public static String getQueryValues(List<JsonObject> entities) {
-    return entities.stream().map(entity -> "('" + entity.getString("id") + "', '" + entity.encode() + "'::json)").collect(
+    return entities.stream().map(entity -> "('" + entity.getString("id") + "', $$" + entity.encode() + "$$::json)").collect(
       Collectors.joining(","));
   }
 }

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -43,6 +43,7 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.services.finance.FinanceServiceTest;
+import org.folio.services.lines.PoLIneServiceVertxTest;
 import org.folio.services.lines.PoLinesServiceTest;
 import org.folio.services.migration.MigrationServiceTest;
 import org.folio.services.piece.PieceServiceTest;
@@ -255,4 +256,6 @@ public class StorageTestSuite {
   class TitleServiceTestNested extends TitleServiceTest {}
   @Nested
   class OrderLineUpdateInstanceHandlerTestNested extends OrderLineUpdateInstanceHandlerTest {}
+  @Nested
+  class PoLIneServiceVertxTestNested extends PoLIneServiceVertxTest {}
 }

--- a/src/test/java/org/folio/services/lines/PoLIneServiceVertxTest.java
+++ b/src/test/java/org/folio/services/lines/PoLIneServiceVertxTest.java
@@ -1,0 +1,81 @@
+package org.folio.services.lines;
+
+import static org.folio.models.TableNames.PO_LINE_TABLE;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
+import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.folio.dao.lines.PoLinesPostgresDAO;
+import org.folio.rest.impl.TestBase;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.TenantJob;
+import org.folio.rest.persist.DBClient;
+import org.folio.rest.persist.PostgresClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import io.restassured.http.Header;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+public class PoLIneServiceVertxTest extends TestBase {
+
+  static final String TEST_TENANT = "test_tenant";
+  private static final Header TEST_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, TEST_TENANT);
+  private final PoLinesService poLinesService = new PoLinesService(new PoLinesPostgresDAO());
+  private static TenantJob tenantJob;
+
+  @BeforeEach
+  public void initMocks() throws MalformedURLException {
+    MockitoAnnotations.openMocks(this);
+    tenantJob = prepareTenant(TEST_TENANT_HEADER, false, false);
+  }
+
+  @AfterEach
+  void cleanupData() {
+    deleteTenant(tenantJob, TEST_TENANT_HEADER);
+  }
+
+  @Test
+  public void shouldUpdatePoLineWithSingleQuote(Vertx vertx, VertxTestContext testContext) {
+    String id = UUID.randomUUID().toString();
+    PoLine poLine = new PoLine().withId(id)
+      .withTitleOrPackage("Test ' title");
+    Promise<Void> promise1 = Promise.promise();
+    final DBClient client = new DBClient(vertx, TEST_TENANT);
+    client.getPgClient().save(PO_LINE_TABLE, id, poLine, event -> {
+      promise1.complete();
+    });
+    Promise<Void> promise2 = Promise.promise();
+    client.getPgClient().save(PO_LINE_TABLE, poLine, event -> {
+      promise2.complete();
+    });
+    poLine.withLastEDIExportDate(new Date());
+
+    testContext.assertComplete(promise1.future()
+        .compose(aVoid -> promise2.future())
+        .compose(o -> poLinesService.updatePoLines(List.of(poLine), client)))
+      .onComplete(event -> {
+        Integer numUpdLines = event.result();
+        testContext.verify(() -> {
+          assertThat(1, is(numUpdLines));
+        });
+        testContext.completeNow();
+      });
+  }
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Already exported order line contains single quote is included repeatedly in next exports.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
@folio-org/acquisitions

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
