### PR TITLE
[MODORDSTOR-416-6]. Update outbox code to use the same tx

### DIFF
--- a/src/main/java/org/folio/event/dto/HoldingEventHolder.java
+++ b/src/main/java/org/folio/event/dto/HoldingEventHolder.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Map;
-import java.util.Objects;
 
 import static org.folio.event.dto.HoldingFields.ID;
 import static org.folio.event.dto.HoldingFields.INSTANCE_ID;
@@ -40,10 +39,6 @@ public class HoldingEventHolder {
       Pair.of(oldValue.getString(INSTANCE_ID.getValue()), newValue.getString(INSTANCE_ID.getValue())));
     setSearchLocationIdPair(
       Pair.of(oldValue.getString(PERMANENT_LOCATION_ID.getValue()), newValue.getString(PERMANENT_LOCATION_ID.getValue())));
-  }
-
-  public String getActiveTenantId() {
-    return Objects.nonNull(centralTenantId) ? centralTenantId : tenantId;
   }
 
   public boolean instanceIdEqual() {

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -102,11 +102,10 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
     log.info("updatePoLines:: Updating {} poLine(s) with holdingId '{}', setting receivingTenantId to '{}' in centralTenant: '{}'",
       poLines.size(), holdingId, tenantIdFromEvent, centralTenantId);
 
-    var poLinesToUpdate = poLines.stream()
-      .filter(poLine -> {
-        var poLineLocations = poLine.getLocations().stream().map(Location::getHoldingId).toList();
-        return poLineLocations.contains(holdingId);
-      }).toList();
+    var poLinesToUpdate = poLines.stream().filter(poLine -> {
+      var poLineLocations = poLine.getLocations().stream().map(Location::getHoldingId).toList();
+      return poLineLocations.contains(holdingId);
+    }).toList();
 
     updatePoLineLocations(poLinesToUpdate, tenantIdFromEvent, permanentLocationId);
     return poLinesService.updatePoLines(poLines, conn, centralTenantId)

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -102,10 +102,11 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
     log.info("updatePoLines:: Updating {} poLine(s) with holdingId '{}', setting receivingTenantId to '{}' in centralTenant: '{}'",
       poLines.size(), holdingId, tenantIdFromEvent, centralTenantId);
 
-    var poLinesToUpdate = poLines.stream().filter(poLine -> {
-      var poLineLocations = poLine.getLocations().stream().map(Location::getHoldingId).toList();
-      return poLineLocations.contains(holdingId);
-    }).toList();
+    var poLinesToUpdate = poLines.stream()
+      .filter(poLine -> {
+        var poLineLocations = poLine.getLocations().stream().map(Location::getHoldingId).toList();
+        return poLineLocations.contains(holdingId);
+      }).toList();
 
     updatePoLineLocations(poLinesToUpdate, tenantIdFromEvent, permanentLocationId);
     return poLinesService.updatePoLines(poLines, conn, centralTenantId)

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -101,13 +101,16 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
 
     log.info("updatePoLines:: Updating {} poLine(s) with holdingId '{}', setting receivingTenantId to '{}' in centralTenant: '{}'",
       poLines.size(), holdingId, tenantIdFromEvent, centralTenantId);
+    poLines.forEach(poLine -> {
+      updateLocationTenantIdIfNeeded(poLine.getLocations(), holdingId, tenantIdFromEvent);
+      var searchLocationIds = poLine.getSearchLocationIds();
+      if (!searchLocationIds.contains(permanentLocationId)) {
+        searchLocationIds.add(permanentLocationId);
+        log.info("updatePoLines:: Added new search location, poLineId: {}, searchLocationId: {}",
+          poLine.getId(), permanentLocationId);
+      }
+    });
 
-    var poLinesToUpdate = poLines.stream().filter(poLine -> {
-      var poLineLocations = poLine.getLocations().stream().map(Location::getHoldingId).toList();
-      return poLineLocations.contains(holdingId);
-    }).toList();
-
-    updatePoLineLocations(poLinesToUpdate, tenantIdFromEvent, permanentLocationId);
     return poLinesService.updatePoLines(poLines, conn, centralTenantId)
       .map(v -> poLines);
   }
