### PR TITLE
[MODORDERS-1192/MODORDSTOR-419] - Avoid triggering unsupported events

### DIFF
--- a/src/main/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandler.java
@@ -54,7 +54,7 @@ public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordH
     var holder = createInventoryUpdateHolder(resourceEvent, headers);
     holder.prepareAllIds();
     if (holder.instanceIdEqual() && holder.searchLocationIdEqual()) {
-      log.info("processInventoryUpdateEvent:: No instance id or search location ids to update, ignoring update");
+      log.info("processInventoryUpdateEvent:: No instance id or search location ids to update in holding '{}', ignoring update", holder.getHoldingId());
       return Future.succeededFuture();
     }
     return consortiumConfigurationService.getCentralTenantId(getContext(), headers)

--- a/src/main/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandler.java
@@ -51,8 +51,7 @@ public abstract class InventoryUpdateAsyncRecordHandler extends BaseAsyncRecordH
       }
       log.info("handle:: Processing new kafkaRecord, topic: {}, key: {}, eventType: {}",
         kafkaRecord.topic(), kafkaRecord.key(), resourceEvent.getType());
-      return consortiumConfigurationService.getCentralTenantId(getContext(), headers)
-        .compose(centralTenantId -> processInventoryUpdateEvent(resourceEvent, headers, centralTenantId))
+      return processInventoryUpdateEvent(resourceEvent, headers)
         .onSuccess(v -> log.info("handle:: Processing successful, topic: {}, key: {}, eventType: {}",
           kafkaRecord.topic(), kafkaRecord.key(),resourceEvent.getType()))
         .onFailure(t -> log.error("Failed to process event: {}", kafkaRecord.value(), t))
@@ -68,6 +67,5 @@ public abstract class InventoryUpdateAsyncRecordHandler extends BaseAsyncRecordH
    *
    * @return future
    */
-  protected abstract Future<Void> processInventoryUpdateEvent(ResourceEvent resourceEvent, Map<String, String> headers,
-                                                              String centralTenantId);
+  protected abstract Future<Void> processInventoryUpdateEvent(ResourceEvent resourceEvent, Map<String, String> header);
 }

--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -42,7 +42,7 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
     var holder = createItemEventHolder(resourceEvent, headers);
     holder.prepareAllIds();
     if (holder.holdingIdEqual()) {
-      log.info("processInventoryUpdateEvent:: Holding is not updated in Item '{}', ignoring update", holder.getItemId());
+      log.info("processInventoryUpdateEvent:: No update in holdingId in Item '{}', so skipping process invent", holder.getItemId());
       return Future.succeededFuture();
     }
     return consortiumConfigurationService.getCentralTenantId(getContext(), headers)

--- a/src/test/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandlerTest.java
@@ -68,7 +68,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -173,7 +172,7 @@ public class HoldingUpdateAsyncRecordHandlerTest {
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(poLinesService).getPoLinesByCqlQuery(eq(query), any(Conn.class));
     verify(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
 
@@ -228,7 +227,7 @@ public class HoldingUpdateAsyncRecordHandlerTest {
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(poLinesService).getPoLinesByCqlQuery(eq(query), any(Conn.class));
     verify(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
 
@@ -289,7 +288,7 @@ public class HoldingUpdateAsyncRecordHandlerTest {
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(poLinesService).getPoLinesByCqlQuery(eq(query), any(Conn.class));
     verify(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT));
 
@@ -343,7 +342,7 @@ public class HoldingUpdateAsyncRecordHandlerTest {
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(poLinesService).getPoLinesByCqlQuery(eq(query), any(Conn.class));
     verify(poLinesService, times(0)).updatePoLines(anyList(), any(Conn.class), eq(DIKU_TENANT));
   }
@@ -379,7 +378,7 @@ public class HoldingUpdateAsyncRecordHandlerTest {
 
     var expectedException = handler.handle(kafkaRecord).cause();
     assertEquals(RuntimeException.class, expectedException.getClass());
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(poLinesService).getPoLinesByCqlQuery(eq(query), any(Conn.class));
     verify(poLinesService, times(1)).updatePoLines(anyList(), any(Conn.class), eq(DIKU_TENANT));
   }

--- a/src/test/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandlerTest.java
@@ -73,11 +73,11 @@ public class InventoryUpdateAsyncRecordHandlerTest {
       .when(consortiumConfigurationService).getConsortiumConfiguration(any());
     doReturn(Future.succeededFuture(tenantId))
       .when(consortiumConfigurationService).getCentralTenantId(any(), any());
-    doReturn(Future.succeededFuture()).when(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    doReturn(Future.succeededFuture()).when(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
-    verify(handler, times(1)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler, times(1)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
   }
 
   @Test
@@ -91,7 +91,7 @@ public class InventoryUpdateAsyncRecordHandlerTest {
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
-    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
   }
 
   @Test
@@ -106,7 +106,7 @@ public class InventoryUpdateAsyncRecordHandlerTest {
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
-    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
   }
 
   @Test
@@ -121,7 +121,7 @@ public class InventoryUpdateAsyncRecordHandlerTest {
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
-    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
   }
 
   @Test
@@ -131,6 +131,6 @@ public class InventoryUpdateAsyncRecordHandlerTest {
     var expectedException = handler.handle(kafkaRecord).cause();
     assertEquals(IllegalArgumentException.class, expectedException.getClass());
     assertTrue(expectedException.getMessage().contains(KAFKA_CONSUMER_RECORD_VALUE_NULL_MSG));
-    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler, times(0)).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
   }
 }

--- a/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -122,7 +121,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(pieceService).getPiecesByItemId(eq(itemId), any(Conn.class));
     verify(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
   }
@@ -138,7 +137,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verifyNoInteractions(pieceService);
     verifyNoInteractions(pieceService);
   }
@@ -161,7 +160,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
 
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(pieceService).getPiecesByItemId(eq(itemId), any(Conn.class));
     verify(pieceService, times(0)).updatePieces(anyList(), any(Conn.class), eq(DIKU_TENANT));
   }
@@ -192,7 +191,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
 
     var expectedException = handler.handle(kafkaRecord).cause();
     assertEquals(RuntimeException.class, expectedException.getClass());
-    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap(), anyString());
+    verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(pieceService).getPiecesByItemId(eq(itemId), any(Conn.class));
     verify(pieceService, times(1)).updatePieces(anyList(), any(Conn.class), eq(DIKU_TENANT));
   }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDERS-1192
https://folio-org.atlassian.net/browse/MODORDSTOR-419
## Purpose
- All changes to item and holding triggering event

## Approach
- Move event verification before fetch central tenant