### PR TITLE
[MODORDSTOR-416] Skip kafka event processing without central ordering

### DIFF
--- a/src/main/java/org/folio/models/ConsortiumConfiguration.java
+++ b/src/main/java/org/folio/models/ConsortiumConfiguration.java
@@ -1,4 +1,4 @@
 package org.folio.models;
 
-public record  ConsortiumConfiguration(String centralTenantId, String consortiumId) {
+public record ConsortiumConfiguration(String centralTenantId, String consortiumId) {
 }

--- a/src/main/java/org/folio/rest/impl/OrdersSettingsAPI.java
+++ b/src/main/java/org/folio/rest/impl/OrdersSettingsAPI.java
@@ -6,51 +6,58 @@ import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Setting;
-import org.folio.rest.jaxrs.model.SettingCollection;
 import org.folio.rest.jaxrs.resource.OrdersStorageSettings;
-import org.folio.rest.persist.PgUtil;
+import org.folio.services.settings.SettingsService;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 
 public class OrdersSettingsAPI implements OrdersStorageSettings {
 
-  private static final String SETTINGS_TABLE = "settings";
+  @Autowired
+  private SettingsService settingsService;
+
+  public OrdersSettingsAPI(Vertx vertx, String tenantId) {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
 
   @Override
   @Validate
   public void getOrdersStorageSettings(String query, String totalRecords, int offset, int limit, Map<String, String> okapiHeaders,
                                        Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.get(SETTINGS_TABLE, Setting.class, SettingCollection.class, query, offset, limit,
-      okapiHeaders, vertxContext, GetOrdersStorageSettingsResponse.class, asyncResultHandler);
+    settingsService.getSettings(query, offset, limit, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   @Validate
-  public void postOrdersStorageSettings(Setting entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(SETTINGS_TABLE, entity, okapiHeaders, vertxContext, PostOrdersStorageSettingsResponse.class, asyncResultHandler);
+  public void postOrdersStorageSettings(Setting entity, Map<String, String> okapiHeaders,
+                                        Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    settingsService.createSetting(entity, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   @Validate
   public void getOrdersStorageSettingsById(String id, Map<String, String> okapiHeaders,
                                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.getById(SETTINGS_TABLE, Setting.class, id, okapiHeaders, vertxContext, GetOrdersStorageSettingsByIdResponse.class, asyncResultHandler);
+    settingsService.getSettingById(id, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   @Validate
   public void putOrdersStorageSettingsById(String id, Setting entity, Map<String, String> okapiHeaders,
                                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.put(SETTINGS_TABLE, entity, id, okapiHeaders, vertxContext, PutOrdersStorageSettingsByIdResponse.class, asyncResultHandler);
+    settingsService.updateSetting(id, entity, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   @Validate
-  public void deleteOrdersStorageSettingsById(String id, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.deleteById(SETTINGS_TABLE, id, okapiHeaders, vertxContext,
-      PutOrdersStorageSettingsByIdResponse.class, asyncResultHandler);
+  public void deleteOrdersStorageSettingsById(String id, Map<String, String> okapiHeaders,
+                                              Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    settingsService.deleteSetting(id, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
 }

--- a/src/main/java/org/folio/services/consortium/util/ConsortiumConfigurationFields.java
+++ b/src/main/java/org/folio/services/consortium/util/ConsortiumConfigurationFields.java
@@ -1,0 +1,16 @@
+package org.folio.services.consortium.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ConsortiumConfigurationFields {
+
+  CONSORTIUM_ID("consortiumId"),
+  CENTRAL_TENANT_ID("centralTenantId"),
+  USER_TENANTS("userTenants");
+
+  private final String value;
+
+}

--- a/src/main/java/org/folio/services/settings/SettingsService.java
+++ b/src/main/java/org/folio/services/settings/SettingsService.java
@@ -1,0 +1,70 @@
+package org.folio.services.settings;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.folio.rest.jaxrs.model.Setting;
+import org.folio.rest.jaxrs.model.SettingCollection;
+import org.folio.rest.jaxrs.resource.OrdersStorageSettings;
+import org.folio.rest.persist.PgUtil;
+import org.folio.services.settings.util.SettingKey;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class SettingsService {
+
+  private static final String SETTINGS_TABLE = "settings";
+  private static final String SETTINGS_BY_KEY_QUERY = "key==%s";
+
+  public void getSettings(String query, int offset, int limit, Map<String, String> okapiHeaders,
+                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    getSettings(query, offset, limit, okapiHeaders, vertxContext)
+      .onComplete(asyncResultHandler);
+  }
+
+  public Future<Response> getSettings(String query, int offset, int limit, Map<String, String> okapiHeaders, Context vertxContext) {
+    return PgUtil.get(SETTINGS_TABLE, Setting.class, SettingCollection.class, query, offset, limit, okapiHeaders, vertxContext,
+      OrdersStorageSettings.GetOrdersStorageSettingsResponse.class);
+  }
+
+  public Future<Optional<Setting>> getSettingByKey(SettingKey settingKey, Map<String, String> okapiHeaders, Context vertxContext) {
+    return getSettings(String.format(SETTINGS_BY_KEY_QUERY, settingKey.getName()), 0, 1, okapiHeaders, vertxContext)
+      .map(response -> response.readEntity(SettingCollection.class))
+      .map(settings -> settings.getTotalRecords() == null || settings.getTotalRecords() != 1 || CollectionUtils.isEmpty(settings.getSettings())
+        ? Optional.<Setting>empty()
+        : Optional.of(settings.getSettings().get(0)));
+  }
+
+  public void createSetting(Setting entity, Map<String, String> okapiHeaders,
+                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.post(SETTINGS_TABLE, entity, okapiHeaders, vertxContext,
+      OrdersStorageSettings.PostOrdersStorageSettingsResponse.class, asyncResultHandler);
+  }
+
+  public void getSettingById(String id, Map<String, String> okapiHeaders,
+                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.getById(SETTINGS_TABLE, Setting.class, id, okapiHeaders, vertxContext,
+      OrdersStorageSettings.GetOrdersStorageSettingsByIdResponse.class, asyncResultHandler);
+  }
+
+  public void updateSetting(String id, Setting entity, Map<String, String> okapiHeaders,
+                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.put(SETTINGS_TABLE, entity, id, okapiHeaders, vertxContext,
+      OrdersStorageSettings.PutOrdersStorageSettingsByIdResponse.class, asyncResultHandler);
+  }
+
+  public void deleteSetting(String id, Map<String, String> okapiHeaders,
+                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.deleteById(SETTINGS_TABLE, id, okapiHeaders, vertxContext,
+      OrdersStorageSettings.PutOrdersStorageSettingsByIdResponse.class, asyncResultHandler);
+  }
+
+
+}

--- a/src/main/java/org/folio/services/settings/util/SettingKey.java
+++ b/src/main/java/org/folio/services/settings/util/SettingKey.java
@@ -1,0 +1,14 @@
+package org.folio.services.settings.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum SettingKey {
+
+  CENTRAL_ORDERING_ENABLED("ALLOW_ORDERING_WITH_AFFILIATED_LOCATIONS");
+
+  private final String name;
+
+}

--- a/src/main/java/org/folio/util/ResourcePath.java
+++ b/src/main/java/org/folio/util/ResourcePath.java
@@ -1,0 +1,21 @@
+package org.folio.util;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ResourcePath {
+
+  USER_TENANTS_ENDPOINT("/user-tenants");
+
+  private static final String PATH_BY_ID = "%s/%s";
+
+  private final String path;
+
+  public String getPathById(String id) {
+    return String.format(PATH_BY_ID, path, id);
+  }
+
+}


### PR DESCRIPTION
## Purpose
[[MODORDSTOR-416] Add kafka consumer for Holdings Create events with processing logic
](https://folio-org.atlassian.net/browse/MODORDSTOR-416)

## Approach
- Add SettingsService and use in controller and event handler
- Add add ResourcePath enum for declaring paths for RestClient