### PR TITLE
[MODORDSTOR_IDX_FIX]. Remove faulty purchase_order_no_acq_unit index

### DIFF
--- a/src/main/resources/templates/db_scripts/purchase_order_table.sql
+++ b/src/main/resources/templates/db_scripts/purchase_order_table.sql
@@ -3,6 +3,3 @@ CREATE UNIQUE INDEX IF NOT EXISTS purchase_order_po_number_unique_idx ON ${myuni
 
 CREATE INDEX IF NOT EXISTS purchase_order_customfields_recordservice_idx_gin
   ON ${myuniversity}_${mymodule}.purchase_order USING GIN ((jsonb->'customFields'));
-
-CREATE INDEX IF NOT EXISTS purchase_order_no_acq_unit ON ${myuniversity}_${mymodule}.purchase_order(jsonb)
-  WHERE left(lower(f_unaccent(jsonb ->> 'acqUnitIds')), 600) NOT LIKE '[]';


### PR DESCRIPTION
## Purpose

- Remove faulty purchase_order_no_acq_unit index thats break installation in older versions of PG DB (v12)

## Approach

- Remove custom the index from the installation script