### PR TITLE
[MODORDSTOR-426] Update libraries of dependant acq modules to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <!--Dependency Management Properties-->
     <vertx.version>4.5.10</vertx.version>
-    <kafkaclients.version>3.8.0</kafkaclients.version>
+    <kafkaclients.version>3.3.2</kafkaclients.version>
     <lombok.version>1.18.34</lombok.version>
     <postgres.image>postgres:12-alpine</postgres.image>
     <log4j.version>2.24.1</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <vertx.version>4.5.10</vertx.version>
     <kafkaclients.version>3.6.1</kafkaclients.version>
     <lombok.version>1.18.34</lombok.version>
-    <postgres.image>postgres:12-alpine</postgres.image>
+    <postgres.image>postgres:16-alpine</postgres.image>
     <log4j.version>2.24.1</log4j.version>
 
     <!--Dependency properties-->

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
     <!--Test Scope dependencies-->
     <junit-jupiter.version>5.11.2</junit-jupiter.version>
     <jmockit.version>1.49</jmockit.version>
-    <testcontainers.version>1.20.2</testcontainers.version>
 
     <!--Sonar properties-->
     <sonar.exclusions>**/models/**.java, **/event/dto/**.java, **/HttpException.java, **/ErrorCodes.java</sonar.exclusions>
@@ -188,24 +187,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
       <version>${vertx.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,41 +19,44 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>35.2.0</raml-module-builder.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
     <java.version>17</java.version>
 
     <!--Dependency Management Properties-->
-    <vertx.version>4.5.4</vertx.version>
-    <kafkaclients.version>3.3.2</kafkaclients.version>
-    <lombok.version>1.18.30</lombok.version>
+    <vertx.version>4.5.10</vertx.version>
+    <kafkaclients.version>3.8.0</kafkaclients.version>
+    <lombok.version>1.18.34</lombok.version>
     <postgres.image>postgres:12-alpine</postgres.image>
-    <log4j.version>2.23.0</log4j.version>
+    <log4j.version>2.24.1</log4j.version>
 
     <!--Dependency properties-->
-    <streamx.version>0.8.1</streamx.version>
-    <rest-assured.version>5.4.0</rest-assured.version>
-    <aspectj.version>1.9.21.1</aspectj.version>
+    <streamx.version>0.8.3</streamx.version>
+    <rest-assured.version>5.5.0</rest-assured.version>
+    <aspectj.version>1.9.22.1</aspectj.version>
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
     <common-lang.version>2.6</common-lang.version>
-    <jackson-bom.version>2.15.2</jackson-bom.version>
+    <jackson-bom.version>2.18.0</jackson-bom.version>
     <folio-di-support.version>2.1.0</folio-di-support.version>
+
+    <!--Folio dependencies properties-->
     <mod-configuration-client.version>5.10.0</mod-configuration-client.version>
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
 
     <!--Maven plugin properties-->
-    <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-    <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+    <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
 
     <!--Test Scope dependencies-->
-    <junit-jupiter.version>5.10.0</junit-jupiter.version>
+    <junit-jupiter.version>5.11.2</junit-jupiter.version>
     <jmockit.version>1.49</jmockit.version>
-    <testcontainers.version>1.19.6</testcontainers.version>
+    <testcontainers.version>1.20.2</testcontainers.version>
 
     <!--Sonar properties-->
     <sonar.exclusions>**/models/**.java, **/event/dto/**.java, **/HttpException.java, **/ErrorCodes.java</sonar.exclusions>
@@ -169,7 +172,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>4.8.0</version>
+      <version>5.14.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -215,7 +218,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -237,12 +240,12 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.1.3</version>
+      <version>3.1.8</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>3.3.0</version>
+      <version>3.6.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -266,7 +269,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.8.1</version>
+      <version>3.9.9</version>
     </dependency>
   </dependencies>
 
@@ -302,7 +305,18 @@
           <parameters>true</parameters>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -325,7 +339,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.1</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <vertx.version>4.5.10</vertx.version>
     <kafkaclients.version>3.6.1</kafkaclients.version>
     <lombok.version>1.18.34</lombok.version>
-    <postgres.image>postgres:16-alpine</postgres.image>
     <log4j.version>2.24.1</log4j.version>
 
     <!--Dependency properties-->

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <!--Dependency Management Properties-->
     <vertx.version>4.5.10</vertx.version>
-    <kafkaclients.version>3.3.2</kafkaclients.version>
+    <kafkaclients.version>3.6.1</kafkaclients.version>
     <lombok.version>1.18.34</lombok.version>
     <postgres.image>postgres:12-alpine</postgres.image>
     <log4j.version>2.24.1</log4j.version>

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -67,7 +67,6 @@ import org.folio.spring.SpringContextUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
@@ -91,8 +90,6 @@ public class StorageTestSuite {
   public static final Header URL_TO_HEADER = new Header("X-Okapi-Url-to","http://localhost:"+port);
   private static final Header URL_HEADER = new Header(XOkapiHeaders.URL, "http://localhost:" + port);
   private static TenantJob tenantJob;
-  private static PostgreSQLContainer<?> postgresSQLContainer;
-  public static final String POSTGRES_DOCKER_IMAGE = "postgres:12-alpine";
   public static EmbeddedKafkaCluster kafkaCluster;
   public static final String KAFKA_ENV_VALUE = "test-env";
   private static final String KAFKA_HOST = "KAFKA_HOST";

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -12,9 +12,9 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.testcontainers.shaded.org.apache.commons.lang3.ObjectUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
## Purpose
[[MODORDSTOR-426] Update libraries of dependant acq modules to the latest versions
](https://folio-org.atlassian.net/browse/MODORDSTOR-426)

## Approach
- Update versions
- Add module descriptor validator