### PR TITLE
[MODORDSTOR-354] - Implement business rules to update piece statues in batch job

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1202,6 +1202,19 @@
       ]
     },
     {
+      "permissionName" : "orders-storage.claiming.process",
+      "displayName" : "orders-storage-claiming-process",
+      "description" : "Iterate through claimed pieces and modify their status as needed"
+    },
+    {
+      "permissionName" : "orders-storage.claiming.all",
+      "displayName" : "All orders-storage claiming perms",
+      "description" : "All permissions for the orders-storage - claiming",
+      "subPermissions" : [
+        "orders-storage.claiming.process"
+      ]
+    },
+    {
       "permissionName" : "orders-storage.audit-outbox.process",
       "displayName" : "orders-storage-audit-outbox-process",
       "description" : "Fetch audit events and send them to kafka"
@@ -1237,7 +1250,8 @@
         "orders-storage.configuration.prefixes.all",
         "orders-storage.configuration.suffixes.all",
         "orders-storage.export-history.all",
-        "orders-storage.audit-outbox.all"
+        "orders-storage.audit-outbox.all",
+        "orders-storage.claiming.all"
       ]
     }
   ],

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -4,7 +4,9 @@ import java.util.EnumMap;
 import java.util.Map;
 
 import io.vertx.core.Vertx;
+import org.folio.dao.ExtensionRepository;
 import org.folio.dao.InternalLockRepository;
+import org.folio.dao.PieceClaimingRepository;
 import org.folio.dao.PostgresClientFactory;
 import org.folio.dao.audit.AuditOutboxEventsLogRepository;
 import org.folio.dao.export.ExportHistoryPostgresRepository;
@@ -154,7 +156,19 @@ public class ApplicationConfig {
   }
 
   @Bean
-  PieceClaimingService pieceClaimingService() {
-    return new PieceClaimingService();
+  ExtensionRepository extensionRepository() {
+    return new ExtensionRepository();
+  }
+
+  @Bean
+  PieceClaimingRepository pieceClaimingRepository() {
+    return new PieceClaimingRepository();
+  }
+
+  @Bean
+  PieceClaimingService pieceClaimingService(PostgresClientFactory pgClientFactory,
+                                            ExtensionRepository extensionRepository,
+                                            PieceClaimingRepository pieceClaimingRepository) {
+    return new PieceClaimingService(pgClientFactory, extensionRepository, pieceClaimingRepository);
   }
 }

--- a/src/main/java/org/folio/dao/ExtensionRepository.java
+++ b/src/main/java/org/folio/dao/ExtensionRepository.java
@@ -1,0 +1,27 @@
+package org.folio.dao;
+
+import io.vertx.core.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.persist.Conn;
+
+public class ExtensionRepository {
+  private static final Logger log = LogManager.getLogger();
+  private static final String UUID_OSSP_EXTENSION = "uuid-ossp";
+  private static final String CREATE_EXTENSION_STATEMENT = """
+    CREATE EXTENSION IF NOT EXISTS "%s" WITH SCHEMA public;
+    """;
+
+  public Future<Void> createUUIDExtension(Conn conn) {
+    return createExtension(UUID_OSSP_EXTENSION, conn);
+  }
+
+  private Future<Void> createExtension(String extensionName, Conn conn) {
+    String query = String.format(CREATE_EXTENSION_STATEMENT, extensionName);
+    return conn.execute(query)
+      .onSuccess(result -> log.info("createExtension:: Extension created or existed, extensionName={}", extensionName))
+      .onFailure(t -> log.error("createExtension:: Failed to create extension, extensionName={}", extensionName, t))
+      .mapEmpty();
+  }
+
+}

