### PR TITLE
[MODORDSTOR-416] Add kafka consumer for Holdings Create events with processing logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>3.1.3</version>
+    </dependency>
+    <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
       <version>3.3.0</version>

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -22,6 +22,7 @@ import org.folio.rest.jaxrs.model.CreateInventoryType;
 import org.folio.rest.jaxrs.model.OrderLinePatchOperationType;
 import org.folio.service.UserService;
 import org.folio.services.configuration.TenantLocaleSettingsService;
+import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.lines.PoLineNumbersService;
 import org.folio.services.lines.PoLinesBatchService;
 import org.folio.services.lines.PoLinesService;
@@ -186,4 +187,10 @@ public class ApplicationConfig {
                                             TenantLocaleSettingsService tenantLocaleSettingsService) {
     return new PieceClaimingService(pgClientFactory, extensionRepository, pieceClaimingRepository, tenantLocaleSettingsService);
   }
+
+  @Bean
+  ConsortiumConfigurationService consortiumConfigurationService(Vertx vertx) {
+    return new ConsortiumConfigurationService(vertx);
+  }
+
 }

--- a/src/main/java/org/folio/dao/lines/PoLinesDAO.java
+++ b/src/main/java/org/folio/dao/lines/PoLinesDAO.java
@@ -14,4 +14,5 @@ public interface PoLinesDAO {
   Future<List<PoLine>> getPoLines(Criterion criterion, Conn conn);
   Future<PoLine> getPoLineById(String id, DBClient client);
   Future<Integer> updatePoLines(String sql, Conn conn);
+  Future<Integer> updatePoLines(String sql, DBClient client);
 }

--- a/src/main/java/org/folio/dao/lines/PoLinesDAO.java
+++ b/src/main/java/org/folio/dao/lines/PoLinesDAO.java
@@ -14,5 +14,5 @@ public interface PoLinesDAO {
   Future<List<PoLine>> getPoLines(Criterion criterion, Conn conn);
   Future<PoLine> getPoLineById(String id, DBClient client);
   Future<Integer> updatePoLines(String sql, Conn conn);
-  Future<Integer> updatePoLines(String sql, DBClient client);
+
 }

--- a/src/main/java/org/folio/dao/lines/PoLinesPostgresDAO.java
+++ b/src/main/java/org/folio/dao/lines/PoLinesPostgresDAO.java
@@ -64,27 +64,11 @@ public class PoLinesPostgresDAO implements PoLinesDAO {
 
   @Override
   public Future<Integer> updatePoLines(String sql, Conn conn) {
-    log.debug("updatePoLines, sql={}", sql);
-    Promise<Integer> promise = Promise.promise();
-    conn.execute(sql)
-      .onSuccess(result -> {
-        log.debug("updatePoLines success, sql={}", sql);
-        promise.complete(result.rowCount());
-      })
-      .onFailure(t -> {
-        log.error("updatePoLines failed, sql={}", sql, t);
-        handleFailure(promise, t);
-      });
-    return promise.future();
-  }
-
-  @Override
-  public Future<Integer> updatePoLines(String sql, DBClient dbClient) {
-    log.debug("updatePoLines, sql={}", sql);
-    return dbClient.getPgClient().execute(sql)
+    log.debug("updatePoLines:: sql={}", sql);
+    return conn.execute(sql)
       .map(SqlResult::rowCount)
-      .onSuccess(result -> log.debug("updatePoLines success, sql={}", sql))
-      .onFailure(t -> log.error("updatePoLines failed, sql={}", sql, t));
-
+      .onSuccess(result -> log.debug("updatePoLines:: success, sql={}", sql))
+      .onFailure(t -> log.error("updatePoLines:: failed, sql={}", sql, t));
   }
+
 }

--- a/src/main/java/org/folio/dao/lines/PoLinesPostgresDAO.java
+++ b/src/main/java/org/folio/dao/lines/PoLinesPostgresDAO.java
@@ -83,12 +83,8 @@ public class PoLinesPostgresDAO implements PoLinesDAO {
     log.debug("updatePoLines, sql={}", sql);
     return dbClient.getPgClient().execute(sql)
       .map(SqlResult::rowCount)
-      .onSuccess(result -> {
-        log.debug("updatePoLines success, sql={}", sql);
-      })
-      .onFailure(t -> {
-        log.error("updatePoLines failed, sql={}", sql, t);
-      });
+      .onSuccess(result -> log.debug("updatePoLines success, sql={}", sql))
+      .onFailure(t -> log.error("updatePoLines failed, sql={}", sql, t));
 
   }
 }

--- a/src/main/java/org/folio/dao/lines/PoLinesPostgresDAO.java
+++ b/src/main/java/org/folio/dao/lines/PoLinesPostgresDAO.java
@@ -18,6 +18,7 @@ import org.folio.rest.persist.Criteria.Criterion;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.SqlResult;
 
 
 public class PoLinesPostgresDAO implements PoLinesDAO {
@@ -75,5 +76,19 @@ public class PoLinesPostgresDAO implements PoLinesDAO {
         handleFailure(promise, t);
       });
     return promise.future();
+  }
+
+  @Override
+  public Future<Integer> updatePoLines(String sql, DBClient dbClient) {
+    log.debug("updatePoLines, sql={}", sql);
+    return dbClient.getPgClient().execute(sql)
+      .map(SqlResult::rowCount)
+      .onSuccess(result -> {
+        log.debug("updatePoLines success, sql={}", sql);
+      })
+      .onFailure(t -> {
+        log.error("updatePoLines failed, sql={}", sql, t);
+      });
+
   }
 }

--- a/src/main/java/org/folio/event/InventoryEventType.java
+++ b/src/main/java/org/folio/event/InventoryEventType.java
@@ -1,15 +1,16 @@
 package org.folio.event;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-@AllArgsConstructor
 public enum InventoryEventType {
-  INVENTORY_ITEM_CREATE("inventory.item", EventType.CREATE);
 
-  private String topicName;
-  private EventType eventType;
+  INVENTORY_ITEM_CREATE("inventory.item", EventType.CREATE),
+  INVENTORY_HOLDING_CREATE("inventory.holdings-record", EventType.CREATE);
+
+  private final String topicName;
+  private final EventType eventType;
+
 }

--- a/src/main/java/org/folio/event/dto/InventoryFields.java
+++ b/src/main/java/org/folio/event/dto/InventoryFields.java
@@ -1,15 +1,15 @@
 package org.folio.event.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@AllArgsConstructor
 @Getter
-public enum ItemField {
+public enum InventoryFields {
+
   ID("id"),
   HOLDINGS_RECORD_ID("holdingsRecordId");
 
-  private String value;
+  private final String value;
+
 }

--- a/src/main/java/org/folio/event/dto/ResourceEvent.java
+++ b/src/main/java/org/folio/event/dto/ResourceEvent.java
@@ -1,12 +1,17 @@
 package org.folio.event.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.folio.event.EventType;
 
 @Data
 @RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
 public class ResourceEvent {
   private String id;
   private EventType type;

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -3,17 +3,21 @@ package org.folio.event.handler;
 import static org.folio.event.InventoryEventType.INVENTORY_HOLDING_CREATE;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.Logger;
 import org.folio.event.dto.InventoryFields;
 import org.folio.event.dto.ResourceEvent;
+import org.folio.models.ConsortiumConfiguration;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.persist.DBClient;
+import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.lines.PoLinesService;
 import org.folio.services.piece.PieceService;
 import org.folio.spring.SpringContextUtil;
@@ -33,6 +37,9 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
 
   @Autowired
   private PoLinesService poLinesService;
+
+  @Autowired
+  private ConsortiumConfigurationService consortiumConfigurationService;
 
   public HoldingCreateAsyncRecordHandler(Vertx vertx, Context context) {
     super(INVENTORY_HOLDING_CREATE, vertx, context);
@@ -89,6 +96,11 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
     locations.stream()
       .filter(location -> Objects.equals(location.getHoldingId(), holdingId))
       .forEach(location -> location.setTenantId(tenantId));
+  }
+
+  @Override
+  protected Future<Optional<ConsortiumConfiguration>> getConsortiumConfiguration(Map<String, String> headers) {
+    return consortiumConfigurationService.getConsortiumConfiguration(headers);
   }
 
   @Override

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -34,7 +34,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
   @Autowired
   private PoLinesService poLinesService;
 
-  public HoldingCreateAsyncRecordHandler(Context context, Vertx vertx) {
+  public HoldingCreateAsyncRecordHandler(Vertx vertx, Context context) {
     super(INVENTORY_HOLDING_CREATE, vertx, context);
     SpringContextUtil.autowireDependencies(this, context);
   }

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -62,7 +62,9 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
           processPoLinesUpdate(holdingId, tenantId, headers, conn),
           processPiecesUpdate(holdingId, tenantId, headers, conn)
         );
-        return GenericCompositeFuture.all(tenantIdUpdates).mapEmpty();
+        return GenericCompositeFuture.all(tenantIdUpdates)
+          .onSuccess(ar -> auditOutboxService.processOutboxEventLogs(headers))
+          .mapEmpty();
       });
   }
 

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -1,0 +1,86 @@
+package org.folio.event.handler;
+
+import static org.folio.event.InventoryEventType.INVENTORY_HOLDING_CREATE;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.logging.log4j.Logger;
+import org.folio.event.dto.InventoryFields;
+import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.rest.jaxrs.model.Location;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.persist.DBClient;
+import org.folio.services.lines.PoLinesService;
+import org.folio.services.piece.PieceService;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHandler {
+
+  @Autowired
+  private PieceService pieceService;
+
+  @Autowired
+  private PoLinesService poLinesService;
+
+  public HoldingCreateAsyncRecordHandler(Context context, Vertx vertx) {
+    super(INVENTORY_HOLDING_CREATE, vertx, context);
+    SpringContextUtil.autowireDependencies(this, context);
+  }
+
+  @Override
+  protected Future<Void> processInventoryCreationEvent(JsonObject holdingObject, String tenantId) {
+    var holdingId = holdingObject.getString(InventoryFields.ID.getValue());
+    var dbClient = new DBClient(getVertx(), tenantId);
+    var tenantIdUpdates = List.of(
+      processPoLinesUpdate(holdingId, tenantId, dbClient),
+      processPiecesUpdate(holdingId, tenantId, dbClient)
+    );
+    return GenericCompositeFuture.all(tenantIdUpdates).mapEmpty();
+  }
+
+  private Future<Void> processPoLinesUpdate(String holdingId, String tenantId, DBClient dbClient) {
+    return poLinesService.getPoLinesByHoldingId(holdingId, dbClient)
+      .compose(poLines -> updatePoLines(poLines, holdingId, tenantId, dbClient));
+  }
+
+  private Future<Void> processPiecesUpdate(String holdingId, String tenantId, DBClient dbClient) {
+    return pieceService.getPiecesByHoldingId(holdingId, dbClient)
+      .compose(pieces -> updatePieces(pieces, holdingId, tenantId, dbClient));
+  }
+
+  private Future<Void> updatePoLines(List<PoLine> poLines, String holdingId, String tenantId, DBClient dbClient) {
+    log.info("updatePoLines:: Updating {} poLine(s) with holdingId '{}', setting receivingTenantId to '{}'", poLines.size(), holdingId, tenantId);
+    poLines.forEach(poLine -> updateLocationTenantIdIfNeeded(poLine.getLocations(), holdingId, tenantId));
+    return dbClient.getPgClient()
+      .withConn(conn -> poLinesService.updatePoLines(poLines, conn, tenantId))
+      .mapEmpty();
+  }
+
+  private Future<Void> updatePieces(List<Piece> pieces, String holdingId, String tenantId, DBClient client) {
+    log.info("updatePieces:: Updating {} piece(s) with holdingId '{}', setting receivingTenantId to '{}'", pieces.size(), holdingId, tenantId);
+    pieces.forEach(piece -> piece.setReceivingTenantId(tenantId));
+    return pieceService.updatePieces(pieces, client);
+  }
+
+  private void updateLocationTenantIdIfNeeded(List<Location> locations, String holdingId, String tenantId) {
+    locations.stream()
+      .filter(location -> Objects.equals(location.getHoldingId(), holdingId))
+      .forEach(location -> location.setTenantId(tenantId));
+  }
+
+  @Override
+  protected Logger getLogger() {
+    return log;
+  }
+
+}

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import org.apache.logging.log4j.Logger;
 import org.folio.event.dto.InventoryFields;
