### PR TITLE
MODORDSTOR-324. Add audit log message schemas and producer for sending these Kafka messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0</version>
+      <version>2.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>2.5.0</version>
+      <version>3.2.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/ramls/po-line.raml
+++ b/ramls/po-line.raml
@@ -14,6 +14,7 @@ types:
     order-line-patch-operation-type: !include acq-models/mod-orders/schemas/patch_order_line_operation_type.json
     storage-patch-order-line-request: !include acq-models/mod-orders-storage/schemas/storage_patch_order_line_request.json
     storage-replace-order-line-instance: !include acq-models/mod-orders-storage/schemas/storage_replace_order_line_instance_ref.json
+    order-line-audit-event: !include acq-models/mod-orders-storage/schemas/order_line_audit_event.json
     UUID:
      type: string
      pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$

--- a/ramls/purchase-order.raml
+++ b/ramls/purchase-order.raml
@@ -13,6 +13,7 @@ types:
     UUID:
      type: string
      pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
+    order-audit-event: !include acq-models/mod-orders-storage/schemas/order_audit_event.json
 
 traits:
     orderable: !include raml-util/traits/orderable.raml

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -7,6 +7,8 @@ import org.folio.dao.export.ExportHistoryPostgresRepository;
 import org.folio.dao.export.ExportHistoryRepository;
 import org.folio.dao.lines.PoLinesDAO;
 import org.folio.dao.lines.PoLinesPostgresDAO;
+import org.folio.event.service.AuditEventProducer;
+import org.folio.kafka.KafkaConfig;
 import org.folio.rest.jaxrs.model.CreateInventoryType;
 import org.folio.rest.jaxrs.model.OrderLinePatchOperationType;
 import org.folio.services.lines.PoLineNumbersService;
@@ -30,7 +32,7 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @ComponentScan({ "org.folio.verticles", "org.folio.event.listener" })
-@Import({ KafkaConsumersConfiguration.class })
+@Import({ KafkaConfiguration.class })
 public class ApplicationConfig {
 
   @Bean
@@ -111,4 +113,8 @@ public class ApplicationConfig {
     return new ExportHistoryService(exportHistoryRepository);
   }
 
+  @Bean
+  AuditEventProducer auditEventProducerService(KafkaConfig kafkaConfig) {
+    return new AuditEventProducer(kafkaConfig);
+  }
 }