--- a/src/main/java/org/folio/dao/PieceClaimingRepository.java
+++ b/src/main/java/org/folio/dao/PieceClaimingRepository.java
@@ -1,0 +1,50 @@
+package org.folio.dao;
+
+import io.vertx.core.Future;
+import io.vertx.sqlclient.SqlResult;
+import io.vertx.sqlclient.Tuple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.persist.Conn;
+
+import static org.folio.dao.audit.AuditOutboxEventsLogRepository.OUTBOX_TABLE_NAME;
+import static org.folio.rest.impl.PiecesAPI.PIECES_TABLE;
+import static org.folio.rest.impl.TitlesAPI.TITLES_TABLE;
+import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
+
+public class PieceClaimingRepository {
+  private static final Logger log = LogManager.getLogger();
+  private static final String SYNTHETIC_USER_ID = "06c3485f-631c-427e-bade-5e763636c470";
+  private static final String UPDATE_STATEMENT = """
+    WITH updated AS (
+        UPDATE %1$s.%2$s as pieces
+        SET jsonb = pieces.jsonb || jsonb_build_object(
+            'receivingStatus', 'Late',
+            'statusUpdatedDate', to_char(clock_timestamp(),'YYYY-MM-DD"T"HH24:MI:SS.MSTZH:TZM')::text,
+            'metadata', pieces.jsonb -> 'metadata' || jsonb_build_object(
+                'updatedDate', to_char(clock_timestamp(),'YYYY-MM-DD"T"HH24:MI:SS.MSTZH:TZM')::text,
+                'updatedByUserId', $1))
+        FROM %1$s.%3$s as titles
+        WHERE pieces.titleid = titles.id
+        AND (titles.jsonb ->> 'claimingActive')::boolean = TRUE
+        AND (
+          (pieces.jsonb ->> 'receivingStatus' = 'Expected'
+              AND current_date >= ((pieces.jsonb ->> 'receiptDate')::date + INTERVAL '1 day' * (titles.jsonb ->> 'claimingInterval')::int))
+          OR (pieces.jsonb ->> 'receivingStatus' IN ('Claim delayed', 'Claim sent')
+              AND current_date >= ((pieces.jsonb ->> 'statusUpdatedDate')::date + INTERVAL '1 day' * (pieces.jsonb->>'claimingInterval')::int))
+        )
+        RETURNING pieces.*
+    )
+    INSERT INTO %1$s.%4$s (event_id, entity_type, action, payload)
+    SELECT public.uuid_generate_v4(), 'Piece', 'Edit', to_jsonb(updated.jsonb::text)
+    FROM updated;
+    """;
+
+  public Future<Integer> updatePieceStatusBasedOnIntervals(Conn conn, String tenantId) {
+    String query = String.format(UPDATE_STATEMENT, convertToPsqlStandard(tenantId), PIECES_TABLE, TITLES_TABLE, OUTBOX_TABLE_NAME);
+    Tuple queryParams = Tuple.of(SYNTHETIC_USER_ID);
+    return conn.execute(query, queryParams).map(SqlResult::rowCount)
+      .onFailure(t -> log.warn("updatePieceStatusBasedOnIntervals failed, tenantId={}", tenantId, t));
+  }
+
+}

--- a/src/main/java/org/folio/dao/PieceClaimingRepository.java
+++ b/src/main/java/org/folio/dao/PieceClaimingRepository.java
@@ -25,8 +25,8 @@ public class PieceClaimingRepository {
                 'updatedDate', to_char(clock_timestamp(),'YYYY-MM-DD"T"HH24:MI:SS.MSTZH:TZM')::text,
                 'updatedByUserId', $1))
         FROM %1$s.%3$s as titles
