### PR TITLE
Modorders-1087-Delete received pieces in bulk

### DIFF
--- a/ramls/piecesBatch.raml
+++ b/ramls/piecesBatch.raml
@@ -1,0 +1,51 @@
+#%RAML 1.0
+title: "Orders Storage"
+baseUri: http://github.com/org/folio/mod-orders-storage
+version: v3.2
+
+
+documentation:
+ - title: Pieces Batch
+   content:  <b>This module implements the pieces batch processing interface. This API is intended for internal use only. </b>
+
+
+types:
+   piece_collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
+   UUID:
+    type: string
+    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
+
+
+traits:
+   orderable: !include raml-util/traits/orderable.raml
+   pageable:  !include raml-util/traits/pageable.raml
+   searchable: !include raml-util/traits/searchable.raml
+
+
+resourceTypes:
+   collection: !include raml-util/rtypes/collection.raml
+   collection-item: !include raml-util/rtypes/item-collection.raml
+
+
+/orders-storage/pieces-batch:
+ type:
+   collection:
+     exampleCollection: !include acq-models/mod-orders-storage/examples/piece_collection.sample
+     exampleItem: !include acq-models/mod-orders-storage/examples/piece_post.sample
+     schemaCollection: piece_collection
+ delete:
+   description: delete collection of pieces
+   is: [
+     searchable: {description: "with valid searchable fields: for example code", example: "[\"code\", \"MEDGRANT\", \"=\"]"},
+     pageable
+   ]
+ /piecesCollection:
+   uriParameters:
+     pieceCollection:
+       description: A Collection of Pieces
+       type: collection
+   type:
+     collection-item:
+       exampleItem: !include acq-models/mod-orders-storage/examples/piece_get.sample
+       schema: piece
+

--- a/ramls/piecesBatch.raml
+++ b/ramls/piecesBatch.raml
@@ -3,49 +3,39 @@ title: "Orders Storage"
 baseUri: http://github.com/org/folio/mod-orders-storage
 version: v3.2
 
-
 documentation:
- - title: Pieces Batch
-   content:  <b>This module implements the pieces batch processing interface. This API is intended for internal use only. </b>
-
+  - title: Pieces Batch
+    content: <b>API to manage batch operations for Pieces. This batch API allows for creating, updating, and deleting multiple pieces in one request.</b>
 
 types:
-   piece_collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
-   UUID:
-    type: string
-    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
-
+    piece: !include acq-models/mod-orders-storage/schemas/piece.json
+    piece_collection: !include acq-models/mod-orders-storage/schemas/piece_collection.json
+    UUID:
+     type: string
+     pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-f]{3}-[0-9a-fA-F]{12}$
 
 traits:
-   orderable: !include raml-util/traits/orderable.raml
-   pageable:  !include raml-util/traits/pageable.raml
-   searchable: !include raml-util/traits/searchable.raml
-
+    orderable: !include raml-util/traits/orderable.raml
+    pageable:  !include raml-util/traits/pageable.raml
+    searchable: !include raml-util/traits/searchable.raml
 
 resourceTypes:
-   collection: !include raml-util/rtypes/collection.raml
-   collection-item: !include raml-util/rtypes/item-collection.raml
-
+    collection: !include raml-util/rtypes/collection.raml
+    collection-item: !include raml-util/rtypes/item-collection.raml
 
 /orders-storage/pieces-batch:
- type:
-   collection:
-     exampleCollection: !include acq-models/mod-orders-storage/examples/piece_collection.sample
-     exampleItem: !include acq-models/mod-orders-storage/examples/piece_post.sample
-     schemaCollection: piece_collection
- delete:
-   description: delete collection of pieces
-   is: [
-     searchable: {description: "with valid searchable fields: for example code", example: "[\"code\", \"MEDGRANT\", \"=\"]"},
-     pageable
-   ]
- /piecesCollection:
-   uriParameters:
-     pieceCollection:
-       description: A Collection of Pieces
-       type: collection
-   type:
-     collection-item:
-       exampleItem: !include acq-models/mod-orders-storage/examples/piece_get.sample
-       schema: piece
-
+  delete:
+    description: Delete multiple pieces in a batch.
+    body:
+      application/json:
+        type: piece_collection
+        example: !include acq-models/mod-orders-storage/examples/piece_collection.sample
+    responses:
+      204:
+        description: Successfully deleted pieces.
+      400:
+        description: Bad request, e.g., malformed JSON.
+      404:
+        description: Not found, one or more pieces do not exist.
+      500:
+        description: Internal server error, e.g., database error.

--- a/src/main/java/org/folio/rest/impl/PiecesAPIBatch.java
+++ b/src/main/java/org/folio/rest/impl/PiecesAPIBatch.java
@@ -45,27 +45,6 @@ public class PiecesAPIBatch extends BaseApi implements OrdersStoragePiecesBatch 
     pgClient = pgClientFactory.createInstance(tenantId);
   }
 
-
-  @Override
-  @Validate
-  public void deleteOrdersStoragePiecesByBatch(PieceCollection pieceCollection, Map<String, String> okapiHeaders,
-                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    Future.all(pieceCollection.getPieces().stream()
-        .map(piece -> PgUtil.deleteById(PIECES_TABLE, piece.getId(), okapiHeaders, vertxContext, OrdersStoragePieces.DeleteOrdersStoragePiecesByIdResponse.class)
-          .onFailure(t -> log.error("Failed to delete piece with ID: {}", piece.getId()))
-          .mapEmpty())
-        .collect(Collectors.toList()))
-      .onComplete(ar -> {
-        if (ar.failed()) {
-          log.error("deleteOrdersStoragePiecesBatch:: failed, piece ids: {}", getPieceIdsForLogMessage(pieceCollection.getPieces()), ar.cause());
-          asyncResultHandler.handle(buildErrorResponse(ar.cause()));
-        } else {
-          log.info("deleteOrdersStoragePiecesBatch:: completed, piece ids: {}", getPieceIdsForLogMessage(pieceCollection.getPieces()));
-          asyncResultHandler.handle(buildNoContentResponse());
-        }
-      });
-  }
-
   private String getPieceIdsForLogMessage(List<Piece> pieces) {
     return pieces.stream()
       .map(Piece::getId)
@@ -77,5 +56,22 @@ public class PiecesAPIBatch extends BaseApi implements OrdersStoragePiecesBatch 
   }
 
 
-
+  @Override
+  @Validate
+  public void deleteOrdersStoragePiecesBatch(PieceCollection entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    Future.all(entity.getPieces().stream()
+        .map(piece -> PgUtil.deleteById(PIECES_TABLE, piece.getId(), okapiHeaders, vertxContext, OrdersStoragePieces.DeleteOrdersStoragePiecesByIdResponse.class)
+          .onFailure(t -> log.error("Failed to delete piece with ID: {}", piece.getId()))
+          .mapEmpty())
+        .collect(Collectors.toList()))
+      .onComplete(ar -> {
+        if (ar.failed()) {
+          log.error("deleteOrdersStoragePiecesBatch:: failed, piece ids: {}", getPieceIdsForLogMessage(entity.getPieces()), ar.cause());
+          asyncResultHandler.handle(buildErrorResponse(ar.cause()));
+        } else {
+          log.info("deleteOrdersStoragePiecesBatch:: completed, piece ids: {}", getPieceIdsForLogMessage(entity.getPieces()));
+          asyncResultHandler.handle(buildNoContentResponse());
+        }
+      });
+  }
 }