+import org.folio.event.dto.ResourceEvent;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Piece;
@@ -38,7 +39,8 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
   }
 
   @Override
-  protected Future<Void> processInventoryCreationEvent(JsonObject holdingObject, String tenantId) {
+  protected Future<Void> processInventoryCreationEvent(ResourceEvent resourceEvent, String tenantId) {
+    var holdingObject = JsonObject.mapFrom(resourceEvent.getNewValue());
     var holdingId = holdingObject.getString(InventoryFields.ID.getValue());
     var dbClient = new DBClient(getVertx(), tenantId);
     var tenantIdUpdates = List.of(

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -47,7 +47,8 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
   }
 
   @Override
-  protected Future<Void> processInventoryCreationEvent(ResourceEvent resourceEvent, String tenantId, Map<String, String> headers, DBClient dbClient) {
+  protected Future<Void> processInventoryCreationEvent(ResourceEvent resourceEvent, String tenantId,
+                                                       Map<String, String> headers, DBClient dbClient) {
     var holdingObject = JsonObject.mapFrom(resourceEvent.getNewValue());
     var holdingId = holdingObject.getString(InventoryFields.ID.getValue());
     return dbClient.getPgClient()
@@ -72,7 +73,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
   private Future<Void> processPiecesUpdate(String holdingId, String tenantId, Map<String, String> headers, Conn conn) {
     return pieceService.getPiecesByHoldingId(holdingId, conn)
       .compose(pieces -> updatePieces(pieces, holdingId, tenantId, conn))
-      .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.CREATE, headers))
+      .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.EDIT, headers))
       .mapEmpty();
   }
 
@@ -81,7 +82,8 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
       log.info("updatePoLines:: No poLines to update for holding: '{}' and tenant: '{}'", holdingId, tenantId);
       return Future.succeededFuture(List.of());
     }
-    log.info("updatePoLines:: Updating {} poLine(s) with holdingId '{}', setting receivingTenantId to '{}'", poLines.size(), holdingId, tenantId);
+    log.info("updatePoLines:: Updating {} poLine(s) with holdingId '{}', setting receivingTenantId to '{}'",
+      poLines.size(), holdingId, tenantId);
     poLines.forEach(poLine -> updateLocationTenantIdIfNeeded(poLine.getLocations(), holdingId, tenantId));
     return poLinesService.updatePoLines(poLines, conn, tenantId)
       .map(v -> poLines);
@@ -96,7 +98,8 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
       log.info("updatePieces:: No pieces to update for holding: '{}' and tenant: '{}'", holdingId, tenantId);
       return Future.succeededFuture(List.of());
     }
-    log.info("updatePieces:: Updating {} piece(s) with holdingId '{}', setting receivingTenantId to '{}'", pieces.size(), holdingId, tenantId);
+    log.info("updatePieces:: Updating {} piece(s) with holdingId '{}', setting receivingTenantId to '{}'",
+      pieces.size(), holdingId, tenantId);
     return pieceService.updatePieces(piecesToUpdate, conn, tenantId);
   }
 

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -62,9 +62,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
           processPoLinesUpdate(holdingId, tenantId, headers, conn),
           processPiecesUpdate(holdingId, tenantId, headers, conn)
         );
-        return GenericCompositeFuture.all(tenantIdUpdates)
-          .onSuccess(ar -> auditOutboxService.processOutboxEventLogs(headers))
-          .mapEmpty();
+        return GenericCompositeFuture.all(tenantIdUpdates).mapEmpty();
       });
   }
 
@@ -72,6 +70,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
     return poLinesService.getPoLinesByHoldingId(holdingId, conn)
       .compose(poLines -> updatePoLines(poLines, holdingId, tenantId, conn))
       .compose(poLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, poLines, OrderLineAuditEvent.Action.EDIT, headers))
+      .onSuccess(ar -> auditOutboxService.processOutboxEventLogs(headers))
       .mapEmpty();
   }
 
@@ -79,6 +78,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
     return pieceService.getPiecesByHoldingId(holdingId, conn)
       .compose(pieces -> updatePieces(pieces, holdingId, tenantId, conn))
       .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.CREATE, headers))
+      .onSuccess(ar -> auditOutboxService.processOutboxEventLogs(headers))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
@@ -50,9 +50,8 @@ public abstract class InventoryCreateAsyncRecordHandler extends BaseAsyncRecordH
         return Future.succeededFuture();
       }
 
-      var inventoryObject = JsonObject.mapFrom(resourceEvent.getNewValue());
       var tenantId = extractTenantFromHeaders(kafkaConsumerRecord.headers());
-      return processInventoryCreationEvent(inventoryObject, tenantId)
+      return processInventoryCreationEvent(resourceEvent, tenantId)
         .onSuccess(v -> getLogger().info("handle:: '{}' event for '{}' processed successfully", eventType, inventoryEventType.getTopicName()))
         .onFailure(t -> getLogger().error("Failed to process event: {}", kafkaConsumerRecord.value(), t))
         .map(kafkaConsumerRecord.key());
@@ -62,7 +61,7 @@ public abstract class InventoryCreateAsyncRecordHandler extends BaseAsyncRecordH
     }
   }
 
-  protected abstract Future<Void> processInventoryCreationEvent(JsonObject inventoryObject, String tenantId);
+  protected abstract Future<Void> processInventoryCreationEvent(ResourceEvent resourceEvent, String tenantId);
 
   protected abstract Logger getLogger();
 

