### PR TITLE
[MODORDSTOR-427]. PO locations are not changed after updating the item ownership

### DIFF
--- a/src/main/java/org/folio/event/dto/ItemFields.java
+++ b/src/main/java/org/folio/event/dto/ItemFields.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ItemFields {
 
   ID("id"),
-  HOLDINGS_RECORD_ID("holdingsRecordId");
+  HOLDINGS_RECORD_ID("holdingsRecordId"),
+  EFFECTIVE_LOCATION_ID("effectiveLocationId");
 
   private final String value;
 }

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -92,12 +92,14 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
     log.info("updatePieces:: Updating '{}' piece(s), setting receivingTenantId to '{}' and holdingId to '{}' " +
         "in centralTenant: '{}'", updateRequiredPieces.size(), tenantIdFromEvent, holdingId, centralTenantId);
 
+    updateRequiredPieces.forEach(updateRequiredPiece -> log.info("updatePieces:: Updated required piece: {}", JsonObject.mapFrom(updateRequiredPiece).encode()));
+
     return pieceService.updatePieces(updateRequiredPieces, conn, centralTenantId)
       .compose(updatedPieces -> {
         log.info("updatePieces:: Updated '{}' piece(s), setting receivingTenantId to '{}' and holdingId to '{}' " +
           "in centralTenant: '{}'", updatedPieces.size(), tenantIdFromEvent, holdingId, centralTenantId);
         updatedPieces.forEach(updatedPiece -> log.info("updatePieces:: Updated piece: {}", JsonObject.mapFrom(updatedPiece).encode()));
-        return auditOutboxService.savePiecesOutboxLog(conn, updatedPieces, PieceAuditEvent.Action.EDIT, headers).map(updatedPieces);
+        return auditOutboxService.savePiecesOutboxLog(conn, updatedPieces, PieceAuditEvent.Action.EDIT, headers).map(updateRequiredPieces);
       });
   }
 

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -3,24 +3,33 @@ package org.folio.event.handler;
 import static org.folio.event.InventoryEventType.INVENTORY_ITEM_CREATE;
 import static org.folio.event.dto.ItemFields.HOLDINGS_RECORD_ID;
 import static org.folio.event.dto.ItemFields.ID;
+import static org.folio.util.HelperUtils.collectResultsOnSuccess;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
+import org.folio.rest.jaxrs.model.Location;
+import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PieceAuditEvent;
+import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
+import org.folio.services.lines.PoLinesService;
 import org.folio.services.piece.PieceService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +39,9 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
 
   @Autowired
   private PieceService pieceService;
+
+  @Autowired
+  private PoLinesService poLinesService;
 
   @Autowired
   private AuditOutboxService auditOutboxService;
@@ -47,19 +59,26 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
     var tenantIdFromEvent = resourceEvent.getTenant();
     return dbClient.getPgClient()
       .withTrans(conn -> pieceService.getPiecesByItemId(itemId, conn)
-        .compose(pieces -> updatePieces(pieces, itemObject, tenantIdFromEvent, centralTenantId, conn)) // order of tenants is important
-        .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.EDIT, headers)))
+        .compose(pieces -> processPiecesUpdate(pieces, itemObject, tenantIdFromEvent, centralTenantId, headers, conn))
+        .compose(updatedPieces -> processPoLinesUpdate(updatedPieces, itemObject, tenantIdFromEvent, centralTenantId, headers, conn))
+      )
       .onComplete(v -> auditOutboxService.processOutboxEventLogs(headers))
       .mapEmpty();
   }
 