--- a/src/main/java/org/folio/rest/impl/PiecesAPIBatch.java
+++ b/src/main/java/org/folio/rest/impl/PiecesAPIBatch.java
@@ -1,0 +1,81 @@
+package org.folio.rest.impl;
+
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dao.PostgresClientFactory;
+import org.folio.event.service.AuditOutboxService;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.core.BaseApi;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.PieceCollection;
+import org.folio.rest.jaxrs.resource.OrdersStoragePieces;
+import org.folio.rest.jaxrs.resource.OrdersStoragePiecesBatch;
+import org.folio.rest.persist.HelperUtils;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class PiecesAPIBatch extends BaseApi implements OrdersStoragePiecesBatch {
+  private static final Logger log = LogManager.getLogger();
+
+  public static final String PIECES_TABLE = "pieces";
+
+  private final PostgresClient pgClient;
+
+  @Autowired
+  private AuditOutboxService auditOutboxService;
+  @Autowired
+  private PostgresClientFactory pgClientFactory;
+  private static final Logger logger = LogManager.getLogger();
+  @Autowired
+  public PiecesAPIBatch(Vertx vertx, String tenantId) {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+    log.trace("Init PiecesAPI creating PostgresClient");
+    pgClient = pgClientFactory.createInstance(tenantId);
+  }
+
+
+  @Override
+  @Validate
+  public void deleteOrdersStoragePiecesByBatch(PieceCollection pieceCollection, Map<String, String> okapiHeaders,
+                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    Future.all(pieceCollection.getPieces().stream()
+        .map(piece -> PgUtil.deleteById(PIECES_TABLE, piece.getId(), okapiHeaders, vertxContext, OrdersStoragePieces.DeleteOrdersStoragePiecesByIdResponse.class)
+          .onFailure(t -> log.error("Failed to delete piece with ID: {}", piece.getId()))
+          .mapEmpty())
+        .collect(Collectors.toList()))
+      .onComplete(ar -> {
+        if (ar.failed()) {
+          log.error("deleteOrdersStoragePiecesBatch:: failed, piece ids: {}", getPieceIdsForLogMessage(pieceCollection.getPieces()), ar.cause());
+          asyncResultHandler.handle(buildErrorResponse(ar.cause()));
+        } else {
+          log.info("deleteOrdersStoragePiecesBatch:: completed, piece ids: {}", getPieceIdsForLogMessage(pieceCollection.getPieces()));
+          asyncResultHandler.handle(buildNoContentResponse());
+        }
+      });
+  }
+
+  private String getPieceIdsForLogMessage(List<Piece> pieces) {
+    return pieces.stream()
+      .map(Piece::getId)
+      .collect(Collectors.joining(", "));
+  }
+
+  protected String getEndpoint(Object entity) {
+    return HelperUtils.getEndpoint(OrdersStoragePiecesBatch.class);
+  }
+
+
+
+}


### PR DESCRIPTION
Purpose: Libraries that use the Receiving app for receipt of print serials may wish to delete pieces that precede a specific date. Currently, FOLIO supports the deletion of pieces, but one at a time. When a library wishes to purge receiving records for multiple years on an ongoing workflow, the ability to delete pieces in bulk will streamline this workflow. 

Weeding old journal issues; receiving records no longer necessary since items have been withdrawn

User story statement(s):

As a serials librarian,
I want to delete multiple pieces at one time
so that the continuous addition of pieces does not eventually impact performance of the Receiving app.

Scenarios:

Bulk edit received/expected pieces:

Given user has received multiple piece records for a given receiving title

When expanding received/expected pieces accordion

Then user has option in action menu for Bulk edit

Select one or more pieces:

Given user clicks Bulk edit

When toggles appear in table

Then user can select one or more pieces

Edit pieces:

Given user has selected one or more pieces

When user clicks edit piece button

Then Bulk edit piece form is displayed

Delete all pieces

Given user clicks edit piece button

When Bulk edit piece form is displayed

Then "Delete all" button is active

Delete all pieces confirmation

Given user is viewing Bulk edit piece form

When user clicks "Delete all"

Then confirmation modal is shown

Message: "This will permanently remove all the pieces you have selected. Any related items with a status of "On order" will also be deleted. Would you like to proceed?

AND user can confirm or cancel

Library enhancement suggested by Lafayette College (May 2022 adopter)