--- a/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
@@ -37,9 +37,12 @@ public abstract class InventoryCreateAsyncRecordHandler extends BaseAsyncRecordH
   @Override
   public Future<String> handle(KafkaConsumerRecord<String, String> kafkaConsumerRecord) {
     getLogger().debug("handle:: Trying to process kafkaConsumerRecord: {}", kafkaConsumerRecord.value());
-
     try {
-      var resourceEvent = new JsonObject(kafkaConsumerRecord.value()).mapTo(ResourceEvent.class);
+      var eventValue = kafkaConsumerRecord.value();
+      if (eventValue == null) {
+        throw new IllegalArgumentException("Cannot process kafkaConsumerRecord: value is null");
+      }
+      var resourceEvent = new JsonObject(eventValue).mapTo(ResourceEvent.class);
       var eventType = resourceEvent.getType();
       if (!Objects.equals(eventType, inventoryEventType.getEventType())) {
         getLogger().info("handle:: Unsupported event type: {}", eventType);

--- a/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
@@ -1,0 +1,69 @@
+package org.folio.event.handler;
+
+import static org.folio.event.util.KafkaEventUtil.extractTenantFromHeaders;
+
+import java.util.Objects;
+
+import org.apache.logging.log4j.Logger;
+import org.folio.event.InventoryEventType;
+import org.folio.event.dto.ResourceEvent;
+import org.folio.services.lines.PoLinesService;
+import org.folio.services.piece.PieceService;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+public abstract class InventoryCreateAsyncRecordHandler extends BaseAsyncRecordHandler<String, String> {
+
+  @Autowired
+  private PieceService pieceService;
+
+  @Autowired
+  private PoLinesService poLinesService;
+
+  private final InventoryEventType inventoryEventType;
+
+  public InventoryCreateAsyncRecordHandler(InventoryEventType inventoryEventType, Vertx vertx, Context context) {
+    super(vertx, context);
+    SpringContextUtil.autowireDependencies(this, context);
+    this.inventoryEventType = inventoryEventType;
+  }
+
+  @Override
+  public Future<String> handle(KafkaConsumerRecord<String, String> kafkaConsumerRecord) {
+    getLogger().debug("handle:: Trying to process kafkaConsumerRecord: {}", kafkaConsumerRecord.value());
+
+    try {
+      var resourceEvent = new JsonObject(kafkaConsumerRecord.value()).mapTo(ResourceEvent.class);
+      var eventType = resourceEvent.getType();
+      if (!Objects.equals(eventType, inventoryEventType.getEventType())) {
+        getLogger().info("handle:: Unsupported event type: {}", eventType);
+        return Future.succeededFuture();
+      }
+      if (Objects.isNull(resourceEvent.getNewValue())) {
+        getLogger().warn("handle:: Failed to find new version. 'new' is null: {}", resourceEvent);
+        return Future.succeededFuture();
+      }
+
+      var inventoryObject = JsonObject.mapFrom(resourceEvent.getNewValue());
+      var tenantId = extractTenantFromHeaders(kafkaConsumerRecord.headers());
+      return processInventoryCreationEvent(inventoryObject, tenantId)
+        .onSuccess(v -> getLogger().info("handle:: '{}' event for '{}' processed successfully", eventType, inventoryEventType.getTopicName()))
+        .onFailure(t -> getLogger().error("Failed to process event: {}", kafkaConsumerRecord.value(), t))
+        .map(kafkaConsumerRecord.key());
+    } catch (Exception e) {
+      getLogger().error("Failed to process kafkaConsumerRecord: {}", kafkaConsumerRecord, e);
+      return Future.failedFuture(e);
+    }
+  }
+
+  protected abstract Future<Void> processInventoryCreationEvent(JsonObject inventoryObject, String tenantId);
+
+  protected abstract Logger getLogger();
+
+}

--- a/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
@@ -7,10 +7,6 @@ import java.util.Objects;
 import org.apache.logging.log4j.Logger;
 import org.folio.event.InventoryEventType;
 import org.folio.event.dto.ResourceEvent;
-import org.folio.services.lines.PoLinesService;
-import org.folio.services.piece.PieceService;
-import org.folio.spring.SpringContextUtil;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -20,17 +16,10 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
 public abstract class InventoryCreateAsyncRecordHandler extends BaseAsyncRecordHandler<String, String> {
 
-  @Autowired
-  private PieceService pieceService;
-
-  @Autowired
-  private PoLinesService poLinesService;
-
   private final InventoryEventType inventoryEventType;
 
   protected InventoryCreateAsyncRecordHandler(InventoryEventType inventoryEventType, Vertx vertx, Context context) {
     super(vertx, context);
-    SpringContextUtil.autowireDependencies(this, context);
     this.inventoryEventType = inventoryEventType;
   }
 

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -1,20 +1,18 @@
 package org.folio.event.handler;
 
 import static org.folio.event.InventoryEventType.INVENTORY_ITEM_CREATE;
-import static org.folio.event.util.KafkaEventUtil.extractTenantFromHeaders;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
-import org.folio.event.dto.ItemField;
-import org.folio.event.dto.ResourceEvent;
+import org.apache.logging.log4j.Logger;
+import org.folio.event.dto.InventoryFields;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.persist.DBClient;
 import org.folio.services.piece.PieceService;
@@ -22,51 +20,20 @@ import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Log4j2
-public class ItemCreateAsyncRecordHandler extends BaseAsyncRecordHandler<String, String> {
+public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHandler {
 
   @Autowired
   private PieceService pieceService;
 
   public ItemCreateAsyncRecordHandler(Context context, Vertx vertx) {
-    super(vertx, context);
+    super(INVENTORY_ITEM_CREATE, vertx, context);
     SpringContextUtil.autowireDependencies(this, context);
   }
 
   @Override
-  public Future<String> handle(KafkaConsumerRecord<String, String> kafkaConsumerRecord) {
-    log.debug("handle:: Trying to process kafkaRecord={}", kafkaConsumerRecord.value());
-
-    try {
-      var resourceEvent = new JsonObject(kafkaConsumerRecord.value()).mapTo(ResourceEvent.class);
-
-      var eventType = resourceEvent.getType();
-      if (!Objects.equals(eventType, INVENTORY_ITEM_CREATE.getEventType())) {
-        log.info("handle:: unsupported event type: {}", eventType);
-        return Future.succeededFuture();
-      }
-
-      if (Objects.isNull(resourceEvent.getNewValue())) {
-        log.warn("handle:: Failed to find new version. 'new' is null: {}", resourceEvent);
-        return Future.succeededFuture();
-      }
-
-      var tenantId = extractTenantFromHeaders(kafkaConsumerRecord.headers());
-      var dbClient = new DBClient(getVertx(), tenantId);
-      return processItemCreationEvent(resourceEvent, dbClient)
-        .onSuccess(v -> log.info("handle:: item '{}' event processed successfully", eventType))
-        .onFailure(t -> log.error("Failed to process event: {}", kafkaConsumerRecord.value(), t))
-        .map(kafkaConsumerRecord.key());
-    } catch (Exception e) {
-      log.error("Failed to process item event kafka record, kafkaRecord={}", kafkaConsumerRecord, e);
-      return Future.failedFuture(e);
-    }
-  }
-
-  private Future<Void> processItemCreationEvent(ResourceEvent resourceEvent, DBClient dbClient) {
-    var tenantId = resourceEvent.getTenant();
-    var itemObject = JsonObject.mapFrom(resourceEvent.getNewValue());
-    var itemId = itemObject.getString(ItemField.ID.getValue());
-
+  protected Future<Void> processInventoryCreationEvent(JsonObject itemObject, String tenantId) {
+    var itemId = itemObject.getString(InventoryFields.ID.getValue());
+    var dbClient = new DBClient(getVertx(), tenantId);
     return pieceService.getPiecesByItemId(itemId, dbClient)
       .compose(pieces -> updatePieces(pieces, itemObject, tenantId, dbClient));
   }
@@ -74,11 +41,11 @@ public class ItemCreateAsyncRecordHandler extends BaseAsyncRecordHandler<String,
   private Future<Void> updatePieces(List<Piece> pieces, JsonObject itemObject, String tenantId, DBClient client) {
     if (CollectionUtils.isEmpty(pieces)) {
       log.info("updatePieces:: no pieces to update found, nothing to update for item={}, tenant={}",
-        itemObject.getString(ItemField.ID.getValue()), tenantId);
+        itemObject.getString(InventoryFields.ID.getValue()), tenantId);
       return Future.succeededFuture();
     }
 
-    var holdingId = itemObject.getString(ItemField.HOLDINGS_RECORD_ID.getValue());
+    var holdingId = itemObject.getString(InventoryFields.HOLDINGS_RECORD_ID.getValue());
     var updateRequiredPieces = filterPiecesToUpdate(pieces, holdingId, tenantId);
     updatePieceFields(updateRequiredPieces, holdingId, tenantId);
 
@@ -105,6 +72,11 @@ public class ItemCreateAsyncRecordHandler extends BaseAsyncRecordHandler<String,
         piece.setHoldingId(holdingId);
       }
     });
+  }
+
+  @Override
+  protected Logger getLogger() {
+    return log;
   }
 
 }

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -53,7 +53,8 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
       .withTrans(conn -> pieceService.getPiecesByItemId(itemId, conn)
         .compose(pieces -> updatePieces(pieces, itemObject, tenantId, conn))
         .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.CREATE, headers))
-        .mapEmpty());
+        .onSuccess(ar -> auditOutboxService.processOutboxEventLogs(headers)))
+      .mapEmpty();
   }
 
   private Future<List<Piece>> updatePieces(List<Piece> pieces, JsonObject itemObject, String tenantId, Conn conn) {

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -13,6 +13,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.logging.log4j.Logger;
 import org.folio.event.dto.InventoryFields;
+import org.folio.event.dto.ResourceEvent;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.persist.DBClient;
 import org.folio.services.piece.PieceService;
@@ -31,7 +32,8 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
   }
 
   @Override
-  protected Future<Void> processInventoryCreationEvent(JsonObject itemObject, String tenantId) {
+  protected Future<Void> processInventoryCreationEvent(ResourceEvent resourceEvent, String tenantId) {
+    var itemObject = JsonObject.mapFrom(resourceEvent.getNewValue());
     var itemId = itemObject.getString(InventoryFields.ID.getValue());
     var dbClient = new DBClient(getVertx(), tenantId);
     return pieceService.getPiecesByItemId(itemId, dbClient)

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -26,7 +26,7 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
   @Autowired
   private PieceService pieceService;
 
-  public ItemCreateAsyncRecordHandler(Context context, Vertx vertx) {
+  public ItemCreateAsyncRecordHandler(Vertx vertx, Context context) {
     super(INVENTORY_ITEM_CREATE, vertx, context);
     SpringContextUtil.autowireDependencies(this, context);
   }

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -7,15 +7,20 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.logging.log4j.Logger;
 import org.folio.event.dto.InventoryFields;
 import org.folio.event.dto.ResourceEvent;
+import org.folio.models.ConsortiumConfiguration;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.persist.DBClient;
+import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.piece.PieceService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +30,9 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
 
   @Autowired
   private PieceService pieceService;
+
+  @Autowired
+  private ConsortiumConfigurationService consortiumConfigurationService;
 
   public ItemCreateAsyncRecordHandler(Vertx vertx, Context context) {
     super(INVENTORY_ITEM_CREATE, vertx, context);
@@ -72,6 +80,11 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
         piece.setHoldingId(holdingId);
       }
     });
+  }
+
+  @Override
+  protected Future<Optional<ConsortiumConfiguration>> getConsortiumConfiguration(Map<String, String> headers) {
+    return consortiumConfigurationService.getConsortiumConfiguration(headers);
   }
 
   @Override

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -9,21 +9,17 @@ import io.vertx.core.json.JsonObject;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
-import org.apache.logging.log4j.Logger;
 import org.folio.event.dto.InventoryFields;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
-import org.folio.models.ConsortiumConfiguration;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PieceAuditEvent;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
-import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.piece.PieceService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,9 +29,6 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
 
   @Autowired
   private PieceService pieceService;
-
-  @Autowired
-  private ConsortiumConfigurationService consortiumConfigurationService;
 
   @Autowired
   private AuditOutboxService auditOutboxService;
@@ -52,8 +45,8 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
     return new DBClient(getVertx(), tenantId).getPgClient()
       .withTrans(conn -> pieceService.getPiecesByItemId(itemId, conn)
         .compose(pieces -> updatePieces(pieces, itemObject, tenantId, conn))
-        .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.CREATE, headers))
-        .onSuccess(ar -> auditOutboxService.processOutboxEventLogs(headers)))
+        .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.CREATE, headers)))
+      .onSuccess(ar -> auditOutboxService.processOutboxEventLogs(headers))
       .mapEmpty();
   }
 
@@ -89,11 +82,6 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
         piece.setHoldingId(holdingId);
       }
     });
-  }
-
-  @Override
-  protected Future<Optional<ConsortiumConfiguration>> getConsortiumConfiguration(Map<String, String> headers) {
-    return consortiumConfigurationService.getConsortiumConfiguration(headers);
   }
 
 }