-        WHERE pieces.titleid = titles.id
-        AND (titles.jsonb ->> 'claimingActive')::boolean = TRUE
+        WHERE (titles.jsonb ->> 'claimingActive')::boolean = TRUE
+        AND pieces.titleid = titles.id
         AND (
           (pieces.jsonb ->> 'receivingStatus' = 'Expected'
               AND current_date >= ((pieces.jsonb ->> 'receiptDate')::date + INTERVAL '1 day' * (titles.jsonb ->> 'claimingInterval')::int))

--- a/src/main/java/org/folio/dao/audit/AuditOutboxEventsLogRepository.java
+++ b/src/main/java/org/folio/dao/audit/AuditOutboxEventsLogRepository.java
@@ -20,7 +20,7 @@ import io.vertx.sqlclient.Tuple;
 
 public class AuditOutboxEventsLogRepository {
   private static final Logger log = LogManager.getLogger();
-  private static final String OUTBOX_TABLE_NAME = "outbox_event_log";
+  public static final String OUTBOX_TABLE_NAME = "outbox_event_log";
   private static final String EVENT_ID_FIELD = "event_id";
   private static final String ENTITY_TYPE_FIELD = "entity_type";
   private static final String ACTION_FIELD = "action";

--- a/src/main/java/org/folio/services/piece/PieceClaimingService.java
+++ b/src/main/java/org/folio/services/piece/PieceClaimingService.java
@@ -1,11 +1,33 @@
 package org.folio.services.piece;
 
 import io.vertx.core.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dao.ExtensionRepository;
+import org.folio.dao.PieceClaimingRepository;
+import org.folio.dao.PostgresClientFactory;
+import org.folio.rest.persist.PostgresClient;
 
 public class PieceClaimingService {
+  private static final Logger log = LogManager.getLogger();
 
-  public Future<Integer> processClaimedPieces() {
-    return Future.succeededFuture(0);
+
+  private final PostgresClientFactory pgClientFactory;
+  private final ExtensionRepository extensionRepository;
+  private final PieceClaimingRepository pieceClaimingRepository;
+
+  public PieceClaimingService(PostgresClientFactory pgClientFactory, ExtensionRepository extensionRepository, PieceClaimingRepository pieceClaimingRepository) {
+    this.pgClientFactory = pgClientFactory;
+    this.extensionRepository = extensionRepository;
+    this.pieceClaimingRepository = pieceClaimingRepository;
+  }
+
+
+  public Future<Integer> processClaimedPieces(String tenantId) {
+    log.trace("processClaimedPieces, tenantId={}", tenantId);
+    PostgresClient pgClient = pgClientFactory.createInstance(tenantId);
+    return pgClient.withConn(conn -> extensionRepository.createUUIDExtension(conn)
+      .compose(aVoid -> pieceClaimingRepository.updatePieceStatusBasedOnIntervals(conn, tenantId)));
   }
 
 }

--- a/src/main/java/org/folio/services/piece/PieceClaimingService.java
+++ b/src/main/java/org/folio/services/piece/PieceClaimingService.java
@@ -22,7 +22,6 @@ public class PieceClaimingService {
     this.pieceClaimingRepository = pieceClaimingRepository;
   }
 
-
   public Future<Integer> processClaimedPieces(String tenantId) {
     log.trace("processClaimedPieces, tenantId={}", tenantId);
     PostgresClient pgClient = pgClientFactory.createInstance(tenantId);

--- a/src/main/java/org/folio/services/piece/PieceClaimingService.java
+++ b/src/main/java/org/folio/services/piece/PieceClaimingService.java
@@ -23,7 +23,7 @@ public class PieceClaimingService {
   }
 
   public Future<Integer> processClaimedPieces(String tenantId) {
-    log.trace("processClaimedPieces, tenantId={}", tenantId);
+    log.info("processClaimedPieces, tenantId={}", tenantId);
     PostgresClient pgClient = pgClientFactory.createInstance(tenantId);
     return pgClient.withConn(conn -> extensionRepository.createUUIDExtension(conn)
       .compose(aVoid -> pieceClaimingRepository.updatePieceStatusBasedOnIntervals(conn, tenantId)));

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -430,6 +430,12 @@
           "targetTableAlias": "purchaseOrder",
           "tableAlias": "titles"
         }
+      ],
+      "index": [
+        {
+          "fieldName": "claimingActive",
+          "caseSensitive": false
+        }
       ]
     },
     {

--- a/src/test/java/org/folio/rest/impl/ClaimingAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ClaimingAPITest.java
@@ -3,26 +3,104 @@ package org.folio.rest.impl;
 import io.restassured.http.Headers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.StorageTestSuite;
+import org.folio.event.AuditEventType;
+import org.folio.rest.jaxrs.model.*;
+import org.folio.rest.utils.TestData;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
-import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static io.vertx.core.json.JsonObject.mapFrom;
+import static org.folio.rest.utils.TestEntities.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ClaimingAPITest extends TestBase {
 
   private static final Logger log = LogManager.getLogger();
-  private static final String PO_NUMBER_ENDPOINT = "/orders-storage/claiming/process";
+  private static final String SYNTHETIC_USER_ID = "06c3485f-631c-427e-bade-5e763636c470";
+  public static final String CLAIMING_ENDPOINT = "/orders-storage/claiming/process";
 
   @Test
   void testPieceCreateUpdateEvents() throws MalformedURLException {
     log.info("--- mod-orders-storage claiming batch job test: start job");
-
     String userId = UUID.randomUUID().toString();
     Headers headers = getDikuTenantHeaders(userId);
-    postData(PO_NUMBER_ENDPOINT, EMPTY, headers)
-      .then()
-      .statusCode(200);
+
+    PurchaseOrder purchaseOrder = getFileAsObject(TestData.PurchaseOrder.DEFAULT, PurchaseOrder.class);
+
+    createEntity(PURCHASE_ORDER.getEndpoint(), mapFrom(purchaseOrder).encode(), headers);
+
+    PoLine poLine = getFileAsObject(TestData.PoLine.DEFAULT, PoLine.class).withIsPackage(true).withClaimingActive(true);
+
+    createEntity(PO_LINE.getEndpoint(), mapFrom(poLine).encode(), headers);
+
+    Title titleWithClaimingActive = getFileAsObject(TestData.Title.DEFAULT, Title.class)
+      .withId(UUID.randomUUID().toString()).withClaimingActive(true).withClaimingInterval(1).withPoLineId(poLine.getId());
+    Title titleWithoutClaimingActive = getFileAsObject(TestData.Title.DEFAULT, Title.class)
+      .withId(UUID.randomUUID().toString()).withClaimingActive(false).withPoLineId(poLine.getId());
+
+    createEntity(TITLES.getEndpoint(), mapFrom(titleWithClaimingActive).encode(), headers);
+    createEntity(TITLES.getEndpoint(), mapFrom(titleWithoutClaimingActive).encode(), headers);
+
+    LocalDate eligibleDateForUpdate = LocalDate.now().minusDays(2);
+    Date eligibleDate = Date.from(eligibleDateForUpdate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+
+    Piece pieceExpectedUnclaimed = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
+      .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+      .withTitleId(titleWithoutClaimingActive.getId());
+    Piece pieceExpectedOutdated = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
+      .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
+      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate);
+    Piece pieceClaimSentOutdated = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
+      .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_SENT).withClaimingInterval(1)
+      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate);
+    Piece pieceClaimDelayedOutdated = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
+      .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_DELAYED).withClaimingInterval(1)
+      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate);
+
+    createEntity(PIECE.getEndpoint(), mapFrom(pieceExpectedUnclaimed).encode(), headers);
+    createEntity(PIECE.getEndpoint(), mapFrom(pieceExpectedOutdated).encode(), headers);
+    createEntity(PIECE.getEndpoint(), mapFrom(pieceClaimSentOutdated).encode(), headers);
+    createEntity(PIECE.getEndpoint(), mapFrom(pieceClaimDelayedOutdated).encode(), headers);
+
+    callClaimingApi(headers);
+
+    List<String> events = StorageTestSuite.checkKafkaEventSent(TENANT_NAME, AuditEventType.ACQ_PIECE_CHANGED.getTopicName(), 7, userId);
+    assertEquals(7, events.size());
+    checkPieceEventContent(events.get(0), PieceAuditEvent.Action.CREATE);
+    checkPieceEventContent(events.get(1), PieceAuditEvent.Action.CREATE);
+    checkPieceEventContent(events.get(2), PieceAuditEvent.Action.CREATE);
+    checkPieceEventContent(events.get(3), PieceAuditEvent.Action.CREATE);
+    checkPieceEventContent(events.get(4), PieceAuditEvent.Action.EDIT);
+    checkPieceEventContent(events.get(5), PieceAuditEvent.Action.EDIT);
+    checkPieceEventContent(events.get(6), PieceAuditEvent.Action.EDIT);
+
+    ZonedDateTime startOfDay = ZonedDateTime.now(ZoneId.systemDefault()).toLocalDate().atStartOfDay(ZoneId.systemDefault());
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+    Stream.of(pieceExpectedOutdated, pieceClaimSentOutdated, pieceClaimDelayedOutdated)
+      .map(Piece::getId)
+      .forEach(updatePieceId -> {
+        try {
+          getDataById(PIECE.getEndpointWithId(), updatePieceId, TENANT_HEADER)
+            .then()
+            .assertThat()
+            .body("receivingStatus", Matchers.equalTo(Piece.ReceivingStatus.LATE.toString()))
+            .body("statusUpdatedDate", greaterThanOrEqualTo(startOfDay.format(formatter)))
+            .body("metadata.updatedDate", greaterThanOrEqualTo(startOfDay.format(formatter)))
+            .body("metadata.updatedByUserId", Matchers.equalTo(SYNTHETIC_USER_ID));
+        } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+        }
+      });
   }
