### PR TITLE
MODORDSTOR-434: $1::text fixing "could not determine data type"

### DIFF
--- a/src/main/java/org/folio/dao/PieceClaimingRepository.java
+++ b/src/main/java/org/folio/dao/PieceClaimingRepository.java
@@ -26,7 +26,7 @@ public class PieceClaimingRepository {
             'statusUpdatedDate', to_char(clock_timestamp(),'YYYY-MM-DD"T"HH24:MI:SS.MSTZH:TZM')::text,
             'metadata', pieces.jsonb -> 'metadata' || jsonb_build_object(
                 'updatedDate', to_char(clock_timestamp(),'YYYY-MM-DD"T"HH24:MI:SS.MSTZH:TZM')::text,
-                'updatedByUserId', $1))
+                'updatedByUserId', $1::text))
         FROM %1$s.%3$s as titles
         WHERE (titles.jsonb ->> 'claimingActive')::boolean = TRUE
         AND pieces.titleid = titles.id


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDSTOR-434

## Purpose
Fix SQL error.

## Approach
Replace `$1` with `$1::text`.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.