--- a/src/main/java/org/folio/event/service/AuditOutboxService.java
+++ b/src/main/java/org/folio/event/service/AuditOutboxService.java
@@ -138,6 +138,28 @@ public class AuditOutboxService {
   }
 
   /**
+   * Saves pieces outbox log.
+   *
+   * @param conn         connection in transaction
+   * @param pieces       the audited pieces
+   * @param action       action for piece
+   * @param okapiHeaders the okapi headers
+   * @return future with saved outbox log in the same transaction
+   */
+  public Future<Boolean> savePiecesOutboxLog(Conn conn,
+                                            List<Piece> pieces,
+                                            PieceAuditEvent.Action action,
+                                            Map<String, String> okapiHeaders) {
+    var futures = pieces.stream()
+      .map(piece -> savePieceOutboxLog(conn, piece, action, okapiHeaders))
+      .toList();
+
+    return GenericCompositeFuture.join(futures)
+      .map(res -> true)
+      .otherwise(t -> false);
+  }
+
+  /**
    * Saves piece outbox log.
    *
    * @param conn         connection in transaction

--- a/src/main/java/org/folio/event/util/KafkaEventUtil.java
+++ b/src/main/java/org/folio/event/util/KafkaEventUtil.java
@@ -21,6 +21,11 @@ public final class KafkaEventUtil {
       .orElseThrow(() -> new IllegalStateException(TENANT_NOT_SPECIFIED_MSG));
   }
 
+  public static String extractTenantFromHeaders(Map<String, String> headers) {
+    return Optional.ofNullable(headers.get(OKAPI_HEADER_TENANT))
+      .orElseThrow(() -> new IllegalStateException(TENANT_NOT_SPECIFIED_MSG));
+  }
+
   public static String extractValueFromHeaders(List<KafkaHeader> headers, String key) {
     return headers.stream()
       .filter(header -> header.key().equalsIgnoreCase(key))

--- a/src/main/java/org/folio/event/util/KafkaEventUtil.java
+++ b/src/main/java/org/folio/event/util/KafkaEventUtil.java
@@ -5,7 +5,9 @@ import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import io.vertx.kafka.client.producer.KafkaHeader;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public final class KafkaEventUtil {
   private static final String TENANT_NOT_SPECIFIED_MSG = "Tenant must be specified in the kafka record " + OKAPI_HEADER_TENANT;
@@ -26,4 +28,10 @@ public final class KafkaEventUtil {
       .map(header -> header.value().toString())
       .orElse(null);
   }
+
+  public static Map<String, String> getHeaderMap(List<KafkaHeader> headers) {
+    return headers.stream()
+      .collect(Collectors.toMap(KafkaHeader::key, header -> header.value().toString()));
+  }
+
 }

--- a/src/main/java/org/folio/models/ConsortiumConfiguration.java
+++ b/src/main/java/org/folio/models/ConsortiumConfiguration.java
@@ -1,0 +1,4 @@
+package org.folio.models;
+
+public record  ConsortiumConfiguration(String centralTenantId, String consortiumId) {
+}

--- a/src/main/java/org/folio/services/consortium/ConsortiumConfigurationService.java
+++ b/src/main/java/org/folio/services/consortium/ConsortiumConfigurationService.java
@@ -1,0 +1,79 @@
+package org.folio.services.consortium;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.folio.models.ConsortiumConfiguration;
+import org.folio.rest.tools.utils.TenantTool;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class ConsortiumConfigurationService {
+
+  private static final String CONSORTIUM_ID_FIELD = "consortiumId";
+  private static final String CENTRAL_TENANT_ID_FIELD = "centralTenantId";
+  private static final String USER_TENANTS_ARRAY_IDENTIFIER = "userTenants";
+  private static final String USER_TENANTS_ENDPOINT = "/user-tenants";
+  private static final String LIMIT_PARAM = "limit";
+
+  private final WebClient webClient;
+  private final AsyncCache<String, Optional<ConsortiumConfiguration>> asyncCache;
+
+  @Value("${orders-storage.cache.consortium-data.expiration.time.seconds:300}")
+  private long cacheExpirationTime;
+
+  public ConsortiumConfigurationService(Vertx vertx) {
+    webClient = WebClient.create(vertx);
+    asyncCache = Caffeine.newBuilder()
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(task -> Vertx.currentContext().runOnContext(v -> task.run()))
+      .buildAsync();
+  }
+
+  public Future<Optional<ConsortiumConfiguration>> getConsortiumConfiguration(Map<String, String> okapiHeaders) {
+    try {
+      var tenantId = TenantTool.tenantId(okapiHeaders);
+      return Future.fromCompletionStage(asyncCache.get(tenantId, (key, executor) -> getConsortiumConfigurationFromRemote(okapiHeaders)));
+    } catch (Exception e) {
+      log.error("Error when retrieving consortium configuration", e);
+      return Future.failedFuture(e);
+    }
+  }
+
+  private CompletableFuture<Optional<ConsortiumConfiguration>> getConsortiumConfigurationFromRemote(Map<String, String> okapiHeaders) {
+    return webClient.get(USER_TENANTS_ENDPOINT)
+      .addQueryParam(LIMIT_PARAM, "1")
+      .putHeaders(new HeadersMultiMap().addAll(okapiHeaders))
+      .send()
+      .map(HttpResponse::bodyAsJsonObject)
+      .map(jsonObject -> jsonObject.getJsonArray(USER_TENANTS_ARRAY_IDENTIFIER))
+      .map(this::extractConsortiumConfiguration)
+      .toCompletionStage()
+      .toCompletableFuture();
+  }
+
+  private Optional<ConsortiumConfiguration> extractConsortiumConfiguration(JsonArray userTenants) {
+    if (userTenants.isEmpty()) {
+      log.debug("getConsortiumConfigurationFromRemote:: Central tenant and consortium id not found");
+      return Optional.empty();
+    }
+    var consortiumId = userTenants.getJsonObject(0).getString(CONSORTIUM_ID_FIELD);
+    var centralTenantId = userTenants.getJsonObject(0).getString(CENTRAL_TENANT_ID_FIELD);
+    log.debug("getConsortiumConfigurationFromRemote:: Found centralTenantId: {} and consortiumId: {}", centralTenantId, consortiumId);
+    return Optional.of(new ConsortiumConfiguration(centralTenantId, consortiumId));
+  }
+
+}

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -54,7 +54,7 @@ import org.folio.rest.tools.utils.MetadataUtil;
 public class PoLinesService {
 
   private static final String POLINE_ID_FIELD = "poLineId";
-  private static final String LOCATIONS_HOLDING_ID_FIELD = "locations[].holdingId";
+  private static final String LOCATIONS_HOLDING_ID_FIELD = "location.holdingId";
 
   private final PoLinesDAO poLinesDAO;
   private final AuditOutboxService auditOutboxService;

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -216,23 +216,18 @@ public class PoLinesService {
     return promise.future();
   }
 
-  public Future<List<PoLine>> getPoLinesByHoldingId(String holdingId, DBClient dbClient) {
+  public Future<List<PoLine>> getPoLinesByHoldingId(String holdingId, Conn conn) {
     var criterion = getCriterionByFieldNameAndValue(LOCATIONS_HOLDING_ID_FIELD, holdingId);
-    return getPoLinesByField(criterion, dbClient);
+    return getPoLinesByField(criterion, conn);
   }
 
-  public Future<List<PoLine>> getPoLinesByField(Criterion criterion, DBClient client) {
-    return getEntitiesByField(PO_LINE_TABLE, PoLine.class, criterion, client);
+  public Future<List<PoLine>> getPoLinesByField(Criterion criterion, Conn conn) {
+    return getEntitiesByField(PO_LINE_TABLE, PoLine.class, criterion, conn);
   }
 
   public Future<Integer> updatePoLines(Collection<PoLine> poLines, Conn conn, String tenantId) {
     String query = buildUpdatePoLineBatchQuery(poLines, tenantId);
     return poLinesDAO.updatePoLines(query, conn);
-  }
-
-  public Future<Integer> updatePoLines(Collection<PoLine> poLines, String tenantId, DBClient dbClient) {
-    String query = buildUpdatePoLineBatchQuery(poLines, tenantId);
-    return poLinesDAO.updatePoLines(query, dbClient);
   }
 
   public Future<Integer> getLastLineNumber(String purchaseOrderId, Conn conn) {

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -230,6 +230,11 @@ public class PoLinesService {
     return poLinesDAO.updatePoLines(query, conn);
   }
 
+  public Future<Integer> updatePoLines(Collection<PoLine> poLines, String tenantId, DBClient dbClient) {
+    String query = buildUpdatePoLineBatchQuery(poLines, tenantId);
+    return poLinesDAO.updatePoLines(query, dbClient);
+  }
+
   public Future<Integer> getLastLineNumber(String purchaseOrderId, Conn conn) {
     return getPoLinesByOrderId(purchaseOrderId, conn)
       .compose(this::getLastLineNumber);

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -13,6 +13,7 @@ import static org.folio.rest.persist.HelperUtils.getCriteriaByFieldNameAndValueN
 import static org.folio.rest.persist.HelperUtils.getCriterionByFieldNameAndValue;
 import static org.folio.rest.persist.HelperUtils.getFullTableName;
 import static org.folio.rest.persist.HelperUtils.getQueryValues;
+import static org.folio.util.DbUtils.getEntitiesByField;
 
 import javax.ws.rs.core.Response;
 import java.util.Collection;
@@ -25,8 +26,6 @@ import java.util.UUID;
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.dao.lines.PoLinesDAO;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.models.CriterionBuilder;
@@ -47,12 +46,15 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.HttpException;
+import lombok.extern.log4j.Log4j2;
 import one.util.streamex.StreamEx;
 import org.folio.rest.tools.utils.MetadataUtil;
 
+@Log4j2
 public class PoLinesService {
-  private static final Logger log = LogManager.getLogger();
+
   private static final String POLINE_ID_FIELD = "poLineId";
+  private static final String LOCATIONS_HOLDING_ID_FIELD = "locations[].holdingId";
 
   private final PoLinesDAO poLinesDAO;
   private final AuditOutboxService auditOutboxService;
@@ -212,6 +214,15 @@ public class PoLinesService {
         }
       });
     return promise.future();
+  }
+
+  public Future<List<PoLine>> getPoLinesByHoldingId(String holdingId, DBClient dbClient) {
+    var criterion = getCriterionByFieldNameAndValue(LOCATIONS_HOLDING_ID_FIELD, holdingId);
+    return getPoLinesByField(criterion, dbClient);
+  }
+
+  public Future<List<PoLine>> getPoLinesByField(Criterion criterion, DBClient client) {
+    return getEntitiesByField(PO_LINE_TABLE, PoLine.class, criterion, client);
   }
 
   public Future<Integer> updatePoLines(Collection<PoLine> poLines, Conn conn, String tenantId) {
@@ -501,7 +512,6 @@ public class PoLinesService {
         }
       });
   }
-
 
   private boolean titleUpdateRequired(Title title, PoLine poLine, Map<String, String> headers) {
     return !title.equals(createTitleObject(poLine, title.getAcqUnitIds(), headers)

--- a/src/main/java/org/folio/services/piece/PieceService.java
+++ b/src/main/java/org/folio/services/piece/PieceService.java
@@ -76,11 +76,6 @@ public class PieceService {
   }
 
   public Future<Void> updatePieces(List<Piece> pieces, DBClient client) {
-    if (CollectionUtils.isEmpty(pieces)) {
-      log.info("updatePieces:: No pieces to update");
-      return Future.succeededFuture();
-    }
-
     String query = buildUpdatePieceBatchQuery(pieces, client.getTenantId());
     return client.getPgClient().execute(query)
       .onSuccess(ar -> log.info("updatePieces:: completed, query={}", query))

--- a/src/main/java/org/folio/util/DbUtils.java
+++ b/src/main/java/org/folio/util/DbUtils.java
@@ -1,21 +1,44 @@
 package org.folio.util;
 
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.folio.rest.core.ResponseUtil.httpHandleFailure;
+
+import java.util.List;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.DBClient;
 
 import io.vertx.core.Future;
 import io.vertx.ext.web.handler.HttpException;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public final class DbUtils {
-
-  private DbUtils() {
-  }
 
   public static Future<RowSet<Row>> failOnNoUpdateOrDelete(RowSet<Row> rowSet) {
     return rowSet.rowCount() > 0 ?
       Future.succeededFuture(rowSet) :
       Future.failedFuture(new HttpException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
   }
+
+  public static <T> Future<List<T>> getEntitiesByField(String tableName, Class<T> entityClass, Criterion criterion, DBClient client) {
+    return client.getPgClient().get(tableName, entityClass, criterion, false)
+      .map(ar -> {
+        var result = ar.getResults();
+        if (result.isEmpty()) {
+          log.info("getEntitiesByField:: No entity of table '{}' was found with criterion: {}", tableName, criterion);
+          return null;
+        }
+        log.trace("getEntitiesByField:: Fetching entities of table '{}' completed with criterion: {}", tableName, criterion);
+        return result;
+      })
+      .recover(throwable -> {
+        log.error("Fetching entities of table '{}' failed with criterion: {}", tableName, criterion, throwable);
+        return Future.failedFuture(httpHandleFailure(throwable));
+      });
+  }
+
+  private DbUtils() {}
 
 }

--- a/src/main/java/org/folio/util/DbUtils.java
+++ b/src/main/java/org/folio/util/DbUtils.java
@@ -4,8 +4,12 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.folio.rest.core.ResponseUtil.httpHandleFailure;
 
 import java.util.List;
+
+import org.apache.commons.collections4.IteratorUtils;
+import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.DBClient;
+import org.folio.rest.persist.interfaces.Results;
 
 import io.vertx.core.Future;
 import io.vertx.ext.web.handler.HttpException;
@@ -22,8 +26,16 @@ public final class DbUtils {
       Future.failedFuture(new HttpException(NOT_FOUND.getStatusCode(), NOT_FOUND.getReasonPhrase()));
   }
 
+  public static <T> Future<List<T>> getEntitiesByField(String tableName, Class<T> entityClass, Criterion criterion, Conn conn) {
+    return handleEntities(conn.get(tableName, entityClass, criterion, false), tableName, criterion);
+  }
+
   public static <T> Future<List<T>> getEntitiesByField(String tableName, Class<T> entityClass, Criterion criterion, DBClient client) {
-    return client.getPgClient().get(tableName, entityClass, criterion, false)
+    return handleEntities(client.getPgClient().get(tableName, entityClass, criterion, false), tableName, criterion);
+  }
+
+  private static <T> Future<List<T>> handleEntities(Future<Results<T>> getEntitiesFuture, String tableName, Criterion criterion) {
+    return getEntitiesFuture
       .map(ar -> {
         var result = ar.getResults();
         if (result.isEmpty()) {
@@ -37,6 +49,12 @@ public final class DbUtils {
         log.error("Fetching entities of table '{}' failed with criterion: {}", tableName, criterion, throwable);
         return Future.failedFuture(httpHandleFailure(throwable));
       });
+  }
+
+  public static <T> List<T> getRowSetAsList(RowSet<Row> rowSet, Class<T> entityClass) {
+    return IteratorUtils.toList(rowSet.iterator()).stream()
+      .map(row -> row.toJson().mapTo(entityClass))
+      .toList();
   }
 
   private DbUtils() {}

--- a/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
+++ b/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
@@ -42,7 +42,7 @@ public abstract class InventoryConsumersVerticle extends AbstractConsumersVertic
     var subscriptionPattern = KafkaTopicNameHelper.formatTopicName(kafkaConfig.getEnvId(), TENANT_ID_PATTERN, eventType.getTopicName());
     log.info("createConsumers:: Creating Inventory Event consumers with subscriptionPattern: {} for evenType: {}", subscriptionPattern, eventType.name());
     var subscriptionDefinition = SubscriptionDefinition.builder()
-      .eventType(eventType.name())
+      .eventType(eventType.getTopicName())
       .subscriptionPattern(subscriptionPattern)
       .build();
     var recordHandler = recordHandlerSupplier.apply(vertx, context);

--- a/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
+++ b/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
@@ -40,7 +40,8 @@ public abstract class InventoryConsumersVerticle extends AbstractConsumersVertic
   @Override
   protected Future<Void> createConsumers() {
     var subscriptionPattern = KafkaTopicNameHelper.formatTopicName(kafkaConfig.getEnvId(), TENANT_ID_PATTERN, eventType.getTopicName());
-    log.info("createConsumers:: Creating Inventory Event consumers with subscriptionPattern: {} for evenType: {}", subscriptionPattern, eventType.name());
+    log.info("createConsumers:: Creating Inventory Event consumers with subscriptionPattern: {} for evenType: {}",
+      subscriptionPattern, eventType.name());
     var subscriptionDefinition = SubscriptionDefinition.builder()
       .eventType(eventType.getTopicName())
       .subscriptionPattern(subscriptionPattern)

--- a/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
+++ b/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
@@ -21,12 +21,12 @@ public abstract class InventoryConsumersVerticle extends AbstractConsumersVertic
 
   @Autowired
   protected InventoryConsumersVerticle(InventoryEventType eventType,
-                                       BiFunction<Context, Vertx, InventoryCreateAsyncRecordHandler> asyncRecordHandlerSupplier,
+                                       BiFunction<Vertx, Context, InventoryCreateAsyncRecordHandler> asyncRecordHandlerSupplier,
                                        KafkaConfig kafkaConfig,
                                        AbstractApplicationContext springContext) {
     super(kafkaConfig, springContext);
     this.eventType = eventType;
-    this.asyncRecordHandler = asyncRecordHandlerSupplier.apply(context, vertx);
+    this.asyncRecordHandler = asyncRecordHandlerSupplier.apply(vertx, context);
   }
 
 

--- a/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
+++ b/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
@@ -20,10 +20,10 @@ public abstract class InventoryConsumersVerticle extends AbstractConsumersVertic
   private final InventoryCreateAsyncRecordHandler asyncRecordHandler;
 
   @Autowired
-  public InventoryConsumersVerticle(InventoryEventType eventType,
-                                    BiFunction<Context, Vertx, InventoryCreateAsyncRecordHandler> asyncRecordHandlerSupplier,
-                                    KafkaConfig kafkaConfig,
-                                    AbstractApplicationContext springContext) {
+  protected InventoryConsumersVerticle(InventoryEventType eventType,
+                                       BiFunction<Context, Vertx, InventoryCreateAsyncRecordHandler> asyncRecordHandlerSupplier,
+                                       KafkaConfig kafkaConfig,
+                                       AbstractApplicationContext springContext) {
     super(kafkaConfig, springContext);
     this.eventType = eventType;
     this.asyncRecordHandler = asyncRecordHandlerSupplier.apply(context, vertx);

--- a/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
+++ b/src/main/java/org/folio/verticles/InventoryConsumersVerticle.java
@@ -1,0 +1,51 @@
+package org.folio.verticles;
+
+import java.util.function.BiFunction;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+import org.folio.event.InventoryEventType;
+import org.folio.event.handler.InventoryCreateAsyncRecordHandler;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.SubscriptionDefinition;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.AbstractApplicationContext;
+
+public abstract class InventoryConsumersVerticle extends AbstractConsumersVerticle<InventoryEventType> {
+
+  private final InventoryEventType eventType;
+  private final InventoryCreateAsyncRecordHandler asyncRecordHandler;
+
+  @Autowired
+  public InventoryConsumersVerticle(InventoryEventType eventType,
+                                    BiFunction<Context, Vertx, InventoryCreateAsyncRecordHandler> asyncRecordHandlerSupplier,
+                                    KafkaConfig kafkaConfig,
+                                    AbstractApplicationContext springContext) {
+    super(kafkaConfig, springContext);
+    this.eventType = eventType;
+    this.asyncRecordHandler = asyncRecordHandlerSupplier.apply(context, vertx);
+  }
+
+
+  /**
+   * This method creates a consumer for the given event type.
+   * Note: The method is using specific subscription pattern for inventory topics:
+   * {envId}.{tenant}.{eventType} -> e.g. 'folio.diku.inventory.item'
+   *
+   * @return future with the created consumer
+   */
+  @Override
+  protected Future<Void> createConsumers() {
+    var subscriptionPattern = KafkaTopicNameHelper.formatTopicName(kafkaConfig.getEnvId(), TENANT_ID_PATTERN, eventType.getTopicName());
+    log.info("createConsumers:: Creating Inventory Event consumers with subscriptionPattern: {} for evenType: {}", subscriptionPattern, eventType.name());
+    var subscriptionDefinition = SubscriptionDefinition.builder()
+      .eventType(eventType.name())
+      .subscriptionPattern(subscriptionPattern)
+      .build();
+    return createConsumer(eventType, subscriptionDefinition, asyncRecordHandler)
+      .mapEmpty();
+  }
+}