--- a/src/main/java/org/folio/config/KafkaConfiguration.java
+++ b/src/main/java/org/folio/config/KafkaConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class KafkaConsumersConfiguration {
+public class KafkaConfiguration {
 
   @Value("${KAFKA_HOST:kafka}")
   private String kafkaHost;

--- a/src/main/java/org/folio/event/AuditEventType.java
+++ b/src/main/java/org/folio/event/AuditEventType.java
@@ -5,8 +5,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public enum KafkaTopicType {
-  EXPORT_HISTORY_CREATE("edi-export-history.create");
+public enum AuditEventType {
+  ACQ_ORDER_CHANGED("ACQ_ORDER_CHANGED"),
+  ACQ_ORDER_LINE_CHANGED("ACQ_ORDER_LINE_CHANGED");
 
   private final String topicName;
 }

--- a/src/main/java/org/folio/event/ExportEventType.java
+++ b/src/main/java/org/folio/event/ExportEventType.java
@@ -1,0 +1,12 @@
+package org.folio.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExportEventType {
+  EXPORT_HISTORY_CREATE("edi-export-history.create");
+
+  private final String topicName;
+}

--- a/src/main/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandler.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.event.KafkaEventUtil;
+import org.folio.event.util.KafkaEventUtil;
 import org.folio.rest.jaxrs.model.ExportHistory;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.persist.DBClient;

--- a/src/main/java/org/folio/event/service/AuditEventProducer.java
+++ b/src/main/java/org/folio/event/service/AuditEventProducer.java
@@ -121,11 +121,11 @@ public class AuditEventProducer {
     producer.write(record, ar -> {
       producer.end(ear -> producer.close());
       if (ar.succeeded()) {
-        logger.info("Event with type {} was sent to kafka topic {}", eventType, topicName);
+        logger.info("Event with type '{}' was sent to kafka topic '{}'", eventType, topicName);
         promise.complete(true);
       } else {
         Throwable cause = ar.cause();
-        logger.error("Producer write error for event {}",  eventType, cause);
+        logger.error("Producer write error for event '{}'",  eventType, cause);
         promise.fail(cause);
       }
     });

--- a/src/main/java/org/folio/event/service/AuditEventProducer.java
+++ b/src/main/java/org/folio/event/service/AuditEventProducer.java
@@ -76,9 +76,11 @@ public class AuditEventProducer {
     event.withOrderSnapshot(order);
     if (OrderAuditEvent.Action.CREATE == eventAction) {
       event.setUserId(order.getMetadata().getCreatedByUserId());
+      event.setUserName(order.getMetadata().getCreatedByUsername());
       event.setActionDate(order.getMetadata().getCreatedDate());
     } else if (OrderAuditEvent.Action.EDIT == eventAction) {
       event.setUserId(order.getMetadata().getUpdatedByUserId());
+      event.setUserName(order.getMetadata().getUpdatedByUsername());
       event.setActionDate(order.getMetadata().getUpdatedDate());
     }
     return event;
@@ -94,9 +96,11 @@ public class AuditEventProducer {
     event.withOrderLineSnapshot(poLine);
     if (OrderLineAuditEvent.Action.CREATE == eventAction) {
       event.setUserId(poLine.getMetadata().getCreatedByUserId());
+      event.setUserName(poLine.getMetadata().getCreatedByUsername());
       event.setActionDate(poLine.getMetadata().getCreatedDate());
     } else if (OrderLineAuditEvent.Action.EDIT == eventAction) {
       event.setUserId(poLine.getMetadata().getUpdatedByUserId());
+      event.setUserName(poLine.getMetadata().getUpdatedByUsername());
       event.setActionDate(poLine.getMetadata().getUpdatedDate());
     }
     return event;

--- a/src/main/java/org/folio/event/service/AuditEventProducer.java
+++ b/src/main/java/org/folio/event/service/AuditEventProducer.java
@@ -114,13 +114,13 @@ public class AuditEventProducer {
     Promise<Boolean> promise = Promise.promise();
 
     KafkaProducer<String, String> producer = createProducer(eventType.getTopicName());
-    producer.write(record, war -> {
+    producer.write(record, ar -> {
       producer.end(ear -> producer.close());
-      if (war.succeeded()) {
-        logger.info("Event with type {} was sent to kafka", eventType);
+      if (ar.succeeded()) {
+        logger.info("Event with type {} was sent to kafka topic {}", eventType, topicName);
         promise.complete(true);
       } else {
-        Throwable cause = war.cause();
+        Throwable cause = ar.cause();
         logger.error("Producer write error for event {}",  eventType, cause);
         promise.fail(cause);
       }

--- a/src/main/java/org/folio/event/service/AuditEventProducer.java
+++ b/src/main/java/org/folio/event/service/AuditEventProducer.java
@@ -1,0 +1,147 @@
+package org.folio.event.service;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.event.AuditEventType;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaHeaderUtils;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.rest.jaxrs.model.OrderAuditEvent;
+import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.PurchaseOrder;
+import org.folio.rest.tools.utils.TenantTool;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class AuditEventProducer {
+  private static final Logger logger = LogManager.getLogger(AuditEventProducer.class);
+
+  private final KafkaConfig kafkaConfig;
+
+  /**
+   * Sends event for order change(Create, Edit, Delete) to kafka.
+   * OrderId is used as partition key to send all events for particular order to the same partition.
+   *
+   * @param order        the event payload
+   * @param eventAction  the event action
+   * @param okapiHeaders the okapi headers
+   * @return future with true if sending was success or failed future in another case
+   */
+  public Future<Boolean> sendOrderEvent(PurchaseOrder order,
+                                        OrderAuditEvent.Action eventAction,
+                                        Map<String, String> okapiHeaders) {
+    OrderAuditEvent event = getOrderEvent(order, eventAction);
+    logger.info("Starting to send event with id: {} for Order to Kafka for orderId: {}", event.getId(), order.getId());
+    String eventPayload = Json.encode(event);
+    return sendToKafka(AuditEventType.ACQ_ORDER_CHANGED, eventPayload, okapiHeaders, event.getOrderId());
+  }
+
+  /**
+   * Sends change event for order line to kafka.
+   * OrderLineId is used as partition key to send all events for particular order to the same partition.
+   *
+   * @param poLine       the event payload
+   * @param  eventAction the event action
+   * @param okapiHeaders the okapi headers
+   * @return future with true if sending was success or failed future otherwise
+   */
+  public Future<Boolean> sendOrderLineEvent(PoLine poLine,
+                                            OrderLineAuditEvent.Action eventAction,
+                                            Map<String, String> okapiHeaders) {
+    OrderLineAuditEvent event = getOrderLineEvent(poLine, eventAction);
+    logger.info("Starting to send event wit id: {} for Order Line to Kafka for orderLineId: {}", event.getId(), poLine.getId());
+    String eventPayload = Json.encode(event);
+    return sendToKafka(AuditEventType.ACQ_ORDER_LINE_CHANGED, eventPayload, okapiHeaders, event.getOrderLineId());
+  }
+
+  private OrderAuditEvent getOrderEvent(PurchaseOrder order, OrderAuditEvent.Action eventAction) {
+    OrderAuditEvent event = new OrderAuditEvent();
+    event.setId(UUID.randomUUID().toString());
+    event.setAction(eventAction);
+    event.setOrderId(order.getId());
+    event.setEventDate(new Date());
+    event.withOrderSnapshot(order);
+    if (OrderAuditEvent.Action.CREATE == eventAction) {
+      event.setUserId(order.getMetadata().getCreatedByUserId());
+      event.setActionDate(order.getMetadata().getCreatedDate());
+    } else if (OrderAuditEvent.Action.EDIT == eventAction) {
+      event.setUserId(order.getMetadata().getUpdatedByUserId());
+      event.setActionDate(order.getMetadata().getUpdatedDate());
+    }
+    return event;
+  }
+
+  private OrderLineAuditEvent getOrderLineEvent(PoLine poLine, OrderLineAuditEvent.Action eventAction) {
+    OrderLineAuditEvent event = new OrderLineAuditEvent();
+    event.setId(UUID.randomUUID().toString());
+    event.setAction(eventAction);
+    event.setOrderId(poLine.getPurchaseOrderId());
+    event.setOrderLineId(poLine.getId());
+    event.setEventDate(new Date());
+    event.withOrderLineSnapshot(poLine);
+    if (OrderLineAuditEvent.Action.CREATE == eventAction) {
+      event.setUserId(poLine.getMetadata().getCreatedByUserId());
+      event.setActionDate(poLine.getMetadata().getCreatedDate());
+    } else if (OrderLineAuditEvent.Action.EDIT == eventAction) {
+      event.setUserId(poLine.getMetadata().getUpdatedByUserId());
+      event.setActionDate(poLine.getMetadata().getUpdatedDate());
+    }
+    return event;
+  }
+
+  private Future<Boolean> sendToKafka(AuditEventType eventType,
+                                      String eventPayload,
+                                      Map<String, String> okapiHeaders,
+                                      String key) {
+    String tenantId = TenantTool.tenantId(okapiHeaders);
+    List<KafkaHeader> kafkaHeaders = KafkaHeaderUtils.kafkaHeadersFromMap(okapiHeaders);
+    String topicName = createTopicName(kafkaConfig.getEnvId(), tenantId, eventType.getTopicName());
+    KafkaProducerRecord<String, String> record = createProducerRecord(topicName, key, eventPayload, kafkaHeaders);
+
+    Promise<Boolean> promise = Promise.promise();
+
+    KafkaProducer<String, String> producer = createProducer(eventType.getTopicName());
+    producer.write(record, war -> {
+      producer.end(ear -> producer.close());
+      if (war.succeeded()) {
+        logger.info("Event with type {} was sent to kafka", eventType);
+        promise.complete(true);
+      } else {
+        Throwable cause = war.cause();
+        logger.error("Producer write error for event {}",  eventType, cause);
+        promise.fail(cause);
+      }
+    });
+
+    return promise.future();
+  }
+
+  private KafkaProducer<String, String> createProducer(String eventType) {
+    String producerName = eventType + "_Producer";
+    return KafkaProducer.createShared(Vertx.currentContext().owner(), producerName, kafkaConfig.getProducerProps());
+  }
+
+  private KafkaProducerRecord<String, String> createProducerRecord(String topicName, String key, String eventPayload, List<KafkaHeader> kafkaHeaders) {
+    KafkaProducerRecord<String, String> record = KafkaProducerRecord.create(topicName, key, eventPayload);
+    record.addHeaders(kafkaHeaders);
+    return record;
+  }
+
+  private String createTopicName(String envId, String tenantId, String eventType) {
+    return KafkaTopicNameHelper.formatTopicName(envId, KafkaTopicNameHelper.getDefaultNameSpace(),
+      tenantId, eventType);
+  }
+}

--- a/src/main/java/org/folio/event/util/KafkaEventUtil.java
+++ b/src/main/java/org/folio/event/util/KafkaEventUtil.java
@@ -1,4 +1,4 @@
-package org.folio.event;
+package org.folio.event.util;
 
 import io.vertx.kafka.client.producer.KafkaHeader;
 

--- a/src/main/java/org/folio/verticles/KafkaConsumersVerticle.java
+++ b/src/main/java/org/folio/verticles/KafkaConsumersVerticle.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.event.handler.BaseAsyncRecordHandler;
 import org.folio.event.handler.EdiExportOrdersHistoryAsyncRecordHandler;
-import org.folio.event.KafkaTopicType;
+import org.folio.event.ExportEventType;
 import org.folio.kafka.GlobalLoadSensor;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaConsumerWrapper;
@@ -59,7 +59,7 @@ public class KafkaConsumersVerticle extends AbstractVerticle {
     logger.info("Kafka config: {}", kafkaConfig);
 
     SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(kafkaConfig.getEnvId(),
-      KafkaTopicNameHelper.getDefaultNameSpace(), KafkaTopicType.EXPORT_HISTORY_CREATE.getTopicName());
+      KafkaTopicNameHelper.getDefaultNameSpace(), ExportEventType.EXPORT_HISTORY_CREATE.getTopicName());
 
     KafkaConsumerWrapper<String, String> consumerWrapper = KafkaConsumerWrapper.<String, String>builder()
       .context(context)

--- a/src/test/java/org/folio/event/KafkaEventUtilTest.java
+++ b/src/test/java/org/folio/event/KafkaEventUtilTest.java
@@ -2,6 +2,7 @@ package org.folio.event;
 
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
+import org.folio.event.util.KafkaEventUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/EdiExportOrdersHistoryAsyncRecordHandlerTest.java
@@ -128,7 +128,7 @@ public class EdiExportOrdersHistoryAsyncRecordHandlerTest {
     var consumerRecord = new ConsumerRecord("topic", 1, 1,
               2, null, 1L, 1,1,
           "key", Json.encode(exportHistory), recordHeaders);
-    var record = new KafkaConsumerRecordImpl(consumerRecord) ;
+    var record = new KafkaConsumerRecordImpl(consumerRecord);
     doReturn(Future.succeededFuture(exportHistory)).when(exportHistoryService).createExportHistory(eq(exportHistory), any(DBClient.class));
     List<PoLine> poLines = List.of(new PoLine().withId(lineId));
     doReturn(Future.succeededFuture(poLines)).when(poLinesService).getPoLinesByLineIds(eq(exportHistory.getExportedPoLineIds()), any(Context.class), any(

--- a/src/test/java/org/folio/rest/impl/OrdersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/OrdersAPITest.java
@@ -1,10 +1,11 @@
 package org.folio.rest.impl;
 
+import io.restassured.http.Headers;
 import org.folio.StorageTestSuite;
 import org.folio.event.AuditEventType;
-import static org.folio.rest.impl.HelperUtilsTest.ORDERS_ENDPOINT;
 import org.folio.rest.jaxrs.model.OrderAuditEvent;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
+import static org.folio.rest.impl.HelperUtilsTest.ORDERS_ENDPOINT;
 import static org.folio.rest.utils.TestEntities.PO_LINE;
 import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -60,28 +61,31 @@ public class OrdersAPITest extends TestBase {
       String acqUnitId1 = UUID.randomUUID().toString();
       String acqUnitId2 = UUID.randomUUID().toString();
 
+      String userId = UUID.randomUUID().toString();
+      Headers headers = getDikuTenantHeaders(userId);
+
       logger.info("--- mod-orders-storage orders test: Creating Purchase order 1...");
       // assign 2 units
       purchaseOrderSample.getAcqUnitIds().add(acqUnitId1);
       purchaseOrderSample.getAcqUnitIds().add(acqUnitId2);
-      purchaseOrderSampleId = createEntity(PURCHASE_ORDER.getEndpoint(), JsonObject.mapFrom(purchaseOrderSample).encode());
+      purchaseOrderSampleId = createEntity(PURCHASE_ORDER.getEndpoint(), JsonObject.mapFrom(purchaseOrderSample).encode(), headers);
 
       expectedOrders.put(purchaseOrderSampleId, purchaseOrderSample);
       logger.info("--- mod-orders-storage orders test: Creating Purchase order 2...");
       // assign 1 unit
       purchaseOrderSample2.getAcqUnitIds().add(acqUnitId1);
-      purchaseOrderSampleId2 = createEntity(PURCHASE_ORDER.getEndpoint(), JsonObject.mapFrom(purchaseOrderSample2).encode());
+      purchaseOrderSampleId2 = createEntity(PURCHASE_ORDER.getEndpoint(), JsonObject.mapFrom(purchaseOrderSample2).encode(), headers);
 
       expectedOrders.put(purchaseOrderSampleId2, purchaseOrderSample2);
       logger.info("--- mod-orders-storage orders test: Creating Purchase order without PoLines...");
-      purchaseOrderWithoutPOLinesId = createEntity(PURCHASE_ORDER.getEndpoint(), purchaseOrderWithoutPOLines);
+      purchaseOrderWithoutPOLinesId = createEntity(PURCHASE_ORDER.getEndpoint(), purchaseOrderWithoutPOLines, headers);
       expectedOrders.put(purchaseOrderWithoutPOLinesId, new JsonObject(purchaseOrderWithoutPOLines).mapTo(PurchaseOrder.class));
       verifyCollectionQuantity(PURCHASE_ORDER.getEndpoint(), CREATED_ORDERS_QUANTITY);
 
       logger.info("--- mod-orders-storage orders test: Creating PoLine 1...");
-      poLineSampleId = createEntity(PO_LINE.getEndpoint(), poLineSample);
+      poLineSampleId = createEntity(PO_LINE.getEndpoint(), poLineSample, headers);
       logger.info("--- mod-orders-storage orders test: Creating PoLine 2 ...");
-      poLineSampleId2 = createEntity(PO_LINE.getEndpoint(), poLineSample2);
+      poLineSampleId2 = createEntity(PO_LINE.getEndpoint(), poLineSample2, headers);
       verifyCollectionQuantity(PO_LINE.getEndpoint(), CREATED_PO_LINES_QUANTITY);
 
 
@@ -140,14 +144,14 @@ public class OrdersAPITest extends TestBase {
       verifyExpectedOrders(filteredByUnit, purchaseOrderWithoutPOLinesId);
 
       // for 3 created orders 3 create events should be produced
-      List<String> sentCreateOrderEvents = StorageTestSuite.checkEventWithTypeSent(AuditEventType.ACQ_ORDER_CHANGED.getTopicName(), CREATED_ORDERS_QUANTITY);
+      List<String> sentCreateOrderEvents = StorageTestSuite.checkKafkaEventSent(TENANT_NAME, AuditEventType.ACQ_ORDER_CHANGED.getTopicName(), CREATED_ORDERS_QUANTITY, userId);
       assertEquals(CREATED_ORDERS_QUANTITY.intValue(), sentCreateOrderEvents.size());
       checkOrderEventContent(sentCreateOrderEvents.get(0), OrderAuditEvent.Action.CREATE);
       checkOrderEventContent(sentCreateOrderEvents.get(1), OrderAuditEvent.Action.CREATE);
       checkOrderEventContent(sentCreateOrderEvents.get(2), OrderAuditEvent.Action.CREATE);
 
       // for 2 created order lines 2 create events should be produced
-      List<String> sendCreatePoLineEvents = StorageTestSuite.checkEventWithTypeSent(AuditEventType.ACQ_ORDER_LINE_CHANGED.getTopicName(), CREATED_PO_LINES_QUANTITY);
+      List<String> sendCreatePoLineEvents = StorageTestSuite.checkKafkaEventSent(TENANT_NAME, AuditEventType.ACQ_ORDER_LINE_CHANGED.getTopicName(), CREATED_PO_LINES_QUANTITY, userId);
       assertEquals(CREATED_PO_LINES_QUANTITY.intValue(), sendCreatePoLineEvents.size());
       checkOrderLineEventContent(sendCreatePoLineEvents.get(0), OrderLineAuditEvent.Action.CREATE);
       checkOrderLineEventContent(sendCreatePoLineEvents.get(1), OrderLineAuditEvent.Action.CREATE);

--- a/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchOrderLinesTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import io.restassured.http.Headers;
 import io.restassured.http.Header;
 import io.vertx.core.json.JsonObject;
 import java.net.MalformedURLException;
@@ -121,7 +122,7 @@ public class SearchOrderLinesTest extends TestBase {
     String acqUnitId = UUID.randomUUID().toString();
     order.getAcqUnitIds().add(acqUnitId);
     order.getMetadata().setCreatedByUserId(UUID.randomUUID().toString());
-    putData(TestEntities.PURCHASE_ORDER.getEndpointWithId(), purchaseOrderId, JsonObject.mapFrom(order).encode(), NEW_TENANT);
+    putData(TestEntities.PURCHASE_ORDER.getEndpointWithId(), purchaseOrderId, JsonObject.mapFrom(order).encode(), new Headers(NEW_TENANT));
 
     // Search lines by existing and new acq units
     verifySearchByAcqUnit(String.format("?query=purchaseOrder.acqUnitIds=(%s and %s)", order.getAcqUnitIds().get(0), acqUnitId), purchaseOrderId);

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -1,13 +1,15 @@
 package org.folio.rest.impl;
 
 import static io.restassured.RestAssured.given;
+import io.restassured.http.Headers;
 import io.vertx.core.json.Json;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.StorageTestSuite.initSpringContext;
 import static org.folio.StorageTestSuite.storageUrl;
 import org.folio.rest.jaxrs.model.OrderAuditEvent;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import static org.folio.rest.utils.TestEntities.TITLES;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
@@ -80,7 +82,7 @@ public abstract class TestBase {
       String id = new JsonObject(sample).getString("id");
       pair.getLeft().setId(id);
 
-      postData(pair.getLeft().getEndpoint(), sample, ISOLATED_TENANT_HEADER)
+      postData(pair.getLeft().getEndpoint(), sample, new Headers(ISOLATED_TENANT_HEADER))
         .then()
         .statusCode(201);
     }
@@ -142,12 +144,12 @@ public abstract class TestBase {
   }
 
   Response postData(String endpoint, String input) throws MalformedURLException {
-    return postData(endpoint, input, TENANT_HEADER);
+    return postData(endpoint, input, new Headers(TENANT_HEADER));
   }
 
-  Response postData(String endpoint, String input, Header tenant) throws MalformedURLException {
+  Response postData(String endpoint, String input, Headers headers) throws MalformedURLException {
     return given()
-      .header(tenant)
+      .headers(headers)
       .accept(ContentType.JSON)
       .contentType(ContentType.JSON)
       .body(input)
@@ -165,24 +167,28 @@ public abstract class TestBase {
   }
 
   String createEntity(String endpoint, String entity, Header tenant) throws MalformedURLException {
-    return postData(endpoint, entity, tenant)
-      .then().log().all()
-        .statusCode(201)
-        .extract()
-          .path("id");
+    return createEntity(endpoint, entity, new Headers(tenant));
   }
 
-  Response putData(String endpoint, String id, String input, Header tenant) throws MalformedURLException {
+  String createEntity(String endpoint, String entity, Headers headers) throws MalformedURLException {
+    return postData(endpoint, entity, headers)
+      .then().log().all()
+      .statusCode(201)
+      .extract()
+      .path("id");
+  }
+
+  Response putData(String endpoint, String id, String input, Headers headers) throws MalformedURLException {
     return given()
       .pathParam("id", id)
-      .header(tenant)
+      .headers(headers)
       .contentType(ContentType.JSON)
       .body(input)
       .put(storageUrl(endpoint));
   }
 
   Response putData(String endpoint, String id, String input) throws MalformedURLException {
-    return putData(endpoint, id, input, TENANT_HEADER);
+    return putData(endpoint, id, input, new Headers(TENANT_HEADER));
   }
 
   void deleteDataSuccess(String endpoint, String id) throws MalformedURLException {
@@ -270,6 +276,16 @@ public abstract class TestBase {
 
   <T> T getFileAsObject(String path, Class<T> clazz) {
     return new JsonObject(getFile(path)).mapTo(clazz);
+  }
+
+  protected Headers getDikuTenantHeaders(String userId) {
+    Header userIdHeader = new Header(OKAPI_USERID_HEADER, userId);
+    return new Headers(TENANT_HEADER, userIdHeader);
+  }
+
+  protected Headers getIsolatedTenantHeaders(String userId) {
+    Header userIdHeader = new Header(OKAPI_USERID_HEADER, userId);
+    return new Headers(ISOLATED_TENANT_HEADER, userIdHeader);
   }
 
   protected void checkOrderEventContent(String eventPayload, OrderAuditEvent.Action action) {

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -1,9 +1,12 @@
 package org.folio.rest.impl;
 
 import static io.restassured.RestAssured.given;
+import io.vertx.core.json.Json;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.StorageTestSuite.initSpringContext;
 import static org.folio.StorageTestSuite.storageUrl;
+import org.folio.rest.jaxrs.model.OrderAuditEvent;
+import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import static org.folio.rest.utils.TestEntities.TITLES;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -28,6 +31,8 @@ import org.folio.config.ApplicationConfig;
 import org.folio.rest.jaxrs.model.TitleCollection;
 import org.folio.rest.utils.TestEntities;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.BeforeAll;
 
 /**
@@ -267,4 +272,24 @@ public abstract class TestBase {
     return new JsonObject(getFile(path)).mapTo(clazz);
   }
 
+  protected void checkOrderEventContent(String eventPayload, OrderAuditEvent.Action action) {
+    OrderAuditEvent event = Json.decodeValue(eventPayload, OrderAuditEvent.class);
+    Assertions.assertEquals(action, event.getAction());
+    assertNotNull(event.getId());
+    assertNotNull(event.getOrderId());
+    assertNotNull(event.getActionDate());
+    assertNotNull(event.getEventDate());
+    assertNotNull(event.getPurchaseOrder());
+  }
+
+  protected void checkOrderLineEventContent(String eventPayload, OrderLineAuditEvent.Action action) {
+    OrderLineAuditEvent event = Json.decodeValue(eventPayload, OrderLineAuditEvent.class);
+    Assertions.assertEquals(action, event.getAction());
+    assertNotNull(event.getId());
+    assertNotNull(event.getOrderId());
+    assertNotNull(event.getOrderLineId());
+    assertNotNull(event.getActionDate());
+    assertNotNull(event.getEventDate());
+    assertNotNull(event.getPoLine());
+  }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDSTOR-324 
Currently we use implementation to send event after creating/updating order as 2 separate actions. When we implement transaction outbox pattern - implementation in OrderAPI/ Order Line API will be changed to make it more reliable atomic operation. Integration tests should not be changed after switching to outbox pattern implementation

Tests using shared kafka, to distinquish kafka messages between separate tests userId header is used, each test has unqiue userId header 