@@ -135,16 +138,9 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
     return pieceService.updatePieces(piecesToUpdate, conn, centralTenantId);
   }
 
-  private void updatePoLineLocations(List<PoLine> poLinesToUpdate, String tenantIdFromEvent, String permanentLocationId) {
-    poLinesToUpdate.forEach(poLine -> {
-      poLine.getLocations().forEach(location -> location.setTenantId(tenantIdFromEvent));
-
-      var searchLocationIds = poLine.getSearchLocationIds();
-      if (!searchLocationIds.contains(permanentLocationId)) {
-        searchLocationIds.add(permanentLocationId);
-        log.info("updatePoLines:: Added new search location, poLineId: {}, searchLocationId: {}",
-          poLine.getId(), permanentLocationId);
-      }
-    });
+  private void updateLocationTenantIdIfNeeded(List<Location> locations, String holdingId, String tenantIdFromEvent) {
+    locations.stream()
+      .filter(location -> Objects.equals(location.getHoldingId(), holdingId))
+      .forEach(location -> location.setTenantId(tenantIdFromEvent));
   }
 }

--- a/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/InventoryCreateAsyncRecordHandler.java
@@ -44,7 +44,7 @@ public abstract class InventoryCreateAsyncRecordHandler extends BaseAsyncRecordH
       var eventType = resourceEvent.getType();
 
       if (!Objects.equals(eventType, inventoryEventType.getEventType())) {
-        log.info("handle:: Unsupported event type: {}", eventType);
+        log.debug("handle:: Unsupported event type: {}", eventType);
         return Future.succeededFuture();
       }
 

--- a/src/main/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandler.java
@@ -42,7 +42,7 @@ public abstract class InventoryUpdateAsyncRecordHandler extends BaseAsyncRecordH
       }
       var resourceEvent = new JsonObject(kafkaRecord.value()).mapTo(ResourceEvent.class);
       if (!Objects.equals(resourceEvent.getType(), inventoryEventType.getEventType())) {
-        log.warn("handle:: Unsupported event type: {}, ignoring record processing", resourceEvent.getType());
+        log.debug("handle:: Unsupported event type: {}, ignoring record processing", resourceEvent.getType());
         return Future.succeededFuture(kafkaRecord.key());
       }
       if (Objects.isNull(resourceEvent.getOldValue()) || Objects.isNull(resourceEvent.getNewValue())) {

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -49,7 +49,7 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
       .withTrans(conn -> pieceService.getPiecesByItemId(itemId, conn)
         .compose(pieces -> updatePieces(pieces, itemObject, tenantIdFromEvent, centralTenantId, conn)) // order of tenants is important
         .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.EDIT, headers)))
-      .compose(v -> auditOutboxService.processOutboxEventLogs(headers))
+      .onComplete(v -> auditOutboxService.processOutboxEventLogs(headers))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -54,7 +54,7 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
     var dbClient = createDBClient(holder.getActiveTenantId());
     return dbClient.getPgClient()
       .withTrans(conn -> processPiecesUpdate(holder, conn))
-      .compose(v -> auditOutboxService.processOutboxEventLogs(holder.getHeaders()))
+      .onComplete(v -> auditOutboxService.processOutboxEventLogs(holder.getHeaders()))
       .mapEmpty();
   }
 

--- a/src/main/java/org/folio/services/consortium/ConsortiumConfigurationService.java
+++ b/src/main/java/org/folio/services/consortium/ConsortiumConfigurationService.java
@@ -72,8 +72,8 @@ public class ConsortiumConfigurationService {
           });
       })
       .recover(throwable -> {
-        log.warn("getCentralTenantId:: Error when retrieving central tenant id, unsupported endpoint or permission missing", throwable);
-        return null;
+        log.warn("getCentralTenantId:: Error when retrieving central tenant id, unsupported endpoint or missing permission", throwable);
+        return Future.succeededFuture();
       });
   }
 

--- a/src/main/java/org/folio/services/consortium/ConsortiumConfigurationService.java
+++ b/src/main/java/org/folio/services/consortium/ConsortiumConfigurationService.java
@@ -70,6 +70,10 @@ public class ConsortiumConfigurationService {
               return null;
             }
           });