--- a/src/main/java/org/folio/verticles/InventoryHoldingConsumersVerticle.java
+++ b/src/main/java/org/folio/verticles/InventoryHoldingConsumersVerticle.java
@@ -1,7 +1,7 @@
 package org.folio.verticles;
 
 import org.folio.event.InventoryEventType;
-import org.folio.event.handler.ItemCreateAsyncRecordHandler;
+import org.folio.event.handler.HoldingCreateAsyncRecordHandler;
 import org.folio.kafka.KafkaConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-public class InventoryItemConsumersVerticle extends InventoryConsumersVerticle {
+public class InventoryHoldingConsumersVerticle extends InventoryConsumersVerticle {
 
   @Autowired
-  public InventoryItemConsumersVerticle(KafkaConfig kafkaConfig, AbstractApplicationContext springContext) {
-    super(InventoryEventType.INVENTORY_ITEM_CREATE, ItemCreateAsyncRecordHandler::new, kafkaConfig, springContext);
+  public InventoryHoldingConsumersVerticle(KafkaConfig kafkaConfig, AbstractApplicationContext springContext) {
+    super(InventoryEventType.INVENTORY_HOLDING_CREATE, HoldingCreateAsyncRecordHandler::new, kafkaConfig, springContext);
   }
 
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -321,6 +321,10 @@
           "caseSensitive": false
         },
         {
+          "fieldName": "location.holdingId",
+          "caseSensitive": false
+        },
+        {
           "fieldName": "physical.receiptDue",
           "caseSensitive": false
         },

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -22,6 +22,8 @@ import org.apache.logging.log4j.Logger;
 import org.folio.dao.lines.PoLinesPostgresDAOTest;
 import org.folio.event.KafkaEventUtilTest;
 import org.folio.event.handler.EdiExportOrdersHistoryAsyncRecordHandlerTest;
+import org.folio.event.handler.HoldingCreateAsyncRecordHandlerTest;
+import org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest;
 import org.folio.event.handler.ItemCreateAsyncRecordHandlerTest;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.okapi.common.XOkapiHeaders;
@@ -265,7 +267,11 @@ public class StorageTestSuite {
   @Nested
   class EdiExportOrdersHistoryAsyncRecordHandlerTestNested extends EdiExportOrdersHistoryAsyncRecordHandlerTest {}
   @Nested
+  class InventoryCreateAsyncRecordHandlerTestNested extends InventoryCreateAsyncRecordHandlerTest {}
+  @Nested
   class ItemCreateAsyncRecordHandlerTestNested extends ItemCreateAsyncRecordHandlerTest {}
+  @Nested
+  class HoldingCreateAsyncRecordHandlerTestNested extends HoldingCreateAsyncRecordHandlerTest {}
   @Nested
   class KafkaEventUtilTestNested extends KafkaEventUtilTest {}
   @Nested

--- a/src/test/java/org/folio/TestUtils.java
+++ b/src/test/java/org/folio/TestUtils.java
@@ -40,12 +40,23 @@ public class TestUtils {
   public static void setInternalState(Object target, String field, Object value) {
     Class<?> c = target.getClass();
     try {
-      Field f = c.getDeclaredField(field);
+      var f = getDeclaredFieldRecursive(field, c);
       f.setAccessible(true);
       f.set(target, value);
     } catch (Exception e) {
       throw new RuntimeException(
         "Unable to set internal state on a private field. [...]", e);
+    }
+  }
+
+  private static Field getDeclaredFieldRecursive(String field, Class<?> cls) {
+    try {
+      return cls.getDeclaredField(field);
+    } catch (NoSuchFieldException e) {
+      if (cls.getSuperclass() != null) {
+        return getDeclaredFieldRecursive(field, cls.getSuperclass());
+      }
+      throw new RuntimeException(String.format("Unable to find field: %s for class: %s", field, cls.getName()), e);
     }
   }
 

--- a/src/test/java/org/folio/TestUtils.java
+++ b/src/test/java/org/folio/TestUtils.java
@@ -1,7 +1,12 @@
 package org.folio;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.apache.commons.io.IOUtils;
 import org.folio.rest.util.TestConstants;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.support.AbstractApplicationContext;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,6 +15,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 
 public class TestUtils {
   private TestUtils() {}
@@ -39,5 +47,13 @@ public class TestUtils {
       throw new RuntimeException(
         "Unable to set internal state on a private field. [...]", e);
     }
+  }
+
+  public static Context mockContext(Vertx vertx) {
+    AbstractApplicationContext springContextMock = mock(AbstractApplicationContext.class);
+    when(springContextMock.getAutowireCapableBeanFactory()).thenReturn(mock(AutowireCapableBeanFactory.class));
+    Context context = vertx.getOrCreateContext();
+    context.put("springContext", springContextMock);
+    return context;
   }
 }

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -3,6 +3,7 @@ package org.folio.event.handler;
 import static org.folio.TestUtils.mockContext;
 import static org.folio.event.EventType.CREATE;
 import static org.folio.event.dto.InventoryFields.ID;
+import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.CONSORTIUM_ID;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.DIKU_TENANT;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createKafkaRecord;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createResourceEvent;
@@ -28,6 +29,7 @@ import java.util.function.Function;
 import org.folio.TestUtils;
 import org.folio.event.EventType;
 import org.folio.event.service.AuditOutboxService;
+import org.folio.models.ConsortiumConfiguration;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.Location;
@@ -76,7 +78,8 @@ public class HoldingCreateAsyncRecordHandlerTest {
       TestUtils.setInternalState(holdingHandler, "auditOutboxService", auditOutboxService);
       handler = spy(holdingHandler);
       doReturn(pgClient).when(dbClient).getPgClient();
-      doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any());
+      doReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration(DIKU_TENANT, CONSORTIUM_ID))))
+        .when(consortiumConfigurationService).getConsortiumConfiguration(any());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(any(Conn.class), anyList(), any(), anyMap());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), anyList(), any(), anyMap());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).processOutboxEventLogs(anyMap());

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -1,0 +1,247 @@
+package org.folio.event.handler;
+
+import static org.folio.TestUtils.mockContext;
+import static org.folio.event.EventType.CREATE;
+import static org.folio.event.dto.InventoryFields.ID;
+import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.DIKU_TENANT;
+import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createKafkaRecord;
+import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createResourceEvent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.UUID;
+
+import org.folio.TestUtils;
+import org.folio.event.EventType;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.jaxrs.model.Location;
+import org.folio.rest.persist.DBClient;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.services.lines.PoLinesService;
+import org.folio.services.piece.PieceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
+
+public class HoldingCreateAsyncRecordHandlerTest {
+
+  @Mock
+  private PieceService pieceService;
+  @Mock
+  private PoLinesService poLinesService;
+  @Mock
+  private DBClient dbClient;
+  @Mock
+  private PostgresClient pgClient;
+
+  private HoldingCreateAsyncRecordHandler handler;
+
+  @BeforeEach
+  public void initMocks() throws Exception {
+    try (var ignored = MockitoAnnotations.openMocks(this)) {
+      var vertx = Vertx.vertx();
+      handler = new HoldingCreateAsyncRecordHandler(mockContext(vertx), vertx);
+      TestUtils.setInternalState(handler, "pieceService", pieceService);
+      TestUtils.setInternalState(handler, "poLinesService", poLinesService);
+      doReturn(pgClient).when(dbClient).getPgClient();
+    }
+  }
+
+  @Test
+  void positive_shouldProcessHoldingCreateEvent() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    var pieceId1 = UUID.randomUUID().toString();
+    var pieceId2 = UUID.randomUUID().toString();
+    var poLineId1 = UUID.randomUUID().toString();
+    var poLineId2 = UUID.randomUUID().toString();
+    var holdingId1 = UUID.randomUUID().toString();
+    var holdingId2 = UUID.randomUUID().toString();
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+
+    var actualPieces = List.of(
+      createPiece(pieceId1, holdingId1).withReceivingTenantId("college"),
+      createPiece(pieceId2, holdingId1).withReceivingTenantId(DIKU_TENANT)
+    );
+    var expectedPieces = List.of(
+      createPiece(pieceId1, holdingId1).withReceivingTenantId(DIKU_TENANT)
+    );
+
+    var actualPoLines = List.of(
+      createPoLine(poLineId1, List.of(createLocation(holdingId1, "college"), createLocation(holdingId2, "college"))),
+      createPoLine(poLineId2, List.of(createLocation(holdingId1, "college"), createLocation(holdingId1, DIKU_TENANT)))
+    );
+    var expectedPoLines = List.of(
+      createPoLine(poLineId1, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId2, "college"))),
+      createPoLine(poLineId2, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId1, DIKU_TENANT)))
+    );
+
+    doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    doReturn(Future.succeededFuture()).when(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+    doReturn(Future.succeededFuture()).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(DIKU_TENANT), any(DBClient.class));
+
+    handler.handle(kafkaRecord);
+
+    verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
+    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(poLinesService).updatePoLines(eq(expectedPoLines), eq(DIKU_TENANT), any(DBClient.class));
+
+    assertEquals(2, actualPieces.stream().filter(piece -> piece.getReceivingTenantId().equals(DIKU_TENANT)).count());
+    assertTrue(actualPieces.containsAll(expectedPieces));
+
+    assertEquals(2, actualPoLines.stream()
+      .filter(poLine -> poLine.getLocations().stream()
+        .anyMatch(location -> location.getHoldingId().equals(holdingId1) && location.getTenantId().equals(DIKU_TENANT)))
+      .count());
+    assertEquals(1, actualPoLines.stream()
+      .filter(poLine -> poLine.getLocations().stream()
+        .anyMatch(location -> location.getHoldingId().equals(holdingId2) && !location.getTenantId().equals(DIKU_TENANT)))
+      .count());
+    assertTrue(actualPoLines.containsAll(expectedPoLines));
+  }
+
+  @Test
+  void positive_shouldProcessHoldingCreateEventWhenNoPoLineIsFound() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    var pieceId1 = UUID.randomUUID().toString();
+    var pieceId2 = UUID.randomUUID().toString();
+    var holdingId1 = UUID.randomUUID().toString();
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+
+    var actualPieces = List.of(
+      createPiece(pieceId1, holdingId1).withReceivingTenantId("college"),
+      createPiece(pieceId2, holdingId1).withReceivingTenantId(DIKU_TENANT)
+    );
+    var expectedPieces = List.of(
+      createPiece(pieceId1, holdingId1).withReceivingTenantId(DIKU_TENANT)
+    );
+
+    doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    doReturn(Future.succeededFuture()).when(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
+    doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+
+    handler.handle(kafkaRecord);
+
+    verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
+    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(poLinesService, times(0)).updatePoLines(anyList(), eq(DIKU_TENANT), any(DBClient.class));
+
+    assertEquals(2, actualPieces.stream().filter(piece -> piece.getReceivingTenantId().equals(DIKU_TENANT)).count());
+    assertTrue(actualPieces.containsAll(expectedPieces));
+  }
+
+  @Test
+  void positive_shouldProcessHoldingCreateEventWhenNoPieceIsFound() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    var poLineId1 = UUID.randomUUID().toString();
+    var poLineId2 = UUID.randomUUID().toString();
+    var holdingId1 = UUID.randomUUID().toString();
+    var holdingId2 = UUID.randomUUID().toString();
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+
+    var actualPoLines = List.of(
+      createPoLine(poLineId1, List.of(createLocation(holdingId1, "college"), createLocation(holdingId2, "college"))),
+      createPoLine(poLineId2, List.of(createLocation(holdingId1, "college"), createLocation(holdingId1, DIKU_TENANT)))
+    );
+    var expectedPoLines = List.of(
+      createPoLine(poLineId1, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId2, "college"))),
+      createPoLine(poLineId2, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId1, DIKU_TENANT)))
+    );
+
+    doReturn(Future.succeededFuture(List.of())).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+    doReturn(Future.succeededFuture()).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(DIKU_TENANT), any(DBClient.class));
+
+    handler.handle(kafkaRecord);
+
+    verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(pieceService, times(0)).updatePieces(anyList(), any(DBClient.class));
+    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(poLinesService).updatePoLines(eq(expectedPoLines), eq(DIKU_TENANT), any(DBClient.class));
+
+    assertEquals(2, actualPoLines.stream()
+      .filter(poLine -> poLine.getLocations().stream()
+        .anyMatch(location -> location.getHoldingId().equals(holdingId1) && location.getTenantId().equals(DIKU_TENANT)))
+      .count());
+    assertEquals(1, actualPoLines.stream()
+      .filter(poLine -> poLine.getLocations().stream()
+        .anyMatch(location -> location.getHoldingId().equals(holdingId2) && !location.getTenantId().equals(DIKU_TENANT)))
+      .count());
+    assertTrue(actualPoLines.containsAll(expectedPoLines));
+  }
+
+  @Test
+  void positive_shouldSkipHoldingCreateEventWhenNoPoLineOrPieceIsFound() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    var holdingId1 = UUID.randomUUID().toString();
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+
+    doReturn(Future.succeededFuture(List.of())).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+
+    handler.handle(kafkaRecord);
+
+    verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(DBClient.class));
+    verify(pieceService, times(0)).updatePieces(anyList(), any(DBClient.class));
+    verify(poLinesService, times(0)).updatePoLines(anyList(), eq(DIKU_TENANT), any(DBClient.class));
+  }
+
+  @Test
+  void negative_shouldReturnFailedFutureIfSavingPieceOrPoLineFailed() {
+    var pieceId = UUID.randomUUID().toString();
+    var poLineId = UUID.randomUUID().toString();
+    var holdingId = UUID.randomUUID().toString();
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId, DIKU_TENANT, CREATE);
+
+    var actualPieces = List.of(createPiece(pieceId, holdingId).withReceivingTenantId("college"));
+    var expectedPieces = List.of(createPiece(pieceId, holdingId).withReceivingTenantId(DIKU_TENANT));
+
+    var actualPoLines = List.of(createPoLine(poLineId, List.of(createLocation(holdingId, "college"), createLocation(holdingId, DIKU_TENANT))));
+    var expectedPoLines = List.of(createPoLine(poLineId, List.of(createLocation(holdingId, DIKU_TENANT), createLocation(holdingId, DIKU_TENANT))));
+
+    doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId), any(DBClient.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByHoldingId(eq(holdingId), any(DBClient.class));
+    doThrow(new RuntimeException("Piece save failed")).when(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
+    doThrow(new RuntimeException("PoLine save failed")).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(DIKU_TENANT), any(DBClient.class));
+    doReturn(pgClient).when(dbClient).getPgClient();
+
+
+    var actExp = handler.handle(kafkaRecord).cause();
+    assertEquals(RuntimeException.class, actExp.getClass());
+  }
+
+  private static Piece createPiece(String pieceId, String holdingId) {
+    return new Piece().withId(pieceId).withHoldingId(holdingId);
+  }
+
+  private static PoLine createPoLine(String poLineId, List<Location> locations) {
+    return new PoLine().withId(poLineId).withLocations(locations);
+  }
+
+  private static Location createLocation(String holdingId, String tenantId) {
+    return new Location().withHoldingId(holdingId).withTenantId(tenantId);
+  }
+
+  private static KafkaConsumerRecordImpl<String, String> createHoldingEventKafkaRecord(String id, String tenantId, EventType type) {
+    var resourceEvent = createResourceEvent(tenantId, type);
+    var holdingObject = JsonObject.of(ID.getValue(), id);
+    resourceEvent.setNewValue(holdingObject);
+    return createKafkaRecord(resourceEvent, DIKU_TENANT);
+  }
+
+}

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -77,6 +77,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
       doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(any(Conn.class), anyList(), any(), anyMap());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), anyList(), any(), anyMap());
