### PR TITLE
[MODORDSTOR-389] - Address index warnings for table purchase_order

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -225,6 +225,16 @@
           "fieldName": "poNumber",
           "caseSensitive": false,
           "removeAccents": true
+        },
+        {
+          "fieldName": "dateOrdered",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "metadata.createdDate",
+          "caseSensitive": false,
+          "removeAccents": true
         }
       ]
     },


### PR DESCRIPTION
## Purpose

Adds two additional indexes to mitigate the following warnings when doing a keyword search for orders:
```
WARN  CQL2PgJSON           Doing wildcard LIKE search without index for purchase_order.jsonb->>'dateOrdered', CQL >>> SQL: dateOrdered == "Invalid date*" >>> CASE WHEN length(lower(f_unaccent('Invalid date%'))) <= 600 THEN left(lower(f_unaccent(purchase_order.jsonb->>'dateOrdered')),600) LIKE lower(f_unaccent('Invalid date%')) ELSE left(lower(f_unaccent(purchase_order.jsonb->>'dateOrdered')),600) LIKE left(lower(f_unaccent('Invalid date%')),600) AND lower(f_unaccent(purchase_order.jsonb->>'dateOrdered')) LIKE lower(f_unaccent('Invalid date%')) END
WARN  CQL2PgJSON           Doing wildcard LIKE search without index for purchase_order.jsonb->'metadata'->>'createdDate', CQL >>> SQL: metadata.createdDate == "Invalid date*" >>> CASE WHEN length(lower(f_unaccent('Invalid date%'))) <= 600 THEN left(lower(f_unaccent(purchase_order.jsonb->'metadata'->>'createdDate')),600) LIKE lower(f_unaccent('Invalid date%')) ELSE left(lower(f_unaccent(purchase_order.jsonb->'metadata'->>'createdDate')),600) LIKE left(lower(f_unaccent('Invalid date%')),600) AND lower(f_unaccent(purchase_order.jsonb->'metadata'->>'createdDate')) LIKE lower(f_unaccent('Invalid date%')) END
```

See https://folio-org.atlassian.net/browse/MODORDSTOR-389.