### PR TITLE
[MODORDSTOR-PTF-OPT]. Add RMB-generated bindItemId Btree index

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -575,6 +575,10 @@
         {
           "fieldName": "supplement",
           "caseSensitive": false
+        },
+        {
+          "fieldName": "bindItemId",
+          "caseSensitive": false
         }
       ],
       "fullTextIndex": [


### PR DESCRIPTION
## Purpose

- New Bind Pieces functionally add a new `bindItemId` property on the Piece table, this new property needs a Btree index to improve fetching

## Approach

- Add RMB-generated `bindItemId` Btree index