+      doReturn(Future.succeededFuture(true)).when(auditOutboxService).processOutboxEventLogs(anyMap());
     }
   }
 

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.folio.TestUtils;
@@ -28,6 +29,7 @@ import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.lines.PoLinesService;
 import org.folio.services.piece.PieceService;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +49,8 @@ public class HoldingCreateAsyncRecordHandlerTest {
   @Mock
   private PoLinesService poLinesService;
   @Mock
+  private ConsortiumConfigurationService consortiumConfigurationService;
+  @Mock
   private DBClient dbClient;
   @Mock
   private PostgresClient pgClient;
@@ -60,8 +64,10 @@ public class HoldingCreateAsyncRecordHandlerTest {
       var holdingHandler = new HoldingCreateAsyncRecordHandler(vertx, mockContext(vertx));
       TestUtils.setInternalState(holdingHandler, "pieceService", pieceService);
       TestUtils.setInternalState(holdingHandler, "poLinesService", poLinesService);
+      TestUtils.setInternalState(holdingHandler, "consortiumConfigurationService", consortiumConfigurationService);
       handler = spy(holdingHandler);
       doReturn(pgClient).when(dbClient).getPgClient();
+      doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any());
     }
   }
 

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -57,7 +57,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
   public void initMocks() throws Exception {
     try (var ignored = MockitoAnnotations.openMocks(this)) {
       var vertx = Vertx.vertx();
-      var holdingHandler = new HoldingCreateAsyncRecordHandler(mockContext(vertx), vertx);
+      var holdingHandler = new HoldingCreateAsyncRecordHandler(vertx, mockContext(vertx));
       TestUtils.setInternalState(holdingHandler, "pieceService", pieceService);
       TestUtils.setInternalState(holdingHandler, "poLinesService", poLinesService);
       handler = spy(holdingHandler);

--- a/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
@@ -1,0 +1,93 @@
+package org.folio.event.handler;
+
+import static org.folio.TestUtils.mockContext;
+import static org.folio.event.EventType.CREATE;
+import static org.folio.event.EventType.UPDATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.folio.event.EventType;
+import org.folio.event.dto.ResourceEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
+
+public class InventoryCreateAsyncRecordHandlerTest {
+
+  static final String TENANT_KEY_LOWER_CASE = "x-okapi-tenant";
+  static final String DIKU_TENANT = "diku";
+
+  private List<InventoryCreateAsyncRecordHandler> handlers;
+
+  @BeforeEach
+  public void initMocks() throws Exception {
+    try (var ignored = MockitoAnnotations.openMocks(this)) {
+      var vertx = Vertx.vertx();
+      var context = mockContext(vertx);
+      handlers = List.of(
+        new ItemCreateAsyncRecordHandler(context, vertx),
+        new HoldingCreateAsyncRecordHandler(context, vertx)
+      );
+    }
+  }
+
+  @Test
+  void positive_shouldSkipProcessItemUpdateEvent() {
+    var eventObject = createResourceEvent(DIKU_TENANT, UPDATE);
+    var consumerRecord = new ConsumerRecord<>("topic", 1, 1L,
+      "key", Json.encode(eventObject));
+    RecordHeader header = new RecordHeader(TENANT_KEY_LOWER_CASE, DIKU_TENANT.getBytes());
+    consumerRecord.headers().add(header);
+    var record = new KafkaConsumerRecordImpl<>(consumerRecord);
+
+    handlers.forEach(handler -> {
+      var res = handler.handle(record);
+      assertTrue(res.succeeded());
+    });
+  }
+
+  @Test
+  void negative_shouldThrowExceptionIfKafkaRecordIsNotValid() {
+    var eventObject = createResourceEvent(DIKU_TENANT, CREATE);
+    var consumerRecord = new ConsumerRecord<>("topic", 1, 1, "key",
+      Json.encode(eventObject));
+    var record = new KafkaConsumerRecordImpl<>(consumerRecord);
+
+    handlers.forEach(handler -> {
+      Throwable actExp = handler.handle(record).cause();
+      assertEquals(java.lang.IllegalStateException.class, actExp.getClass());
+      assertTrue(actExp.getMessage().contains("Tenant must be specified in the kafka record X-Okapi-Tenant"));
+    });
+  }
+
+  @Test
+  void negative_shouldThrowExceptionIfTenantIdHeaderIsNotProvided() {
+    var eventObject = createResourceEvent(DIKU_TENANT, CREATE);
+    var consumerRecord = new ConsumerRecord<>("topic", 1, 1, "key",
+      Json.encode(eventObject));
+    var record = new KafkaConsumerRecordImpl<>(consumerRecord);
+
+    handlers.forEach(handler -> {
+      Throwable actExp = handler.handle(record).cause();
+      assertEquals(java.lang.IllegalStateException.class, actExp.getClass());
+    });
+  }
+
+  static ResourceEvent createResourceEvent(String tenantId, EventType type) {
+    return ResourceEvent.builder()
+      .type(type)
+      .newValue(new JsonObject())
+      .tenant(tenantId)
+      .build();
+  }
+
+}

--- a/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.TestUtils;
 import org.folio.event.EventType;
 import org.folio.event.dto.ResourceEvent;
+import org.folio.rest.persist.DBClient;
 import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +68,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
     handlers.forEach(handler -> {
       var res = handler.handle(record);
       assertTrue(res.succeeded());
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap(), any(DBClient.class));
     });
   }
 
