### PR TITLE
[MODORDSTOR-394] Use a table to generate po numbers

### DIFF
--- a/src/main/java/org/folio/dao/order/OrderDAO.java
+++ b/src/main/java/org/folio/dao/order/OrderDAO.java
@@ -7,4 +7,5 @@ import org.folio.rest.persist.Conn;
 public interface OrderDAO {
   Future<PurchaseOrder> getOrderByIdForUpdate(String orderId, Conn conn);
   Future<Void> updateOrder(PurchaseOrder po, Conn conn);
+  Future<Long> getNextPoNumber(Conn conn);
 }

--- a/src/main/java/org/folio/dao/order/OrderPostgresDAO.java
+++ b/src/main/java/org/folio/dao/order/OrderPostgresDAO.java
@@ -12,6 +12,7 @@ import static org.folio.models.TableNames.ORDER_NUMBER_TABLE;
 import static org.folio.models.TableNames.PURCHASE_ORDER_TABLE;
 
 public class OrderPostgresDAO implements OrderDAO {
+  private static final String UPDATE_NUMBER_QUERY = "UPDATE %s SET last_number = last_number + 1 RETURNING last_number";
   private static final Logger log = LogManager.getLogger();
 
   @Override
@@ -29,11 +30,11 @@ public class OrderPostgresDAO implements OrderDAO {
 
   @Override
   public Future<Long> getNextPoNumber(Conn conn) {
-    String sql = String.format("UPDATE %s SET last_number = last_number + 1 RETURNING last_number", ORDER_NUMBER_TABLE);
+    String sql = String.format(UPDATE_NUMBER_QUERY, ORDER_NUMBER_TABLE);
     return conn.execute(sql)
       .map(rowSet -> {
         if (rowSet.rowCount() == 0) {
-          log.error("Could not get a new purchase order number (rowCount is 0)");
+          log.error("getNextPoNumber:: Could not get a new purchase order number (rowCount is 0); sql: {}",sql);
           throw new HttpException(500, "Could not get a new purchase order number (rowCount is 0)");
         }
         Row row = rowSet.iterator().next();

--- a/src/main/java/org/folio/dao/order/OrderPostgresDAO.java
+++ b/src/main/java/org/folio/dao/order/OrderPostgresDAO.java
@@ -1,11 +1,14 @@
 package org.folio.dao.order;
 
 import io.vertx.core.Future;
+import io.vertx.ext.web.handler.HttpException;
+import io.vertx.sqlclient.Row;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.persist.Conn;
 
+import static org.folio.models.TableNames.ORDER_NUMBER_TABLE;
 import static org.folio.models.TableNames.PURCHASE_ORDER_TABLE;
 
 public class OrderPostgresDAO implements OrderDAO {
@@ -22,5 +25,19 @@ public class OrderPostgresDAO implements OrderDAO {
     return conn.update(PURCHASE_ORDER_TABLE, po, po.getId())
       .onFailure(t -> log.error("updateOrder failed for order with id {}", po.getId(), t))
       .mapEmpty();
+  }
+
+  @Override
+  public Future<Long> getNextPoNumber(Conn conn) {
+    String sql = String.format("UPDATE %s SET last_number = last_number + 1 RETURNING last_number", ORDER_NUMBER_TABLE);
+    return conn.execute(sql)
+      .map(rowSet -> {
+        if (rowSet.rowCount() == 0) {
+          log.error("Could not get a new purchase order number (rowCount is 0)");
+          throw new HttpException(500, "Could not get a new purchase order number (rowCount is 0)");
+        }
+        Row row = rowSet.iterator().next();
+        return row.get(Long.class, 0);
+      });
   }
 }

--- a/src/main/java/org/folio/dao/order/OrderPostgresDAO.java
+++ b/src/main/java/org/folio/dao/order/OrderPostgresDAO.java
@@ -1,7 +1,7 @@
 package org.folio.dao.order;
 
 import io.vertx.core.Future;
-import io.vertx.ext.web.handler.HttpException;
+import org.folio.rest.exceptions.HttpException;
 import io.vertx.sqlclient.Row;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/folio/models/TableNames.java
+++ b/src/main/java/org/folio/models/TableNames.java
@@ -9,6 +9,7 @@ public final class TableNames {
   public static final String RECEIVING_HISTORY_VIEW_TABLE = "receiving_history_view";
   public static final String EXPORT_HISTORY_TABLE = "export_history";
   public static final String ROUTING_LIST_TABLE = "routing_list";
+  public static final String ORDER_NUMBER_TABLE = "order_number";
 
   private TableNames() { }
 

--- a/src/main/java/org/folio/rest/impl/PoNumberAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoNumberAPI.java
@@ -38,13 +38,13 @@ public class PoNumberAPI extends BaseApi implements OrdersStoragePoNumber {
 
   @Override
   public void getOrdersStoragePoNumber(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    vertxContext.runOnContext((Void v) -> pgClient.withConn(conn -> orderDAO.getNextPoNumber(conn)
+    vertxContext.runOnContext((Void v) -> pgClient.withConn(conn -> orderDAO.getNextPoNumber(conn))
       .onSuccess(poNumber -> asyncResultHandler.handle(buildOkResponse(new PoNumber().withSequenceNumber(poNumber.toString()))))
       .onFailure(t -> {
         log.error("Error getting a new po number", t);
         asyncResultHandler.handle(buildErrorResponse(t));
       })
-    ));
+    );
   }
 
   @Override

--- a/src/main/java/org/folio/rest/impl/PoNumberAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoNumberAPI.java
@@ -4,49 +4,48 @@ import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.rest.RestVerticle;
+import org.folio.dao.PostgresClientFactory;
+import org.folio.dao.order.OrderDAO;
 import org.folio.rest.jaxrs.model.PoNumber;
 import org.folio.rest.jaxrs.resource.OrdersStoragePoNumber;
 import org.folio.rest.persist.HelperUtils;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.core.BaseApi;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class PoNumberAPI extends BaseApi implements OrdersStoragePoNumber {
   private static final Logger log = LogManager.getLogger();
-  private static final String PO_NUMBER_QUERY = "SELECT nextval('po_number')";
+  private final PostgresClient pgClient;
+
+  @Autowired
+  private OrderDAO orderDAO;
+  @Autowired
+  private PostgresClientFactory pgClientFactory;
+
+  public PoNumberAPI(Vertx vertx, String tenantId) {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+    pgClient = pgClientFactory.createInstance(tenantId);
+  }
 
   @Override
   public void getOrdersStoragePoNumber(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext((Void v) -> {
-      try {
-        String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
-
-        PostgresClient.getInstance(vertxContext.owner(), tenantId).select(PO_NUMBER_QUERY, ar -> {
-          try {
-            if (ar.succeeded()) {
-              String poNumber = ar.result().iterator().next().getLong(0).toString();
-              asyncResultHandler.handle(buildOkResponse(new PoNumber().withSequenceNumber(poNumber)));
-            } else {
-              log.error("Error with pg generating a new po number", ar.cause());
-              asyncResultHandler.handle(buildErrorResponse(ar.cause()));
-            }
-          } catch (Exception e) {
-            log.error("Error getting the generated po number", e);
-            asyncResultHandler.handle(buildErrorResponse(e));
-          }
-        });
-      } catch (Exception e) {
-        log.error("Error getting a new po number", e);
-        asyncResultHandler.handle(buildErrorResponse(e));
-      }
+      pgClient.withConn(conn -> orderDAO.getNextPoNumber(conn)
+        .onSuccess(poNumber -> asyncResultHandler.handle(buildOkResponse(new PoNumber().withSequenceNumber(poNumber.toString()))))
+        .onFailure(t -> {
+          log.error("Error getting a new po number", t);
+          asyncResultHandler.handle(buildErrorResponse(t));
+        })
+      );
     });
   }
 

--- a/src/main/java/org/folio/rest/impl/PoNumberAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoNumberAPI.java
@@ -41,7 +41,7 @@ public class PoNumberAPI extends BaseApi implements OrdersStoragePoNumber {
     vertxContext.runOnContext((Void v) -> pgClient.withConn(conn -> orderDAO.getNextPoNumber(conn))
       .onSuccess(poNumber -> asyncResultHandler.handle(buildOkResponse(new PoNumber().withSequenceNumber(poNumber.toString()))))
       .onFailure(t -> {
-        log.error("Error getting a new po number", t);
+        log.error("getOrdersStoragePoNumber:: Error getting a new po number", t);
         asyncResultHandler.handle(buildErrorResponse(t));
       })
     );

--- a/src/main/java/org/folio/rest/impl/PoNumberAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoNumberAPI.java
@@ -38,15 +38,13 @@ public class PoNumberAPI extends BaseApi implements OrdersStoragePoNumber {
 
   @Override
   public void getOrdersStoragePoNumber(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    vertxContext.runOnContext((Void v) -> {
-      pgClient.withConn(conn -> orderDAO.getNextPoNumber(conn)
-        .onSuccess(poNumber -> asyncResultHandler.handle(buildOkResponse(new PoNumber().withSequenceNumber(poNumber.toString()))))
-        .onFailure(t -> {
-          log.error("Error getting a new po number", t);
-          asyncResultHandler.handle(buildErrorResponse(t));
-        })
-      );
-    });
+    vertxContext.runOnContext((Void v) -> pgClient.withConn(conn -> orderDAO.getNextPoNumber(conn)
+      .onSuccess(poNumber -> asyncResultHandler.handle(buildOkResponse(new PoNumber().withSequenceNumber(poNumber.toString()))))
+      .onFailure(t -> {
+        log.error("Error getting a new po number", t);
+        asyncResultHandler.handle(buildErrorResponse(t));
+      })
+    ));
   }
 
   @Override

--- a/src/main/resources/templates/db_scripts/data-migration/13.8.0/replace_po_number_sequence.ftl
+++ b/src/main/resources/templates/db_scripts/data-migration/13.8.0/replace_po_number_sequence.ftl
@@ -1,0 +1,19 @@
+<#if mode.name() == "UPDATE">
+
+DO $$
+DECLARE
+    seq            record;
+    lastValue      int;
+BEGIN
+    FOR seq IN
+        SELECT sequence_name
+            FROM information_schema.sequences
+            WHERE sequence_schema = '${myuniversity}_${mymodule}' AND sequence_name = 'po_number'
+    LOOP
+        EXECUTE 'SELECT last_value FROM po_number' INTO lastValue;
+        UPDATE ${myuniversity}_${mymodule}.order_number SET last_number = lastValue;
+        DROP SEQUENCE po_number;
+    END LOOP;
+END $$;
+
+</#if>

--- a/src/main/resources/templates/db_scripts/purchase_order_table.sql
+++ b/src/main/resources/templates/db_scripts/purchase_order_table.sql
@@ -1,8 +1,3 @@
-CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.po_number MAXVALUE 9999999999999999 START WITH 10000 CACHE 1 NO CYCLE;
-GRANT USAGE ON SEQUENCE ${myuniversity}_${mymodule}.po_number TO ${myuniversity}_${mymodule};
-
-
 CREATE UNIQUE INDEX IF NOT EXISTS purchase_order_po_number_unique_idx ON ${myuniversity}_${mymodule}.purchase_order ((jsonb->>'poNumber'));
 CREATE INDEX IF NOT EXISTS purchase_order_customfields_recordservice_idx_gin
 ON ${myuniversity}_${mymodule}.purchase_order USING GIN ((jsonb->'customFields'));
-

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -125,6 +125,16 @@
       "run": "after",
       "snippetPath": "data-migration/13.7.0/piece_caption_migration.sql",
       "fromModuleVersion": "mod-orders-storage-13.7.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "tables/create_order_number_table.sql",
+      "fromModuleVersion": "mod-orders-storage-13.8.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/13.8.0/replace_po_number_sequence.ftl",
+      "fromModuleVersion": "mod-orders-storage-13.8.0"
     }
   ],
   "tables": [

--- a/src/main/resources/templates/db_scripts/tables/create_order_number_table.sql
+++ b/src/main/resources/templates/db_scripts/tables/create_order_number_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS ${myuniversity}_${mymodule}.order_number (
+  last_number bigint NOT NULL DEFAULT 9999
+);
+INSERT INTO ${myuniversity}_${mymodule}.order_number (last_number) SELECT 9999
+  WHERE NOT EXISTS (SELECT * FROM ${myuniversity}_${mymodule}.order_number);

--- a/src/test/java/org/folio/rest/impl/PoNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/PoNumberTest.java
@@ -50,13 +50,17 @@ public class PoNumberTest extends TestBase {
   @Test
   public void testError() throws Exception {
     AutoCloseable mockitoMocks = MockitoAnnotations.openMocks(this);
+
     OrderPostgresDAO orderPostgresDAO = new OrderPostgresDAO();
     doReturn(0).when(rowSet).rowCount();
     doReturn(Future.succeededFuture(rowSet)).when(conn).execute(anyString());
+
     Future<Long> f = orderPostgresDAO.getNextPoNumber(conn);
+
     assertThat(f.failed(), is(true));
     HttpException thrown = (HttpException)f.cause();
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), thrown.getCode());
+
     mockitoMocks.close();
   }
 

--- a/src/test/java/org/folio/rest/impl/PoNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/PoNumberTest.java
@@ -1,18 +1,36 @@
 package org.folio.rest.impl;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 
 import java.net.MalformedURLException;
 
+import io.vertx.core.Future;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.dao.order.OrderPostgresDAO;
+import org.folio.rest.exceptions.HttpException;
+import org.folio.rest.persist.Conn;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.core.Response;
 
 
 public class PoNumberTest extends TestBase {
   private static final Logger log = LogManager.getLogger();
-
   private static final String PO_NUMBER_ENDPOINT = "/orders-storage/po-number";
+
+  @Mock
+  private Conn conn;
+  @Mock
+  private RowSet<Row> rowSet;
 
   @Test
   public void testGetPoNumberOk() throws MalformedURLException {
@@ -27,6 +45,19 @@ public class PoNumberTest extends TestBase {
     //ensure that the numbers returned are in fact sequential
     assertEquals(1, poNumber3 - poNumber2);
     assertEquals(1, poNumber2 - poNumber1);
+  }
+
+  @Test
+  public void testError() throws Exception {
+    AutoCloseable mockitoMocks = MockitoAnnotations.openMocks(this);
+    OrderPostgresDAO orderPostgresDAO = new OrderPostgresDAO();
+    doReturn(0).when(rowSet).rowCount();
+    doReturn(Future.succeededFuture(rowSet)).when(conn).execute(anyString());
+    Future<Long> f = orderPostgresDAO.getNextPoNumber(conn);
+    assertThat(f.failed(), is(true));
+    HttpException thrown = (HttpException)f.cause();
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), thrown.getCode());
+    mockitoMocks.close();
   }
 
   private int getPoNumberAsInt() throws MalformedURLException {


### PR DESCRIPTION
## Purpose
[MODORDSTOR-394](https://folio-org.atlassian.net/browse/MODORDSTOR-394) - PO numbers do not go up consecutively

## Approach
- Used a table with the last po number used
- Added a script to create the table and a migration script to convert and remove the sequence

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
