### PR TITLE
MODORDSTOR-319: Replace field.setAccessible(true) for JDK 17

### DIFF
--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -15,13 +15,11 @@ import static org.junit.Assert.fail;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.PurchaseOrder.WorkflowStatus;
 import org.folio.rest.jaxrs.model.PurchaseOrderCollection;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -171,27 +169,14 @@ public class OrdersAPITest extends TestBase {
     return getFileAsObject(path, PurchaseOrder.class);
   }
 
-  private void verifyOrdersConformity(Object actual, Object expected) {
-    Map<Field, Object> actualFieldValueMap = getFieldValueMap(actual);
-    Map<Field, Object> expectedFieldValueMap = getFieldValueMap(expected);
-    for(Map.Entry<Field, Object> e : expectedFieldValueMap.entrySet()) {
-      if(!EXCLUDED_FIELD_NAMES.contains(e.getKey().getName())) {
-        assertThat(EqualsBuilder.reflectionEquals(e.getValue(), actualFieldValueMap.get(e.getKey())), is(true));
-      }
-    }
-  }
-
-  private Map<Field, Object> getFieldValueMap(Object obj) {
-    Map<Field, Object> fieldValueMap = new HashMap<>();
-    Arrays.stream(obj.getClass().getDeclaredFields()).forEach(field -> {
-      try {
-        field.setAccessible(true);
-        fieldValueMap.put(field, field.get(obj));
-      } catch (IllegalAccessException e) {
-        logger.error("--- mod-orders-storage orders test: error extracting fields value", e);
-      }
+  private void verifyOrdersConformity(PurchaseOrder actual, PurchaseOrder expected) {
+    var actualJson = JsonObject.mapFrom(actual);
+    var expectedJson = JsonObject.mapFrom(expected);
+    EXCLUDED_FIELD_NAMES.forEach(excludedFieldName -> {
+      actualJson.remove(excludedFieldName);
+      expectedJson.remove(excludedFieldName);
     });
-    return fieldValueMap;
+    assertThat(actualJson, is(expectedJson));
   }
 
   private List<PurchaseOrder> getViewCollection(String endpoint) throws MalformedURLException {


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDSTOR-319

*Purpose/Overview:*

Building with JDK 17 fails:
```
[ERROR]   StorageTestSuite$OrdersAPITestNested>OrdersAPITest.testGetPurchaseOrders:141 Unable to make field private static final long java.util.ArrayList.serialVersionUID accessible: module java.base does not "opens java.util" to unnamed module @2ff5659e {code}
```

*Requirements/Scope:*

Replace the method call `field.setAccessible(true)`

*Approach:*

Use JsonObject.mapFrom instead.

*Acceptance criteria:*

Build succeeds under JDK 17