@@ -80,7 +81,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
     handlers.forEach(handler -> {
       var res = handler.handle(record);
       assertTrue(res.succeeded());
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap(), any(DBClient.class));
     });
   }
 
@@ -94,7 +95,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
       Throwable actExp = handler.handle(record).cause();
       assertEquals(java.lang.IllegalArgumentException.class, actExp.getClass());
       assertTrue(actExp.getMessage().contains("Cannot process kafkaConsumerRecord: value is null"));
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap(), any(DBClient.class));
     });
   }
 
@@ -107,7 +108,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
       Throwable actExp = handler.handle(record).cause();
       assertEquals(java.lang.IllegalStateException.class, actExp.getClass());
       assertTrue(actExp.getMessage().contains("Tenant must be specified in the kafka record X-Okapi-Tenant"));
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap(), any(DBClient.class));
     });
   }
 

--- a/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
@@ -20,6 +20,7 @@ import org.mockito.MockitoAnnotations;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
 
 public class InventoryCreateAsyncRecordHandlerTest {
@@ -85,14 +86,18 @@ public class InventoryCreateAsyncRecordHandlerTest {
       .build();
   }
 
-  static KafkaConsumerRecordImpl<String, String> createKafkaRecord(ResourceEvent resourceEvent, String tenantId) {
+  static ResourceEvent extractResourceEvent(KafkaConsumerRecord<String, String> record) {
+    return Json.decodeValue(record.value(), ResourceEvent.class);
+  }
+
+  static KafkaConsumerRecord<String, String> createKafkaRecord(ResourceEvent resourceEvent, String tenantId) {
     var consumerRecord = new ConsumerRecord<>("topic", 1, 1, "key", Json.encode(resourceEvent));
     Optional.ofNullable(tenantId)
       .ifPresent(id -> consumerRecord.headers().add(new RecordHeader(TENANT_KEY_LOWER_CASE, id.getBytes())));
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
 
-  private static KafkaConsumerRecordImpl<String, String> createKafkaRecord(ResourceEvent resourceEvent) {
+  private static KafkaConsumerRecord<String, String> createKafkaRecord(ResourceEvent resourceEvent) {
     return createKafkaRecord(resourceEvent, null);
   }
 

--- a/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
@@ -41,8 +41,8 @@ public class InventoryCreateAsyncRecordHandlerTest {
       var vertx = Vertx.vertx();
       var context = mockContext(vertx);
       handlers = List.of(
-        spy(new ItemCreateAsyncRecordHandler(context, vertx)),
-        spy(new HoldingCreateAsyncRecordHandler(context, vertx))
+        spy(new ItemCreateAsyncRecordHandler(vertx, context)),
+        spy(new HoldingCreateAsyncRecordHandler(vertx, context))
       );
     }
   }

--- a/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/InventoryCreateAsyncRecordHandlerTest.java
@@ -3,9 +3,11 @@ package org.folio.event.handler;
 import static org.folio.TestUtils.mockContext;
 import static org.folio.event.EventType.CREATE;
 import static org.folio.event.EventType.UPDATE;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -65,7 +67,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
     handlers.forEach(handler -> {
       var res = handler.handle(record);
       assertTrue(res.succeeded());
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT));
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
     });
   }
 
@@ -78,7 +80,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
     handlers.forEach(handler -> {
       var res = handler.handle(record);
       assertTrue(res.succeeded());
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT));
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
     });
   }
 
@@ -92,7 +94,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
       Throwable actExp = handler.handle(record).cause();
       assertEquals(java.lang.IllegalArgumentException.class, actExp.getClass());
       assertTrue(actExp.getMessage().contains("Cannot process kafkaConsumerRecord: value is null"));
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT));
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
     });
   }
 
@@ -105,7 +107,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
       Throwable actExp = handler.handle(record).cause();
       assertEquals(java.lang.IllegalStateException.class, actExp.getClass());
       assertTrue(actExp.getMessage().contains("Tenant must be specified in the kafka record X-Okapi-Tenant"));
-      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT));
+      verify(handler, times(0)).processInventoryCreationEvent(any(ResourceEvent.class), eq(DIKU_TENANT), anyMap());
     });
   }
 
