### PR TITLE
[MODORDSTOR-PERF]. Add extra btree instanceId index

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -531,6 +531,10 @@
         {
           "fieldName": "claimingActive",
           "caseSensitive": false
+        },
+        {
+          "fieldName": "instanceId",
+          "caseSensitive": false
         }
       ],
       "fullTextIndex": [
@@ -677,7 +681,7 @@
          }
        ]
      },
-     {
+    {
       "tableName": "order_templates",
       "fromModuleVersion": "mod-orders-storage-13.7.0",
       "withMetadata": false,


### PR DESCRIPTION
## Purpose

- Replace Title retrieval by `instanceId` via full-text search with an indexed Btree variant
- Logs before index installation:

```log
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  RestRouting          invoking getOrdersStorageTitles
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] WARN  CQL2PgJSON           Doing LIKE search without index for titles.jsonb->>'instanceId', CQL >>> SQL: instanceId == 8dd18e27-bf78-4871-92fa-cff3ee714a2d >>> lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] WARN  CQL2PgJSON           Doing LIKE search without index for titles.jsonb->>'instanceId', CQL >>> SQL: instanceId == 8dd18e27-bf78-4871-92fa-cff3ee714a2d >>> lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQLWrapper           CQL >>> SQL: (cql.allRecords=1 not acqUnitIds <> []) and (instanceId==8dd18e27-bf78-4871-92fa-cff3ee714a2d) >>>WHERE ((true) AND ( (CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END) IS NOT TRUE)) AND (lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))) LIMIT 5000 OFFSET 0
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] WARN  CQL2PgJSON           Doing LIKE search without index for titles.jsonb->>'instanceId', CQL >>> SQL: instanceId == 8dd18e27-bf78-4871-92fa-cff3ee714a2d >>> lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] WARN  CQL2PgJSON           Doing LIKE search without index for titles.jsonb->>'instanceId', CQL >>> SQL: instanceId == 8dd18e27-bf78-4871-92fa-cff3ee714a2d >>> lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] WARN  CQL2PgJSON           Doing LIKE search without index for titles.jsonb->>'instanceId', CQL >>> SQL: instanceId == 8dd18e27-bf78-4871-92fa-cff3ee714a2d >>> lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('8dd18e27-bf78-4871-92fa-cff3ee714a2d'))
13:28:25 [454719/orders;350068/orders-storage] [college] [83e561cc-6eec-465c-896e-bfd59efc1cfa] [mod_orders_storage] INFO  LogUtil              10.0.81.106:52438 GET /orders-storage/titles offset=0&query=%28cql.allRecords%3D1+not+acqUnitIds+%3C%3E+%5B%5D%29+and+%28instanceId%3D%3D8dd18e27-bf78-4871-92fa-cff3ee714a2d%29&limit=5000 HTTP_1_1 200 700 4 tid=college OK 
```

- Logs after index installation:

```log
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  RestRouting          invoking getOrdersStorageTitles
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           full text index f_unaccent(titles.jsonb->>'acqUnitIds') generated SQL get_tsvector(f_unaccent(titles.jsonb->>'acqUnitIds')) @@ tsquery_phrase(f_unaccent('0ebb1f7d-983f-3026-8a4c-5318e0ebc041'))
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL CASE WHEN length(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) ELSE left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE left(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')),600) AND lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           full text index f_unaccent(titles.jsonb->>'acqUnitIds') generated SQL get_tsvector(f_unaccent(titles.jsonb->>'acqUnitIds')) @@ tsquery_phrase(f_unaccent('0ebb1f7d-983f-3026-8a4c-5318e0ebc041'))
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL CASE WHEN length(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) ELSE left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE left(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')),600) AND lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQLWrapper           CQL >>> SQL: (acqUnitIds=(0ebb1f7d-983f-3026-8a4c-5318e0ebc041) or (cql.allRecords=1 not acqUnitIds <> [])) and (instanceId==028af45e-935e-4857-b53c-07ae792b1806) >>>WHERE ((get_tsvector(f_unaccent(titles.jsonb->>'acqUnitIds')) @@ tsquery_phrase(f_unaccent('0ebb1f7d-983f-3026-8a4c-5318e0ebc041'))) OR ((true) AND ( (CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END) IS NOT TRUE))) AND (CASE WHEN length(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) ELSE left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE left(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')),600) AND lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) END) LIMIT 5000 OFFSET 0
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           full text index f_unaccent(titles.jsonb->>'acqUnitIds') generated SQL get_tsvector(f_unaccent(titles.jsonb->>'acqUnitIds')) @@ tsquery_phrase(f_unaccent('0ebb1f7d-983f-3026-8a4c-5318e0ebc041'))
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL CASE WHEN length(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) ELSE left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE left(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')),600) AND lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           full text index f_unaccent(titles.jsonb->>'acqUnitIds') generated SQL get_tsvector(f_unaccent(titles.jsonb->>'acqUnitIds')) @@ tsquery_phrase(f_unaccent('0ebb1f7d-983f-3026-8a4c-5318e0ebc041'))
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL CASE WHEN length(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) ELSE left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE left(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')),600) AND lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           full text index f_unaccent(titles.jsonb->>'acqUnitIds') generated SQL get_tsvector(f_unaccent(titles.jsonb->>'acqUnitIds')) @@ tsquery_phrase(f_unaccent('0ebb1f7d-983f-3026-8a4c-5318e0ebc041'))
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'acqUnitIds' generated SQL CASE WHEN length(lower(f_unaccent('[]'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE lower(f_unaccent('[]')) ELSE left(lower(f_unaccent(titles.jsonb->>'acqUnitIds')),600) NOT LIKE left(lower(f_unaccent('[]')),600) OR lower(f_unaccent(titles.jsonb->>'acqUnitIds')) NOT LIKE lower(f_unaccent('[]')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQL2PgJSON           index titles.jsonb->>'instanceId' generated SQL CASE WHEN length(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806'))) <= 600 THEN left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) ELSE left(lower(f_unaccent(titles.jsonb->>'instanceId')),600) LIKE left(lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')),600) AND lower(f_unaccent(titles.jsonb->>'instanceId')) LIKE lower(f_unaccent('028af45e-935e-4857-b53c-07ae792b1806')) END
10:44:40 [944618/orders;831427/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  LogUtil              10.0.75.40:48460 GET /orders-storage/titles offset=0&query=%28acqUnitIds%3D%280ebb1f7d-983f-3026-8a4c-5318e0ebc041%29+or+%28cql.allRecords%3D1+not+acqUnitIds+%3C%3E+%5B%5D%29%29+and+%28instanceId%3D%3D028af45e-935e-4857-b53c-07ae792b1806%29&limit=5000 HTTP_1_1 200 756 8 tid=consortium OK 
10:44:40 [510679/orders;293798/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  RestRouting          invoking getOrdersStoragePoLines
10:44:40 [510679/orders;293798/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  CQLWrapper           CQL >>> SQL: id==65250711-492f-4dec-a4d8-07794c3d3d24 >>>WHERE id='65250711-492f-4dec-a4d8-07794c3d3d24' LIMIT 5000 OFFSET 0
10:44:40 [510679/orders;293798/orders-storage] [consortium] [6bf8ca86-27dd-4023-ac9b-ef73c97bbd77] [mod_orders_storage] INFO  LogUtil              10.0.75.40:48460 GET /orders-storage/po-lines offset=0&query=id%3D%3D65250711-492f-4dec-a4d8-07794c3d3d24&limit=5000 HTTP_1_1 200 2649 5 tid=consortium OK 
```

## Approach

- Add a single `instanceId` Btree index to `titles` table
- Test installation by running:

```shell
# Find the latest version of mod-orders-storage
curl --location --silent 'http://localhost:9130/_/proxy/tenants/diku/modules' | grep orders-storage
```

```shell
# Install mod-orders-storage with the newly added index in schema.json
curl --location 'http://localhost:9130/_/proxy/tenants/diku/install?deploy=true&depCheck=false&tenantParameters=loadReference%3Dtrue%2CloadSample%3Dtrue' \
--header 'Content-Type: application/json' \
--data '[
    {
        "id": "mod-orders-storage-13.8.0-SNAPSHOT.401",
        "action": "enable"
    }
]'
```