-  private Future<List<Piece>> updatePieces(List<Piece> pieces, JsonObject item, String tenantIdFromEvent,
-                                           String centralTenantId, Conn conn) {
+  private Future<List<Piece>> processPiecesUpdate(List<Piece> pieces, JsonObject itemObject, String tenantIdFromEvent,
+                                                  String centralTenantId, Map<String, String> headers, Conn conn) {
     if (CollectionUtils.isEmpty(pieces)) {
-      log.info("updatePieces:: No pieces were found to update for item: '{}' and tenant: '{}' in centralTenant: {}",
-        item.getString(ID.getValue()), tenantIdFromEvent, centralTenantId);
+      log.info("processPiecesUpdate:: No pieces were found to update for item: '{}' and tenant: '{}' in centralTenant: {}",
+        itemObject.getString(ID.getValue()), tenantIdFromEvent, centralTenantId);
       return Future.succeededFuture(List.of());
     }
+
+    return updatePieces(pieces, itemObject, tenantIdFromEvent, centralTenantId, headers, conn);
+  }
+
+  private Future<List<Piece>> updatePieces(List<Piece> pieces, JsonObject item, String tenantIdFromEvent,
+                                           String centralTenantId, Map<String, String> headers, Conn conn) {
     var holdingId = item.getString(HOLDINGS_RECORD_ID.getValue());
     var updateRequiredPieces = filterPiecesToUpdate(pieces, holdingId, tenantIdFromEvent);
 
@@ -73,7 +92,8 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
     log.info("updatePieces:: Updating '{}' piece(s), setting receivingTenantId to '{}' and holdingId to '{}' " +
         "in centralTenant: '{}'", updateRequiredPieces.size(), tenantIdFromEvent, holdingId, centralTenantId);
 
-    return pieceService.updatePieces(updateRequiredPieces, conn, centralTenantId);
+    return pieceService.updatePieces(updateRequiredPieces, conn, centralTenantId)
+      .compose(updatedPieces -> auditOutboxService.savePiecesOutboxLog(conn, updatedPieces, PieceAuditEvent.Action.EDIT, headers).map(updatedPieces));
   }
 
   private List<Piece> filterPiecesToUpdate(List<Piece> pieces, String holdingId, String tenantIdFromEvent) {
@@ -95,5 +115,67 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
         piece.setHoldingId(holdingId);
       }
     });