@@ -124,7 +126,7 @@ public class InventoryCreateAsyncRecordHandlerTest {
   static KafkaConsumerRecord<String, String> createKafkaRecord(ResourceEvent resourceEvent, String tenantId) {
     var consumerRecord = new ConsumerRecord<>("topic", 1, 1, "key", Json.encode(resourceEvent));
     Optional.ofNullable(tenantId)
-      .ifPresent(id -> consumerRecord.headers().add(new RecordHeader(TENANT_KEY_LOWER_CASE, id.getBytes())));
+      .ifPresent(id -> consumerRecord.headers().add(new RecordHeader(OKAPI_HEADER_TENANT, id.getBytes())));
     return new KafkaConsumerRecordImpl<>(consumerRecord);
   }
 

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -5,8 +5,9 @@ import static org.folio.event.EventType.CREATE;
 import static org.folio.event.dto.InventoryFields.HOLDINGS_RECORD_ID;
 import static org.folio.event.dto.InventoryFields.ID;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.DIKU_TENANT;
-import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.TENANT_KEY_LOWER_CASE;
+import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createKafkaRecord;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createResourceEvent;
+import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.extractResourceEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,24 +15,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import java.util.List;
 import java.util.UUID;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.folio.TestUtils;
 import org.folio.event.EventType;
-import org.folio.event.dto.ResourceEvent;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.PostgresClient;
@@ -50,21 +45,21 @@ public class ItemCreateAsyncRecordHandlerTest {
   @Mock
   private PostgresClient pgClient;
 
-  private ItemCreateAsyncRecordHandler handler;
+  private InventoryCreateAsyncRecordHandler handler;
 
   @BeforeEach
   public void initMocks() throws Exception {
     try (var ignored = MockitoAnnotations.openMocks(this)) {
       var vertx = Vertx.vertx();
-      handler = new ItemCreateAsyncRecordHandler(mockContext(vertx), vertx);
-      TestUtils.setInternalState(handler, "pieceService", pieceService);
+      var holdingHandler = new ItemCreateAsyncRecordHandler(mockContext(vertx), vertx);
+      TestUtils.setInternalState(holdingHandler, "pieceService", pieceService);
+      handler = spy(holdingHandler);
       doReturn(pgClient).when(dbClient).getPgClient();
     }
   }
 
   @Test
-  void positive_shouldProcessItemCreateEvent()
-    throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+  void positive_shouldProcessItemCreateEvent() {
     String pieceId1 = UUID.randomUUID().toString();
     String pieceId2 = UUID.randomUUID().toString();
     String pieceId3 = UUID.randomUUID().toString();
@@ -73,7 +68,7 @@ public class ItemCreateAsyncRecordHandlerTest {
     String locationId = UUID.randomUUID().toString();
     String tenantId = DIKU_TENANT;
 
-    var resourceEvent = createItemResourceEvent(itemId, holdingId, tenantId, CREATE);
+    var kafkaRecord = createItemEventKafkaRecord(itemId, holdingId, tenantId, CREATE);
     var actualPiece1 = createPiece(pieceId1, itemId)
       .withHoldingId(holdingId)
       .withReceivingTenantId("college");
@@ -95,12 +90,9 @@ public class ItemCreateAsyncRecordHandlerTest {
     doReturn(Future.succeededFuture(pieces)).when(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
     doReturn(Future.succeededFuture()).when(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
 
-    Method processItemCreateMethod = InventoryCreateAsyncRecordHandler.class
-      .getDeclaredMethod("processInventoryCreationEvent", ResourceEvent.class, String.class);
-    processItemCreateMethod.setAccessible(true);
+    handler.handle(kafkaRecord);
 
-    processItemCreateMethod.invoke(handler, resourceEvent, tenantId);
-
+    verify(handler).processInventoryCreationEvent(extractResourceEvent(kafkaRecord), DIKU_TENANT);
     verify(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
     verify(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
 
@@ -120,7 +112,7 @@ public class ItemCreateAsyncRecordHandlerTest {
     String locationId = UUID.randomUUID().toString();
     String tenantId = DIKU_TENANT;
 
-    var resourceEvent = createItemResourceEvent(itemId, holdingId, tenantId, CREATE);
+    var kafkaRecord = createItemEventKafkaRecord(itemId, holdingId, tenantId, CREATE);
     // These pieces should be skipped
     // alreadyUpdatedPiece1 have the same tenantId and holdingId
     var alreadyUpdatedPiece1 = createPiece(pieceId1, itemId)
@@ -131,24 +123,18 @@ public class ItemCreateAsyncRecordHandlerTest {
       .withLocationId(locationId)
       .withReceivingTenantId(tenantId);
     var pieces = List.of(alreadyUpdatedPiece1, alreadyUpdatedPiece2);
-
     List<Piece> expectedPieces = List.of();
 
     doReturn(Future.succeededFuture(pieces)).when(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
     doReturn(Future.succeededFuture()).when(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
 
-    var consumerRecord = new ConsumerRecord<>("topic", 1, 1L,
-      "key", Json.encode(resourceEvent));
-    RecordHeader header = new RecordHeader(TENANT_KEY_LOWER_CASE, DIKU_TENANT.getBytes());
-    consumerRecord.headers().add(header);
-    var record = new KafkaConsumerRecordImpl<>(consumerRecord);
+    var res = handler.handle(kafkaRecord);
 
-    var res = handler.handle(record);
     assertTrue(res.succeeded());
-
     assertNull(alreadyUpdatedPiece2.getHoldingId());
     assertEquals(locationId, alreadyUpdatedPiece2.getLocationId());
 
+    verify(handler).processInventoryCreationEvent(extractResourceEvent(kafkaRecord), DIKU_TENANT);
     verify(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
     // skip update pieces in db, in case of no pieces to update
     verify(dbClient.getPgClient(), times(0)).execute(any());
@@ -161,35 +147,30 @@ public class ItemCreateAsyncRecordHandlerTest {
     String holdingId = UUID.randomUUID().toString();
     String tenantId = DIKU_TENANT;
 
-    var resourceEvent = createItemResourceEvent(itemId, holdingId, tenantId, CREATE);
+    var kafkaRecord = createItemEventKafkaRecord(itemId, holdingId, tenantId, CREATE);
     var actualPiece = createPiece(pieceId, itemId);
     var expectedPieces = List.of(createPiece(pieceId, itemId)
       .withHoldingId(holdingId)
       .withReceivingTenantId(tenantId)
     );
 
-    var consumerRecord = new ConsumerRecord<>("topic", 1, 1L,
-      "key", Json.encode(resourceEvent));
-    RecordHeader header = new RecordHeader(TENANT_KEY_LOWER_CASE, DIKU_TENANT.getBytes());
-    consumerRecord.headers().add(header);
-    var record = new KafkaConsumerRecordImpl<>(consumerRecord);
-
     doReturn(Future.succeededFuture(List.of(actualPiece))).when(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
     doThrow(new RuntimeException("Save failed")).when(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
 
-    var actExp = handler.handle(record).cause();
+    var actExp = handler.handle(kafkaRecord).cause();
     assertEquals(RuntimeException.class, actExp.getClass());
+    verify(handler).processInventoryCreationEvent(extractResourceEvent(kafkaRecord), DIKU_TENANT);
   }
 
   private static Piece createPiece(String pieceId, String itemId) {
     return new Piece().withId(pieceId).withItemId(itemId);
   }
 
-  private static ResourceEvent createItemResourceEvent(String itemId, String holdingRecordId, String tenantId, EventType type) {
+  private static KafkaConsumerRecord<String, String> createItemEventKafkaRecord(String itemId, String holdingRecordId, String tenantId, EventType type) {
     var resourceEvent = createResourceEvent(tenantId, type);
     var itemObject = JsonObject.of(ID.getValue(), itemId, HOLDINGS_RECORD_ID.getValue(), holdingRecordId);
     resourceEvent.setNewValue(itemObject);
-    return resourceEvent;
+    return createKafkaRecord(resourceEvent, DIKU_TENANT);
   }
 
 }

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -50,7 +50,7 @@ public class ItemCreateAsyncRecordHandlerTest {
   @Mock
   private PostgresClient pgClient;
 
-  private InventoryCreateAsyncRecordHandler handler;
+  private ItemCreateAsyncRecordHandler handler;
 
   @BeforeEach
   public void initMocks() throws Exception {

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -70,6 +70,7 @@ public class ItemCreateAsyncRecordHandlerTest {
       doReturn(pgClient).when(dbClient).getPgClient();
       doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(any(Conn.class), anyList(), any(), anyMap());
+      doReturn(Future.succeededFuture(true)).when(auditOutboxService).processOutboxEventLogs(anyMap());
     }
   }
 

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -24,12 +24,14 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.folio.TestUtils;
 import org.folio.event.EventType;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.piece.PieceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,8 @@ public class ItemCreateAsyncRecordHandlerTest {
   @Mock
   private PieceService pieceService;
   @Mock
+  private ConsortiumConfigurationService consortiumConfigurationService;
+  @Mock
   private DBClient dbClient;
   @Mock
   private PostgresClient pgClient;
@@ -51,10 +55,12 @@ public class ItemCreateAsyncRecordHandlerTest {
   public void initMocks() throws Exception {
     try (var ignored = MockitoAnnotations.openMocks(this)) {
       var vertx = Vertx.vertx();
-      var holdingHandler = new ItemCreateAsyncRecordHandler(vertx, mockContext(vertx));
-      TestUtils.setInternalState(holdingHandler, "pieceService", pieceService);
-      handler = spy(holdingHandler);
+      var itemHandler = new ItemCreateAsyncRecordHandler(vertx, mockContext(vertx));
+      TestUtils.setInternalState(itemHandler, "pieceService", pieceService);
+      TestUtils.setInternalState(itemHandler, "consortiumConfigurationService", consortiumConfigurationService);
+      handler = spy(itemHandler);
       doReturn(pgClient).when(dbClient).getPgClient();
+      doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any());
     }
   }
 

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -4,6 +4,7 @@ import static org.folio.TestUtils.mockContext;
 import static org.folio.event.EventType.CREATE;
 import static org.folio.event.dto.InventoryFields.HOLDINGS_RECORD_ID;
 import static org.folio.event.dto.InventoryFields.ID;
+import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.CONSORTIUM_ID;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.DIKU_TENANT;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createKafkaRecord;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createResourceEvent;
@@ -35,6 +36,7 @@ import java.util.function.Function;
 import org.folio.TestUtils;
 import org.folio.event.EventType;
 import org.folio.event.service.AuditOutboxService;
+import org.folio.models.ConsortiumConfiguration;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
@@ -72,7 +74,8 @@ public class ItemCreateAsyncRecordHandlerTest {
       TestUtils.setInternalState(itemHandler, "consortiumConfigurationService", consortiumConfigurationService);
       TestUtils.setInternalState(itemHandler, "auditOutboxService", auditOutboxService);
       handler = spy(itemHandler);
-      doReturn(Future.succeededFuture(Optional.empty())).when(consortiumConfigurationService).getConsortiumConfiguration(any());
+      doReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration(DIKU_TENANT, CONSORTIUM_ID))))
+        .when(consortiumConfigurationService).getConsortiumConfiguration(any());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(eq(conn), anyList(), any(), anyMap());
       doReturn(Future.succeededFuture(0)).when(auditOutboxService).processOutboxEventLogs(anyMap());
       doReturn(dbClient).when(handler).createDBClient(any());

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -51,7 +51,7 @@ public class ItemCreateAsyncRecordHandlerTest {
   public void initMocks() throws Exception {
     try (var ignored = MockitoAnnotations.openMocks(this)) {
       var vertx = Vertx.vertx();
-      var holdingHandler = new ItemCreateAsyncRecordHandler(mockContext(vertx), vertx);
+      var holdingHandler = new ItemCreateAsyncRecordHandler(vertx, mockContext(vertx));
       TestUtils.setInternalState(holdingHandler, "pieceService", pieceService);
       handler = spy(holdingHandler);
       doReturn(pgClient).when(dbClient).getPgClient();

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -107,8 +107,7 @@ public class ItemCreateAsyncRecordHandlerTest {
       createPiece(pieceId3, itemId).withHoldingId(holdingId).withReceivingTenantId(tenantId)
     );
 
-    doReturn(Future.succeededFuture(pieces))
-      .when(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
+    doReturn(Future.succeededFuture(pieces)).when(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
     doReturn(Future.succeededFuture()).when(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));
     doReturn(pgClient).when(dbClient).getPgClient();
     doReturn(tenantId).when(dbClient).getTenantId();
@@ -118,10 +117,10 @@ public class ItemCreateAsyncRecordHandlerTest {
     }).when(pgClient).withConn(any());
 
     Method processItemCreateMethod = ItemCreateAsyncRecordHandler.class
-      .getDeclaredMethod("processItemCreationEvent", ResourceEvent.class, DBClient.class);
+      .getDeclaredMethod("processInventoryCreationEvent", ResourceEvent.class, String.class);
     processItemCreateMethod.setAccessible(true);
 
-    processItemCreateMethod.invoke(handler, resourceEvent, dbClient);
+    processItemCreateMethod.invoke(handler, resourceEvent, tenantId);
 
     verify(pieceService).getPiecesByItemId(eq(itemId), any(DBClient.class));
     verify(pieceService).updatePieces(eq(expectedPieces), any(DBClient.class));


### PR DESCRIPTION
## Purpose
[[MODORDSTOR-416] Add kafka consumer for Holdings Create events with processing logic
](https://folio-org.atlassian.net/browse/MODORDSTOR-416)

## Approach
- Add inventory consumer verticle and async handler to extend both with item and holding ones
- Add holding event async handler with processing logic
- Add holding consumer verticle 
- Add ConsortiumConfigurationService (same as in mod-orders)
- Fetch pieces and po lines from central tenant in case of ECS
- Update unit tests