+
 }

--- a/src/test/java/org/folio/rest/impl/ClaimingAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ClaimingAPITest.java
@@ -35,11 +35,12 @@ public class ClaimingAPITest extends TestBase {
     String userId = UUID.randomUUID().toString();
     Headers headers = getDikuTenantHeaders(userId);
 
-    PurchaseOrder purchaseOrder = getFileAsObject(TestData.PurchaseOrder.DEFAULT, PurchaseOrder.class);
+    PurchaseOrder purchaseOrder = getFileAsObject(TestData.PurchaseOrder.DEFAULT, PurchaseOrder.class).withId(UUID.randomUUID().toString());
 
     createEntity(PURCHASE_ORDER.getEndpoint(), mapFrom(purchaseOrder).encode(), headers);
 
-    PoLine poLine = getFileAsObject(TestData.PoLine.DEFAULT, PoLine.class).withIsPackage(true).withClaimingActive(true);
+    PoLine poLine = getFileAsObject(TestData.PoLine.DEFAULT, PoLine.class).withId(UUID.randomUUID().toString()).withIsPackage(true)
+      .withClaimingActive(true).withClaimingInterval(1).withPurchaseOrderId(purchaseOrder.getId());
 
     createEntity(PO_LINE.getEndpoint(), mapFrom(poLine).encode(), headers);
 
@@ -56,16 +57,16 @@ public class ClaimingAPITest extends TestBase {
 
     Piece pieceExpectedUnclaimed = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
       .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
-      .withTitleId(titleWithoutClaimingActive.getId());
+      .withTitleId(titleWithoutClaimingActive.getId()).withPoLineId(poLine.getId());
     Piece pieceExpectedOutdated = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
       .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.EXPECTED)
-      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate);
+      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate).withPoLineId(poLine.getId());
     Piece pieceClaimSentOutdated = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
       .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_SENT).withClaimingInterval(1)
