### PR TITLE
[MODORDSTOR-416] Fix PoLine lookup for kafka holding record consumer

### DIFF
--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -1,6 +1,7 @@
 package org.folio.event.handler;
 
 import static org.folio.event.InventoryEventType.INVENTORY_HOLDING_CREATE;
+import static org.folio.event.handler.HoldingUpdateAsyncRecordHandler.PO_LINE_LOCATIONS_HOLDING_ID_CQL;
 
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
   private Future<Void> processPoLinesUpdate(String holdingId, String permanentLocationId,
                                             String tenantIdFromEvent, String centralTenantId,
                                             Map<String, String> headers, Conn conn) {
-    return poLinesService.getPoLinesByHoldingId(holdingId, conn)
+    return poLinesService.getPoLinesByCqlQuery(String.format(PO_LINE_LOCATIONS_HOLDING_ID_CQL, holdingId), conn)
       .compose(poLines -> updatePoLines(poLines, holdingId, permanentLocationId, tenantIdFromEvent, centralTenantId, conn))
       .compose(poLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, poLines, OrderLineAuditEvent.Action.EDIT, headers))
       .mapEmpty();

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -218,11 +218,6 @@ public class PoLinesService {
     return promise.future();
   }
 
-  public Future<List<PoLine>> getPoLinesByHoldingId(String holdingId, Conn conn) {
-    var criterion = getCriterionByFieldNameAndValue(LOCATIONS_HOLDING_ID_FIELD, holdingId);
-    return getPoLinesByField(criterion, conn);
-  }
-
   @SneakyThrows
   public Future<List<PoLine>> getPoLinesByCqlQuery(String query, Conn conn) {
     var cqlWrapper = new QueryHolder(PO_LINE_TABLE,  query, 0, Integer.MAX_VALUE).buildCQLQuery();

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -130,7 +131,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     );
 
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
-    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     doReturn(Future.succeededFuture(expectedPieces)).when(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
 
@@ -140,7 +141,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     verify(handler).processInventoryCreationEvent(eq(extractResourceEvent(kafkaRecord)), eq(DIKU_TENANT), anyMap(), eq(dbClient));
     verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
     verify(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
-    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    verify(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     verify(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
 
     assertEquals(2, actualPieces.stream().filter(piece -> piece.getReceivingTenantId().equals(DIKU_TENANT)).count());
@@ -174,7 +175,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
 
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
     doReturn(Future.succeededFuture(expectedPieces)).when(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
-    doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
@@ -182,7 +183,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     verify(handler).processInventoryCreationEvent(eq(extractResourceEvent(kafkaRecord)), eq(DIKU_TENANT), anyMap(), eq(dbClient));
     verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
     verify(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
-    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    verify(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     verify(poLinesService, times(0)).updatePoLines(anyList(), any(Conn.class), eq(DIKU_TENANT));
 
     assertEquals(2, actualPieces.stream().filter(piece -> piece.getReceivingTenantId().equals(DIKU_TENANT)).count());
@@ -207,7 +208,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     );
 
     doReturn(Future.succeededFuture(List.of())).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
-    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
 
     var result = handler.handle(kafkaRecord);
@@ -216,7 +217,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     verify(handler).processInventoryCreationEvent(eq(extractResourceEvent(kafkaRecord)), eq(DIKU_TENANT), anyMap(), eq(dbClient));
     verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
     verify(pieceService, times(0)).updatePieces(anyList(), any(Conn.class), eq(DIKU_TENANT));
-    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    verify(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     verify(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
 
     assertEquals(2, actualPoLines.stream()
@@ -236,14 +237,14 @@ public class HoldingCreateAsyncRecordHandlerTest {
     var kafkaRecord = createHoldingEventKafkaRecord(holdingId1, DIKU_TENANT, CREATE, LOCATION_ID);
 
     doReturn(Future.succeededFuture(List.of())).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
-    doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
     verify(handler).processInventoryCreationEvent(eq(extractResourceEvent(kafkaRecord)), eq(DIKU_TENANT), anyMap(), eq(dbClient));
     verify(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
-    verify(poLinesService).getPoLinesByHoldingId(eq(holdingId1), any(Conn.class));
+    verify(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     verify(pieceService, times(0)).updatePieces(anyList(), any(Conn.class), eq(DIKU_TENANT));
     verify(poLinesService, times(0)).updatePoLines(anyList(), any(Conn.class), eq(DIKU_TENANT));
   }
@@ -262,7 +263,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     var expectedPoLines = List.of(createPoLine(poLineId, List.of(createLocation(holdingId, DIKU_TENANT), createLocation(holdingId, DIKU_TENANT)), LOCATION_ID));
 
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId), any(Conn.class));
-    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByHoldingId(eq(holdingId), any(Conn.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     doThrow(new RuntimeException("Piece save failed")).when(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
     doThrow(new RuntimeException("PoLine save failed")).when(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
     doReturn(pgClient).when(dbClient).getPgClient();


### PR DESCRIPTION
## Purpose
[[MODORDSTOR-416] Add kafka consumer for Holdings Create events with processing logic
](https://folio-org.atlassian.net/browse/MODORDSTOR-416)

## Approach
- Fix query parameter for searching PoLines by holdingId