### PR TITLE
[MODORDSTOR-416]. Update searchLocationId during Holdings Create event

### DIFF
--- a/src/main/java/org/folio/event/dto/InventoryFields.java
+++ b/src/main/java/org/folio/event/dto/InventoryFields.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum InventoryFields {
 
   ID("id"),
-  HOLDINGS_RECORD_ID("holdingsRecordId");
+  HOLDINGS_RECORD_ID("holdingsRecordId"),
+  PERMANENT_LOCATION_ID("permanentLocationId");
 
   private final String value;
 }

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -3,6 +3,7 @@ package org.folio.event.handler;
 import static org.folio.TestUtils.mockContext;
 import static org.folio.event.EventType.CREATE;
 import static org.folio.event.dto.InventoryFields.ID;
+import static org.folio.event.dto.InventoryFields.PERMANENT_LOCATION_ID;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createKafkaRecord;
 import static org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest.createResourceEvent;
 import static org.folio.event.handler.TestHandlerUtil.CONSORTIUM_ID;
@@ -55,6 +56,7 @@ import org.mockito.Spy;
 
 public class HoldingCreateAsyncRecordHandlerTest {
 
+  private static final String LOCATION_ID = UUID.randomUUID().toString();
   @Spy
   private SettingService settingService;
   @Mock
@@ -108,7 +110,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     var poLineId2 = UUID.randomUUID().toString();
     var holdingId1 = UUID.randomUUID().toString();
     var holdingId2 = UUID.randomUUID().toString();
-    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE, LOCATION_ID);
 
     var actualPieces = List.of(
       createPiece(pieceId1, holdingId1).withReceivingTenantId("college"),
@@ -123,8 +125,8 @@ public class HoldingCreateAsyncRecordHandlerTest {
       createPoLine(poLineId2, List.of(createLocation(holdingId1, "college"), createLocation(holdingId1, DIKU_TENANT)))
     );
     var expectedPoLines = List.of(
-      createPoLine(poLineId1, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId2, "college"))),
-      createPoLine(poLineId2, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId1, DIKU_TENANT)))
+      createPoLine(poLineId1, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId2, "college")), LOCATION_ID),
+      createPoLine(poLineId2, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId1, DIKU_TENANT)), LOCATION_ID)
     );
 
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
@@ -160,7 +162,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     var pieceId1 = UUID.randomUUID().toString();
     var pieceId2 = UUID.randomUUID().toString();
     var holdingId1 = UUID.randomUUID().toString();
-    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE, LOCATION_ID);
 
     var actualPieces = List.of(
       createPiece(pieceId1, holdingId1).withReceivingTenantId("college"),
@@ -193,15 +195,15 @@ public class HoldingCreateAsyncRecordHandlerTest {
     var poLineId2 = UUID.randomUUID().toString();
     var holdingId1 = UUID.randomUUID().toString();
     var holdingId2 = UUID.randomUUID().toString();
-    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE, LOCATION_ID);
 
     var actualPoLines = List.of(
       createPoLine(poLineId1, List.of(createLocation(holdingId1, "college"), createLocation(holdingId2, "college"))),
       createPoLine(poLineId2, List.of(createLocation(holdingId1, "college"), createLocation(holdingId1, DIKU_TENANT)))
     );
     var expectedPoLines = List.of(
-      createPoLine(poLineId1, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId2, "college"))),
-      createPoLine(poLineId2, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId1, DIKU_TENANT)))
+      createPoLine(poLineId1, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId2, "college")), LOCATION_ID),
+      createPoLine(poLineId2, List.of(createLocation(holdingId1, DIKU_TENANT), createLocation(holdingId1, DIKU_TENANT)), LOCATION_ID)
     );
 
     doReturn(Future.succeededFuture(List.of())).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
@@ -231,7 +233,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
   @Test
   void positive_shouldSkipHoldingCreateEventWhenNoPoLineOrPieceIsFound() {
     var holdingId1 = UUID.randomUUID().toString();
-    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE);
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE, LOCATION_ID);
 
     doReturn(Future.succeededFuture(List.of())).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
     doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
@@ -251,13 +253,13 @@ public class HoldingCreateAsyncRecordHandlerTest {
     var pieceId = UUID.randomUUID().toString();
     var poLineId = UUID.randomUUID().toString();
     var holdingId = UUID.randomUUID().toString();
-    var kafkaRecord = createHoldingEventKafkaRecord(holdingId, DIKU_TENANT, CREATE);
+    var kafkaRecord = createHoldingEventKafkaRecord(holdingId, DIKU_TENANT, CREATE, LOCATION_ID);
 
     var actualPieces = List.of(createPiece(pieceId, holdingId).withReceivingTenantId("college"));
     var expectedPieces = List.of(createPiece(pieceId, holdingId).withReceivingTenantId(DIKU_TENANT));
 
     var actualPoLines = List.of(createPoLine(poLineId, List.of(createLocation(holdingId, "college"), createLocation(holdingId, DIKU_TENANT))));
-    var expectedPoLines = List.of(createPoLine(poLineId, List.of(createLocation(holdingId, DIKU_TENANT), createLocation(holdingId, DIKU_TENANT))));
+    var expectedPoLines = List.of(createPoLine(poLineId, List.of(createLocation(holdingId, DIKU_TENANT), createLocation(holdingId, DIKU_TENANT)), LOCATION_ID));
 
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId), any(Conn.class));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByHoldingId(eq(holdingId), any(Conn.class));
@@ -279,13 +281,19 @@ public class HoldingCreateAsyncRecordHandlerTest {
     return new PoLine().withId(poLineId).withLocations(locations);
   }
 
+  private static PoLine createPoLine(String poLineId, List<Location> locations, String searchLocationId) {
+    return new PoLine().withId(poLineId).withLocations(locations).withSearchLocationIds(List.of(searchLocationId));
+  }
+
   private static Location createLocation(String holdingId, String tenantId) {
     return new Location().withHoldingId(holdingId).withTenantId(tenantId);
   }
 
-  private static KafkaConsumerRecord<String, String> createHoldingEventKafkaRecord(String id, String tenantId, EventType type) {
+  private static KafkaConsumerRecord<String, String> createHoldingEventKafkaRecord(String id, String tenantId,
+                                                                                   EventType type,
+                                                                                   String permanentLocationId) {
     var resourceEvent = createResourceEvent(tenantId, type);
-    var holdingObject = JsonObject.of(ID.getValue(), id);
+    var holdingObject = JsonObject.of(ID.getValue(), id, PERMANENT_LOCATION_ID.getValue(), permanentLocationId);
     resourceEvent.setNewValue(holdingObject);
     return createKafkaRecord(resourceEvent, DIKU_TENANT);
   }


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDSTOR-416

During change ownership for Holding user can select another locationId where holding should be created, so we need to update searchLocationIds accordinly.
UI:
![image](https://github.com/user-attachments/assets/a975e624-2875-4cb4-a1b9-23e79ae6f5fa)
How new locationId populated during changing ownership in mod-inventory side:
![image](https://github.com/user-attachments/assets/0dfad37e-0dc5-47a8-b6c8-17cd685581b6)