-      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate);
+      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate).withPoLineId(poLine.getId());
     Piece pieceClaimDelayedOutdated = getFileAsObject(TestData.Piece.DEFAULT, Piece.class)
       .withId(UUID.randomUUID().toString()).withReceivingStatus(Piece.ReceivingStatus.CLAIM_DELAYED).withClaimingInterval(1)
-      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate);
+      .withStatusUpdatedDate(eligibleDate).withTitleId(titleWithClaimingActive.getId()).withReceiptDate(eligibleDate).withPoLineId(poLine.getId());
 
     createEntity(PIECE.getEndpoint(), mapFrom(pieceExpectedUnclaimed).encode(), headers);
     createEntity(PIECE.getEndpoint(), mapFrom(pieceExpectedOutdated).encode(), headers);

--- a/src/test/java/org/folio/rest/impl/PiecesAPITest.java
+++ b/src/test/java/org/folio/rest/impl/PiecesAPITest.java
@@ -1,7 +1,6 @@
 package org.folio.rest.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.MalformedURLException;
 import java.util.List;
@@ -55,16 +54,6 @@ public class PiecesAPITest extends TestBase {
     assertEquals(2, events.size());
     checkPieceEventContent(events.get(0), PieceAuditEvent.Action.CREATE);
     checkPieceEventContent(events.get(1), PieceAuditEvent.Action.EDIT);
-  }
-
-  protected void checkPieceEventContent(String eventPayload, PieceAuditEvent.Action action) {
-    PieceAuditEvent event = Json.decodeValue(eventPayload, PieceAuditEvent.class);
-    Assertions.assertEquals(action, event.getAction());
-    assertNotNull(event.getId());
-    assertNotNull(event.getPieceId());
-    assertNotNull(event.getActionDate());
-    assertNotNull(event.getEventDate());
-    assertNotNull(event.getPiece());
   }
 
 }

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -8,6 +8,8 @@ import static org.folio.StorageTestSuite.initSpringContext;
 import static org.folio.StorageTestSuite.storageUrl;
 import org.folio.rest.jaxrs.model.OrderAuditEvent;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
