### PR TITLE
MODORDSTOR-395. Metadata for Create Title is not populated

### DIFF
--- a/src/main/java/org/folio/rest/impl/PoLinesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoLinesAPI.java
@@ -93,7 +93,7 @@ public class PoLinesAPI extends BaseApi implements OrdersStoragePoLines {
       validateCustomFields(vertxContext, okapiHeaders, poLine)
         .compose(v ->
           pgClient.withTrans(conn -> poLinesService.createPoLine(conn, poLine)
-            .compose(poLineId -> poLinesService.createTitle(conn, poLine))
+            .compose(poLineId -> poLinesService.createTitle(conn, poLine, okapiHeaders))
             .compose(title -> auditOutboxService.saveOrderLinesOutboxLogs(conn, List.of(poLine), OrderLineAuditEvent.Action.CREATE, okapiHeaders))))
         .onComplete(ar -> {
           if (ar.failed()) {

--- a/src/main/java/org/folio/services/lines/PoLinesBatchService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesBatchService.java
@@ -39,17 +39,17 @@ public class PoLinesBatchService {
 
     return pgClient.withTrans(conn ->
       conn.updateBatch(PO_LINE_TABLE, poLines)
-        .compose(rowSet -> updateTitles(conn, poLines))
+        .compose(rowSet -> updateTitles(conn, poLines, okapiHeaders))
         .compose(rowSet -> auditOutboxService.saveOrderLinesOutboxLogs(conn, poLines, OrderLineAuditEvent.Action.EDIT, okapiHeaders))
         .mapEmpty()
     );
 
   }
 
-  private Future<Void> updateTitles(Conn conn, List<PoLine> poLines) {
+  private Future<Void> updateTitles(Conn conn, List<PoLine> poLines, Map<String, String> headers) {
     var futures = poLines.stream()
       .filter(poLine -> !poLine.getIsPackage())
-      .map(poLine -> poLinesService.updateTitle(conn, poLine))
+      .map(poLine -> poLinesService.updateTitle(conn, poLine, headers))
       .toList();
     return GenericCompositeFuture.join(futures)
       .mapEmpty();

--- a/src/test/java/org/folio/services/lines/PoLinesServiceTest.java
+++ b/src/test/java/org/folio/services/lines/PoLinesServiceTest.java
@@ -269,7 +269,7 @@ public class PoLinesServiceTest {
     doReturn(failedFuture(new Exception("unknown")))
       .when(conn).save(anyString(), anyString(), any(Title.class));
 
-    Future<PoLine> f = poLinesService.createTitle(conn, poLine);
+    Future<PoLine> f = poLinesService.createTitle(conn, poLine, new HashMap<>());
 
     assertThat(f.failed(), is(true));
     io.vertx.ext.web.handler.HttpException thrown = (io.vertx.ext.web.handler.HttpException)f.cause();
@@ -297,7 +297,7 @@ public class PoLinesServiceTest {
     doReturn(failedFuture(new Exception("unknown")))
       .when(conn).save(anyString(), anyString(), any(Title.class));
 
-    Future<PoLine> f = poLinesService.createTitle(conn, poLine);
+    Future<PoLine> f = poLinesService.createTitle(conn, poLine, new HashMap<>());
 
     assertThat(f.failed(), is(true));
     io.vertx.ext.web.handler.HttpException thrown = (io.vertx.ext.web.handler.HttpException)f.cause();


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDSTOR-395

Karate PR - https://github.com/folio-org/folio-integration-tests/pull/1319

## Problem
RMB can populate top level objects, but in code we have an endpoint for PO Line and RMB populates only PO line but not title.

## Approach
Populate metadata manually for creating Title in endpoint to save Po Line 