### PR TITLE
Hot Fix Release v13.7.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 ## 13.8.0 - Unreleased
 
+## 13.7.4 - Released (Quesnelia R1 2024)
+This release focused on remove faulty particular field index
+[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v13.7.3...v13.7.4)
+
+### Bug Fixes
+* [MODORDSTOR_IDX_FIX] - Remove faulty purchase_order_no_acq_unit index
+
+
 ## 13.7.3 - Released (Quesnelia R1 2024)
 This release focused on adding indexes to speed up Orders and Receiving filtering  
 [Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v13.7.2...v13.7.3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 ## 13.8.0 - Unreleased
 
 ## 13.7.4 - Released (Quesnelia R1 2024)
-This release focused on remove faulty particular field index
+This release focused on remove faulty particular field index that breaks installation in older versions of PG DB (v12)
 [Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v13.7.3...v13.7.4)
 
 ### Bug Fixes
-* [MODORDSTOR-406](https://folio-org.atlassian.net/browse/MODORDSTOR-406) -  Remove faulty purchase_order_no_acq_unit index
+* [MODORDSTOR-406](https://folio-org.atlassian.net/browse/MODORDSTOR-406) -  Remove faulty purchase_order_no_acq_unit index that breaks installation in older versions of PG DB (v12)
 
 
 ## 13.7.3 - Released (Quesnelia R1 2024)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ This release focused on remove faulty particular field index
 [Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v13.7.3...v13.7.4)
 
 ### Bug Fixes
-* [MODORDSTOR_IDX_FIX] - Remove faulty purchase_order_no_acq_unit index
+* [MODORDSTOR-406](https://folio-org.atlassian.net/browse/MODORDSTOR-406) -  Remove faulty purchase_order_no_acq_unit index
 
 
 ## 13.7.3 - Released (Quesnelia R1 2024)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>13.7.4</version>
+  <version>13.7.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -635,7 +635,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v13.7.4</tag>
+    <tag>v13.7.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>13.7.4-SNAPSHOT</version>
+  <version>13.7.4</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -635,7 +635,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v13.7.0</tag>
+    <tag>v13.7.4</tag>
   </scm>
 
 </project>

--- a/src/main/resources/templates/db_scripts/purchase_order_table.sql
+++ b/src/main/resources/templates/db_scripts/purchase_order_table.sql
@@ -1,10 +1,8 @@
 CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.po_number MAXVALUE 9999999999999999 START WITH 10000 CACHE 1 NO CYCLE;
 GRANT USAGE ON SEQUENCE ${myuniversity}_${mymodule}.po_number TO ${myuniversity}_${mymodule};
 
+CREATE UNIQUE INDEX IF NOT EXISTS purchase_order_po_number_unique_idx ON ${myuniversity}_${mymodule}.purchase_order
+  ((jsonb->>'poNumber'));
 
-CREATE UNIQUE INDEX IF NOT EXISTS purchase_order_po_number_unique_idx ON ${myuniversity}_${mymodule}.purchase_order ((jsonb->>'poNumber'));
 CREATE INDEX IF NOT EXISTS purchase_order_customfields_recordservice_idx_gin
-ON ${myuniversity}_${mymodule}.purchase_order USING GIN ((jsonb->'customFields'));
-
-CREATE INDEX IF NOT EXISTS purchase_order_no_acq_unit ON ${myuniversity}_${mymodule}.purchase_order(jsonb)
-  WHERE left(lower(f_unaccent(jsonb ->> 'acqUnitIds')), 600) NOT LIKE '[]';
+  ON ${myuniversity}_${mymodule}.purchase_order USING GIN ((jsonb->'customFields'));

--- a/src/main/resources/templates/db_scripts/purchase_order_table.sql
+++ b/src/main/resources/templates/db_scripts/purchase_order_table.sql
@@ -1,8 +1,7 @@
 CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.po_number MAXVALUE 9999999999999999 START WITH 10000 CACHE 1 NO CYCLE;
 GRANT USAGE ON SEQUENCE ${myuniversity}_${mymodule}.po_number TO ${myuniversity}_${mymodule};
 
-CREATE UNIQUE INDEX IF NOT EXISTS purchase_order_po_number_unique_idx ON ${myuniversity}_${mymodule}.purchase_order
-  ((jsonb->>'poNumber'));
 
+CREATE UNIQUE INDEX IF NOT EXISTS purchase_order_po_number_unique_idx ON ${myuniversity}_${mymodule}.purchase_order ((jsonb->>'poNumber'));
 CREATE INDEX IF NOT EXISTS purchase_order_customfields_recordservice_idx_gin
-  ON ${myuniversity}_${mymodule}.purchase_order USING GIN ((jsonb->'customFields'));
+ON ${myuniversity}_${mymodule}.purchase_order USING GIN ((jsonb->'customFields'));


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDSTOR-413
* Remove faulty purchase_order_no_acq_unit index thats break installation in older versions of PG DB (v12)
## Approach
Releasing pr https://github.com/folio-org/mod-orders-storage/pull/429