+  }
+
+  // Find affected POLs from updated pieces, find all other POL pieces, reconstruct POL locations from all pieces
+  private Future<Void> processPoLinesUpdate(List<Piece> pieces, JsonObject itemObject, String tenantIdFromEvent,
+                                            String centralTenantId, Map<String, String> headers, Conn conn) {
+    if (CollectionUtils.isEmpty(pieces)) {
+      log.info("processPoLinesUpdate:: No updated pieces were found to update for item: '{}' and tenant: '{}' in centralTenant: {}",
+        itemObject.getString(ID.getValue()), tenantIdFromEvent, centralTenantId);
+      return Future.succeededFuture();
+    }
+    var poLineIds = pieces.stream()
+      .map(Piece::getPoLineId)
+      .distinct()
+      .toList();
+    log.info("processPoLinesUpdate:: Preparing '{}' poLineIds for update processing", poLineIds.size());
+    return poLinesService.getPoLinesByLineIdsByChunks(poLineIds, conn)
+      .compose(poLines -> {
+        var poLinePiecePairsFutures = new ArrayList<Future<Pair<PoLine, List<Piece>>>>();
+        poLines.forEach(poLine -> {
+          var piecesFuture = pieceService.getPiecesByPoLineId(poLine.getId(), conn)
+            .map(allPieces -> Pair.of(poLine, allPieces));
+          poLinePiecePairsFutures.add(piecesFuture);
+        });
+        return collectResultsOnSuccess(poLinePiecePairsFutures);
+      })
+      .compose(poLinePiecePairs -> updatePoLines(poLinePiecePairs, centralTenantId, headers, conn))
+      .mapEmpty();
+  }
+
+  private Future<List<PoLine>> updatePoLines(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, String centralTenantId,
+                                             Map<String, String> headers, Conn conn) {
+    var updatedPoLines = new ArrayList<PoLine>();
+    poLinePiecePairs.forEach(poLineListPair -> {
+      var poLine = poLineListPair.getLeft();
+      var pieces = poLineListPair.getRight();
+      var locations = new ArrayList<Location>();
+      var piecesByTenantIdGrouped = pieces.stream()
+        .collect(Collectors.groupingBy(Piece::getReceivingTenantId, Collectors.toList()));
+      piecesByTenantIdGrouped.forEach((tenantId, piecesByTenant) -> {
+        var piecesByHoldingIdGrouped = piecesByTenant.stream()
+          .collect(Collectors.groupingBy(Piece::getHoldingId, Collectors.toList()));
+        piecesByHoldingIdGrouped.forEach((holdingId, piecesByHoldings) -> {
+          var piecesByFormat = piecesByHoldings.stream()
+            .collect(Collectors.groupingBy(Piece::getFormat, Collectors.toList()));
+          var location = new Location().withTenantId(tenantId)
+            .withHoldingId(holdingId)
+            .withQuantity(piecesByHoldings.size())
+            .withQuantityPhysical(piecesByFormat.getOrDefault(Piece.Format.PHYSICAL, List.of()).size())
+            .withQuantityElectronic(piecesByFormat.getOrDefault(Piece.Format.ELECTRONIC, List.of()).size());
+          locations.add(location);
+        });
+      });
+      if (!locations.isEmpty()) {
+        var oldLocations = CollectionUtils.isNotEmpty(poLine.getLocations()) ? JsonArray.of(poLine.getLocations()).encode() : List.of();
+        log.info("updatePoLines:: Updating PO Line '{}' with old locations: '{}'", poLine.getId(), oldLocations);
+        updatedPoLines.add(poLine.withLocations(locations));
+        log.info("updatePoLines:: Updating PO Line '{}' with new locations: '{}'", poLine.getId(), JsonArray.of(locations).encode());
+      }
+    });
+    return poLinesService.updatePoLines(updatedPoLines, conn, centralTenantId)
+      .compose(v -> auditOutboxService.saveOrderLinesOutboxLogs(conn, updatedPoLines, OrderLineAuditEvent.Action.EDIT, headers))
+      .mapEmpty();
   }
 }

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -176,13 +176,16 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
 
   private boolean updatePoLineLocations(List<Piece> pieces, PoLine poLine) {
     var locations = new ArrayList<Location>();
-    var piecesByTenantIdGrouped = pieces.stream()
+    var piecesByTenantIdGrouped = pieces.stream().filter(Objects::nonNull)
+      .filter(piece -> Objects.nonNull(piece.getReceivingTenantId()))
       .collect(Collectors.groupingBy(Piece::getReceivingTenantId, Collectors.toList()));
     piecesByTenantIdGrouped.forEach((tenantId, piecesByTenant) -> {
-      var piecesByHoldingIdGrouped = piecesByTenant.stream()
+      var piecesByHoldingIdGrouped = piecesByTenant.stream().filter(Objects::nonNull)
+        .filter(piece -> Objects.nonNull(piece.getHoldingId()))
         .collect(Collectors.groupingBy(Piece::getHoldingId, Collectors.toList()));
       piecesByHoldingIdGrouped.forEach((holdingId, piecesByHoldings) -> {
-        var piecesByFormat = piecesByHoldings.stream()
+        var piecesByFormat = piecesByHoldings.stream() .filter(Objects::nonNull)
+          .filter(piece -> Objects.nonNull(piece.getFormat()))
           .collect(Collectors.groupingBy(Piece::getFormat, Collectors.toList()));
         var location = new Location().withTenantId(tenantId)
           .withHoldingId(holdingId)

--- a/src/main/java/org/folio/services/piece/PieceService.java
+++ b/src/main/java/org/folio/services/piece/PieceService.java
@@ -42,6 +42,11 @@ public class PieceService {
     return getEntitiesByField(PIECES_TABLE, Piece.class, criterion, client);
   }
 
+  public Future<List<Piece>> getPiecesByPoLineId(String poLineId, Conn conn) {
+    var criterion = getCriteriaByFieldNameAndValueNotJsonb(POLINE_ID_FIELD, poLineId);
+    return getEntitiesByField(PIECES_TABLE, Piece.class, criterion, conn);
+  }
+
   public Future<List<Piece>> getPiecesByItemId(String itemId, Conn conn) {
     var criterion = getCriterionByFieldNameAndValue(ITEM_ID_FIELD, itemId);
     return getPiecesByField(criterion, conn);

--- a/src/test/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandlerTest.java
@@ -10,30 +10,24 @@ import org.folio.TestUtils;
 import org.folio.event.dto.InstanceFields;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
-import org.folio.models.ConsortiumConfiguration;
 import org.folio.rest.jaxrs.model.Contributor;
 import org.folio.rest.jaxrs.model.Details;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.ProductId;
-import org.folio.rest.jaxrs.model.Setting;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.inventory.InventoryUpdateService;
 import org.folio.services.lines.PoLinesService;
-import org.folio.services.setting.SettingService;
-import org.folio.services.setting.util.SettingKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -52,7 +46,6 @@ import static org.folio.event.dto.InstanceFields.PUBLICATION;
 import static org.folio.event.dto.InstanceFields.PUBLISHER;
 import static org.folio.event.dto.InstanceFields.TITLE;
 import static org.folio.event.handler.HoldingUpdateAsyncRecordHandler.PO_LINE_LOCATIONS_HOLDING_ID_CQL;
-import static org.folio.event.handler.TestHandlerUtil.CONSORTIUM_ID;
 import static org.folio.event.handler.TestHandlerUtil.DIKU_TENANT;
 import static org.folio.event.handler.TestHandlerUtil.createDefaultUpdateResourceEvent;
 import static org.folio.event.handler.TestHandlerUtil.createKafkaRecord;
@@ -97,8 +90,6 @@ public class HoldingUpdateAsyncRecordHandlerTest {
   private static final String IDENTIFIER_TYPE_VALUE_2 = "Id2";
   private static final String IDENTIFIER_TYPE_ID_2 = "2";
 
-  @Spy
-  private SettingService settingService;
   @Mock
   private PoLinesService poLinesService;
   @Mock
@@ -126,12 +117,6 @@ public class HoldingUpdateAsyncRecordHandlerTest {
       TestUtils.setInternalState(holdingHandler, "consortiumConfigurationService", consortiumConfigurationService);
       TestUtils.setInternalState(holdingHandler, "auditOutboxService", auditOutboxService);
       handler = spy(holdingHandler);
-      doReturn(Future.succeededFuture(Optional.of(new Setting().withValue("true"))))
-        .when(settingService).getSettingByKey(eq(SettingKey.CENTRAL_ORDERING_ENABLED), any(), any());
-      doReturn(Future.succeededFuture(Optional.of(new ConsortiumConfiguration(DIKU_TENANT, CONSORTIUM_ID))))
-        .when(consortiumConfigurationService).getConsortiumConfiguration(any());
-      doReturn(Future.succeededFuture(DIKU_TENANT))
-        .when(consortiumConfigurationService).getCentralTenantId(any(), any());
       doReturn(Future.succeededFuture()).when(inventoryUpdateService).batchUpdateAdjacentHoldingsWithNewInstanceId(any(), any(), any());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), anyList(), any(), anyMap());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).processOutboxEventLogs(anyMap());

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -507,10 +507,9 @@ public class ItemCreateAsyncRecordHandlerTest {
   private KafkaConsumerRecord<String, String> createItemEventKafkaRecord(String itemId, String holdingRecordId,
                                                                          String effectiveLocationId, String tenantId) {
     var resourceEvent = createResourceEvent(tenantId, CREATE);
-    var itemObject = new JsonObject();
-    itemObject.put(ID.getValue(), itemId);
-    itemObject.put(HOLDINGS_RECORD_ID.getValue(), holdingRecordId);
-    itemObject.put(EFFECTIVE_LOCATION_ID.getValue(), effectiveLocationId);
+    var itemObject = new JsonObject().put(ID.getValue(), itemId)
+      .put(HOLDINGS_RECORD_ID.getValue(), holdingRecordId)
+      .put(EFFECTIVE_LOCATION_ID.getValue(), effectiveLocationId);
     resourceEvent.setNewValue(itemObject);
     return createKafkaRecord(resourceEvent, CENTRAL_TENANT);
   }

--- a/src/test/java/org/folio/event/handler/TestHandlerUtil.java
+++ b/src/test/java/org/folio/event/handler/TestHandlerUtil.java
@@ -19,14 +19,16 @@ import static org.folio.event.EventType.UPDATE;
 
 public class TestHandlerUtil {
 
-  static final String DIKU_TENANT = "diku";
   static final String OKAPI_URL = "http://okapi:9130";
   static final String KAFKA_TOPIC = "dummy.topic";
   static final String RECORD_KEY = "dummy_key";
   static final int PARTITION = 1;
   static final int OFFSET = 1;
-  static final String CENTRAL_TENANT = "central";
   static final String CONSORTIUM_ID = "consortiumId";
+  static final String DIKU_TENANT = "diku";
+  static final String CENTRAL_TENANT = "central";
+  static final String UNIVERSITY_TENANT = "university";
+  static final String COLLEGE_TENANT = "college";
 
   private TestHandlerUtil() {
   }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDSTOR-427>

## Approach

- Extract distinct poLine ids from the updated pieces
- Using these distinct poLine ids fetch poLines, and for every fetched poLine fetch all related pieces
- Using all related pieces reconstruct POL locations and searchLocationIds arrays with correct tenantId, holdingId and quantities
- Example unit test output of 2 POL being updated by change item ownership (works in ECS only): 

```log
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePieces:: Preparing '3' piece(s) for update processing
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePieces:: Updating '3' piece(s), setting receivingTenantId to 'college' and holdingId to '43a5db0d-7852-48dd-8009-98a1e208d874' in centralTenant: 'central'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler processPoLinesUpdate:: Preparing '2' poLineIds for update processing
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLines:: Updating '2' POL(s) for item: '2a659194-fbd2-45b7-ad4d-5b4d7b9b8522' in centralTenant: 'central'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineLocations:: Updating POL 'd4ee5e9f-9d16-4938-8ff2-320709191ac4' locations, old locations: '[[{"holdingId":"7124b574-132d-4131-9f4e-b1d60dcaa64d","quantity":1,"quantityElectronic":1,"quantityPhysical":0,"tenantId":"central"},{"holdingId":"cf641e1c-3062-457a-9d52-ad5e5f085075","quantity":1,"quantityElectronic":1,"quantityPhysical":0,"tenantId":"university"},{"holdingId":"43a5db0d-7852-48dd-8009-98a1e208d874","quantity":1,"quantityElectronic":0,"quantityPhysical":1,"tenantId":"university"}]]'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineLocations:: Updating POL 'd4ee5e9f-9d16-4938-8ff2-320709191ac4' locations, new locations: '[[{"holdingId":"43a5db0d-7852-48dd-8009-98a1e208d874","quantity":2,"quantityElectronic":1,"quantityPhysical":1,"tenantId":"college"},{"holdingId":"7124b574-132d-4131-9f4e-b1d60dcaa64d","quantity":1,"quantityElectronic":1,"quantityPhysical":0,"tenantId":"central"}]]'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineSearchLocationIds:: Updating POL 'd4ee5e9f-9d16-4938-8ff2-320709191ac4' searchLocationIds, old searchLocationIds: '[41ae3bda-3785-4eac-bea9-cc838f77e3a9]'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineSearchLocationIds:: Updating POL 'd4ee5e9f-9d16-4938-8ff2-320709191ac4' searchLocationIds, new searchLocationIds: '[41ae3bda-3785-4eac-bea9-cc838f77e3a9, ac95b87d-ee4c-493c-9baa-14c717e4d0ec]'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineLocations:: Updating POL '1ca17baa-8095-4cb3-887f-fee2cfd8ee7e' locations, old locations: '[[{"holdingId":"46d036c3-a147-4da3-8334-15c79d5ee2a4","quantity":1,"quantityElectronic":0,"quantityPhysical":1,"tenantId":"central"}]]'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineLocations:: Updating POL '1ca17baa-8095-4cb3-887f-fee2cfd8ee7e' locations, new locations: '[[{"holdingId":"43a5db0d-7852-48dd-8009-98a1e208d874","quantity":1,"quantityElectronic":0,"quantityPhysical":1,"tenantId":"college"}]]'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineSearchLocationIds:: Updating POL '1ca17baa-8095-4cb3-887f-fee2cfd8ee7e' searchLocationIds, old searchLocationIds: '[41ae3bda-3785-4eac-bea9-cc838f77e3a9]'
14:31:45 [] [] [] [] INFO  ItemCreateAsyncRecordHandler updatePoLineSearchLocationIds:: Updating POL '1ca17baa-8095-4cb3-887f-fee2cfd8ee7e' searchLocationIds, new searchLocationIds: '[41ae3bda-3785-4eac-bea9-cc838f77e3a9, ac95b87d-ee4c-493c-9baa-14c717e4d0ec]'
14:31:45 [] [] [] [] INFO  InventoryCreateAsyncRecordHandler handle:: 'CREATE' event for 'inventory.item' processed successfully

Process finished with exit code 0
``` 

- Example manual test output of 1 POL being updated by change item ownership:

Orders app, POL 427-1:
![image](https://github.com/user-attachments/assets/4a562116-2b52-4198-a180-d1ad505add45)
Inventory app, instance 427-1:
![image](https://github.com/user-attachments/assets/d68f78bf-2d30-4b2a-857c-d7709d882f63)

- Additional changes:
  - Fix outbox tenant id header to avoid 403 DB exceptions triggering a transaction rollback
