### PR TITLE
[MODORDSTOR-362] - Title inherited claimingActive, claimingInterval

### DIFF
--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -449,6 +449,8 @@ public class PoLinesService {
       .withPublisher(poLine.getPublisher())
       .withPublishedDate(poLine.getPublicationDate())
       .withAcqUnitIds(acqUnitIds)
+      .withClaimingActive(poLine.getClaimingActive())
+      .withClaimingInterval(poLine.getClaimingInterval())
       .withExpectedReceiptDate(Objects.nonNull(poLine.getPhysical()) ? poLine.getPhysical().getExpectedReceiptDate() : null);
     if (Objects.nonNull(poLine.getDetails())) {
       title.withProductIds(poLine.getDetails()
@@ -500,6 +502,8 @@ public class PoLinesService {
   private boolean titleUpdateRequired(Title title, PoLine poLine) {
     return !title.equals(createTitleObject(poLine, title.getAcqUnitIds())
       .withId(title.getId())
+      .withClaimingActive(poLine.getClaimingActive())
+      .withClaimingInterval(poLine.getClaimingInterval())
       .withMetadata(title.getMetadata()));
   }
 

--- a/src/main/java/org/folio/services/title/TitleService.java
+++ b/src/main/java/org/folio/services/title/TitleService.java
@@ -132,6 +132,8 @@ public class TitleService {
     title.setPackageName(poLine.getTitleOrPackage());
     title.setExpectedReceiptDate(Objects.nonNull(poLine.getPhysical()) ? poLine.getPhysical().getExpectedReceiptDate() : null);
     title.setPoLineNumber(poLine.getPoLineNumber());
+    title.setClaimingActive(poLine.getClaimingActive());
+    title.setClaimingInterval(poLine.getClaimingInterval());
     if (poLine.getDetails() != null) {
       title.setReceivingNote(poLine.getDetails().getReceivingNote());
     }

--- a/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/PurchaseOrderLinesApiTest.java
@@ -166,6 +166,8 @@ public class PurchaseOrderLinesApiTest extends TestBase {
     log.info("--- mod-orders-storage orders test: post non-package PoLine associated title must be created or updated with poLine");
     JsonObject jsonOrder = new JsonObject(getFile("data/purchase-orders/81_ongoing_pending.json"));
     JsonObject jsonLine = new JsonObject(getFile("data/po-lines/81-1_pending_fomat-other.json"));
+    jsonLine.put("claimingActive", true);
+    jsonLine.put("claimingInterval", 1);
 
     String userId = UUID.randomUUID().toString();
     Headers headers = getDikuTenantHeaders(userId);
@@ -189,6 +191,8 @@ public class PurchaseOrderLinesApiTest extends TestBase {
     assertThat(titleBefore.getPoLineId(), is(poLine.getId()));
     assertThat(titleBefore.getProductIds(), is(poLine.getDetails().getProductIds()));
     assertThat(titleBefore.getTitle(), is(poLine.getTitleOrPackage()));
+    assertEquals(titleBefore.getClaimingActive(), poLine.getClaimingActive());
+    assertEquals(titleBefore.getClaimingInterval(), poLine.getClaimingInterval());
 
     String newTitle = "new Title";
     poLine.setDetails(null);

--- a/src/test/java/org/folio/services/title/TitleServiceTest.java
+++ b/src/test/java/org/folio/services/title/TitleServiceTest.java
@@ -167,7 +167,9 @@ public class TitleServiceTest extends TestBase {
       .withId(poLineId)
       .withIsPackage(false)
       .withPurchaseOrderId(purchaseOrderId)
-      .withTitleOrPackage("Title name");
+      .withTitleOrPackage("Title name")
+      .withClaimingActive(true)
+      .withClaimingInterval(1);
 
     Title title = new Title()
       .withPoLineId(poLineId)
@@ -204,6 +206,8 @@ public class TitleServiceTest extends TestBase {
         Title actTitle = ar.result();
         testContext.verify(() -> assertEquals(actTitle.getPackageName(), poLine.getTitleOrPackage()));
         testContext.verify(() -> assertEquals(actTitle.getAcqUnitIds(), purchaseOrder.getAcqUnitIds()));
+        testContext.verify(() -> assertEquals(actTitle.getClaimingActive(), poLine.getClaimingActive()));
+        testContext.verify(() -> assertEquals(actTitle.getClaimingInterval(), poLine.getClaimingInterval()));
         testContext.completeNow();
       });
   }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDSTOR-70 Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
[MODORDSTOR-362](https://issues.folio.org/browse/MODORDSTOR-362) - Inherit claimingActive, claimingInterval from Purchase Order Line to the Receiving Title
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." 
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDSTOR-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or add-ons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