+      })
+      .recover(throwable -> {
+        log.warn("getCentralTenantId:: Error when retrieving central tenant id, unsupported endpoint or permission missing", throwable);
+        return null;
       });
   }
 

--- a/src/main/java/org/folio/util/HeaderUtils.java
+++ b/src/main/java/org/folio/util/HeaderUtils.java
@@ -8,6 +8,7 @@ import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.vertx.core.MultiMap;
 import io.vertx.kafka.client.producer.KafkaHeader;
@@ -15,6 +16,7 @@ import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.okapi.common.XOkapiHeaders;
 
 public final class HeaderUtils {
+
   public static final String TENANT_NOT_SPECIFIED_MSG = "Tenant must be specified in the kafka record " + OKAPI_HEADER_TENANT;
 
   private HeaderUtils() {
@@ -52,5 +54,11 @@ public final class HeaderUtils {
     CaseInsensitiveMap<String, String> headersCopy = new CaseInsensitiveMap<>(headers);
     headersCopy.put(XOkapiHeaders.TENANT, tenantId);
     return headersCopy;
+  }
+
+  public static  Map<String, String> copyHeadersAndUpdatedTenant(String centralTenantId, Map<String, String> headers) {
+    var newHeaders = headers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    newHeaders.put(XOkapiHeaders.TENANT, centralTenantId);
+    return newHeaders;
   }
 }

--- a/src/test/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/InventoryUpdateAsyncRecordHandlerTest.java
@@ -1,42 +1,27 @@
 package org.folio.event.handler;
 
-import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import org.folio.TestUtils;
 import org.folio.event.dto.ResourceEvent;
-import org.folio.models.ConsortiumConfiguration;
 import org.folio.services.consortium.ConsortiumConfigurationService;
-import org.folio.services.setting.SettingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
-
-import javax.ws.rs.core.Response;
-import java.util.Optional;
 
 import static org.folio.TestUtils.mockContext;
 import static org.folio.event.EventType.CREATE;
 import static org.folio.event.EventType.UPDATE;
 import static org.folio.event.handler.InventoryUpdateAsyncRecordHandler.KAFKA_CONSUMER_RECORD_VALUE_NULL_MSG;
-import static org.folio.event.handler.TestHandlerUtil.CENTRAL_TENANT;
-import static org.folio.event.handler.TestHandlerUtil.CONSORTIUM_ID;
 import static org.folio.event.handler.TestHandlerUtil.DIKU_TENANT;
 import static org.folio.event.handler.TestHandlerUtil.createDefaultUpdateResourceEvent;
 import static org.folio.event.handler.TestHandlerUtil.createKafkaRecord;
-import static org.folio.event.handler.TestHandlerUtil.createSetting;
-import static org.folio.event.handler.TestHandlerUtil.createSettingCollection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -44,8 +29,7 @@ import static org.mockito.Mockito.verify;
 
 public class InventoryUpdateAsyncRecordHandlerTest {
 
-  @Spy
-  private SettingService settingService;
+
   @Mock
   private ConsortiumConfigurationService consortiumConfigurationService;
 
@@ -62,17 +46,10 @@ public class InventoryUpdateAsyncRecordHandlerTest {
     }
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {DIKU_TENANT, CENTRAL_TENANT})
-  void positive_shouldProcessInventoryUpdateEvent(String tenantId) {
+  @Test
+  void positive_shouldProcessInventoryUpdateEvent() {
     var resourceEvent = createDefaultUpdateResourceEvent();
     var kafkaRecord = createKafkaRecord(resourceEvent, DIKU_TENANT);
-    doReturn(Future.succeededFuture(Response.ok(createSettingCollection(createSetting("true"))).build()))
-      .when(settingService).getSettings(anyString(), anyInt(), anyInt(), anyMap(), any(Context.class));
-    doReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration(tenantId, CONSORTIUM_ID))))
-      .when(consortiumConfigurationService).getConsortiumConfiguration(any());
-    doReturn(Future.succeededFuture(tenantId))
-      .when(consortiumConfigurationService).getCentralTenantId(any(), any());
     doReturn(Future.succeededFuture()).when(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
 
     var result = handler.handle(kafkaRecord);

--- a/src/test/java/org/folio/services/consortium/ConsortiumConfigurationServiceTest.java
+++ b/src/test/java/org/folio/services/consortium/ConsortiumConfigurationServiceTest.java
@@ -174,14 +174,14 @@ public class ConsortiumConfigurationServiceTest {
 
   @Test
   void getCentralTenantId_shouldFail_whenRestClientFails(VertxTestContext vertxTestContext) {
-    doReturn(Future.failedFuture(new RuntimeException("Error"))).when(restClient).get(any(RequestEntry.class), any());
+    doReturn(Future.succeededFuture()).when(restClient).get(any(RequestEntry.class), any());
 
     Future<String> future = consortiumConfigurationService.getCentralTenantId(context, Map.of());
 
-    vertxTestContext.assertFailure(future)
+    vertxTestContext.assertComplete(future)
       .onComplete(ar -> {
-        assertTrue(ar.failed());
-        assertEquals("Error", ar.cause().getMessage());
+        assertTrue(ar.succeeded());
+        assertNull(ar.result());
         verify(restClient).get(any(RequestEntry.class), any());
         vertxTestContext.completeNow();
       });

--- a/src/test/java/org/folio/util/HeaderUtilsTest.java
+++ b/src/test/java/org/folio/util/HeaderUtilsTest.java
@@ -1,0 +1,66 @@
+package org.folio.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.folio.CopilotGenerated;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+@CopilotGenerated(partiallyGenerated = true)
+class HeaderUtilsTest {
+
+  @Test
+  void testExtractTenantFromHeaders_List() {
+    var headers = List.of(KafkaHeader.header(XOkapiHeaders.TENANT, "testTenant"));
+    var tenant = HeaderUtils.extractTenantFromHeaders(headers);
+    assertEquals("testTenant", tenant);
+  }
+
+  @Test
+  void testExtractTenantFromHeaders_Map() {
+    var headers = Map.of(XOkapiHeaders.TENANT, "testTenant");
+    var tenant = HeaderUtils.extractTenantFromHeaders(headers);
+    assertEquals("testTenant", tenant);
+  }
+
+  @Test
+  void testExtractValueFromHeaders() {
+    var headers = List.of(KafkaHeader.header("key", "value"));
+    var value = HeaderUtils.extractValueFromHeaders(headers, "key");
+    assertEquals("value", value);
+  }
+
+  @Test
+  void testGetHeaderMap() {
+    var headers = List.of(KafkaHeader.header("key", "value"));
+    var headerMap = HeaderUtils.getHeaderMap(headers);
+    assertEquals("value", headerMap.get("key"));
+  }
+
+  @Test
+  void testConvertToCaseInsensitiveMultiMap() {
+    var headers = Map.of("key", "value");
+    var multiMap = HeaderUtils.convertToCaseInsensitiveMultiMap(headers);
+    assertEquals("value", multiMap.get("key"));
+    assertEquals("application/json, text/plain", multiMap.get("Accept"));
+  }
+
+  @Test
+  void testPrepareHeaderForTenant() {
+    var headers = Map.of("key", "value");
+    CaseInsensitiveMap<String, String> preparedHeaders = HeaderUtils.prepareHeaderForTenant("testTenant", headers);
+    assertEquals("testTenant", preparedHeaders.get(XOkapiHeaders.TENANT));
+  }
+
+  @Test
+  void testCopyHeadersAndUpdatedTenant() {
+    var headers = Map.of("key", "value");
+    var updatedHeaders = HeaderUtils.copyHeadersAndUpdatedTenant("centralTenant", headers);
+    assertEquals("centralTenant", updatedHeaders.get(XOkapiHeaders.TENANT));
+  }
+}


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDSTOR-416>
- <https://folio-org.atlassian.net/browse/MODORDERS-1192>

## Approach

- Holding Create:
  - Replace tenant header with central tenant id
  - Use the same DB transaction for all operations
- Holding Update:
  - Remove central tenant id fetching and usage
- All consumers:
  - Replace `.compose()` with `.onComplete()` for all `auditOutboxService.processOutboxEventLogs()` calls 
  - Handle `GET /user-tenant` 403 exception with a `.recover()` command