+
+import static org.folio.rest.impl.ClaimingAPITest.CLAIMING_ENDPOINT;
 import static org.folio.rest.utils.TestEntities.TITLES;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
@@ -31,6 +33,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.StorageTestSuite;
 import org.folio.config.ApplicationConfig;
+import org.folio.rest.jaxrs.model.PieceAuditEvent;
 import org.folio.rest.jaxrs.model.TitleCollection;
 import org.folio.rest.utils.TestEntities;
 import org.junit.jupiter.api.AfterAll;
@@ -231,6 +234,18 @@ public abstract class TestBase {
       .statusCode(Status.OK.getStatusCode());
   }
 
+  void callClaimingApi(Headers headers) throws MalformedURLException {
+    given()
+      .headers(headers)
+      .accept(ContentType.JSON)
+      .contentType(ContentType.JSON)
+      .post(storageUrl(CLAIMING_ENDPOINT))
+      .then()
+      .log()
+      .all()
+      .statusCode(Status.OK.getStatusCode());
+  }
+
   void deleteTitles(String poLineId) throws MalformedURLException {
     Map<String, Object> params = new HashMap<>();
     params.put("query", "poLineId==" + poLineId);
@@ -329,5 +344,15 @@ public abstract class TestBase {
     assertNotNull(event.getActionDate());
     assertNotNull(event.getEventDate());
     assertNotNull(event.getPoLine());
+  }
+
+  protected void checkPieceEventContent(String eventPayload, PieceAuditEvent.Action action) {
+    PieceAuditEvent event = Json.decodeValue(eventPayload, PieceAuditEvent.class);
+    Assertions.assertEquals(action, event.getAction());
+    assertNotNull(event.getId());
+    assertNotNull(event.getPieceId());
+    assertNotNull(event.getActionDate());
+    assertNotNull(event.getEventDate());
+    assertNotNull(event.getPiece());
   }
 }


### PR DESCRIPTION
## Purpose
The PR aimed to implement pieces daily based batch job bussiness logic.

## Approach

Logic to proccess and update piece status was implemented using complex SQL statement which includes:

1. Update using CTE
2. Insert updated rows to audit outbox table

In the end will trigger audit outbox method which will send records to kafka.

## Learning
[MODORDSTOR-354](https://issues.folio.org/browse/MODORDSTOR-354)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
