### PR TITLE
Prevent audit outbox processing if an entity has missing metadata

### DIFF
--- a/src/main/java/org/folio/event/service/AuditEventProducer.java
+++ b/src/main/java/org/folio/event/service/AuditEventProducer.java
@@ -2,7 +2,9 @@ package org.folio.event.service;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,7 +92,7 @@ public class AuditEventProducer {
   }
 
   private OrderAuditEvent getOrderEvent(PurchaseOrder order, OrderAuditEvent.Action eventAction) {
-    Metadata metadata = order.getMetadata();
+    Metadata metadata = getMetadataOrThrow(order::getMetadata, order.getId());
     return new OrderAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -98,11 +100,11 @@ public class AuditEventProducer {
       .withEventDate(new Date())
       .withActionDate(metadata.getUpdatedDate())
       .withUserId(metadata.getUpdatedByUserId())
-      .withOrderSnapshot(order.withMetadata(null)); // not populate metadata to not include it in snapshot's comparation in UI
+      .withOrderSnapshot(order.withMetadata(null)); // not populate metadata to not include it in snapshot's comparison in UI
   }
 
   private OrderLineAuditEvent getOrderLineEvent(PoLine poLine, OrderLineAuditEvent.Action eventAction) {
-    Metadata metadata = poLine.getMetadata();
+    Metadata metadata = getMetadataOrThrow(poLine::getMetadata, poLine.getId());
     return new OrderLineAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -111,11 +113,11 @@ public class AuditEventProducer {
       .withEventDate(new Date())
       .withActionDate(metadata.getUpdatedDate())
       .withUserId(metadata.getUpdatedByUserId())
-      .withOrderLineSnapshot(poLine.withMetadata(null)); // not populate metadata to not include it in snapshot's comparation in UI
+      .withOrderLineSnapshot(poLine.withMetadata(null)); // not populate metadata to not include it in snapshot's comparison in UI
   }
 
   private PieceAuditEvent getPieceEvent(Piece piece, PieceAuditEvent.Action eventAction) {
-    Metadata metadata = piece.getMetadata();
+    Metadata metadata = getMetadataOrThrow(piece::getMetadata, piece.getId());
     return new PieceAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -123,7 +125,7 @@ public class AuditEventProducer {
       .withEventDate(new Date())
       .withActionDate(metadata.getUpdatedDate())
       .withUserId(metadata.getUpdatedByUserId())
-      .withPieceSnapshot(piece.withMetadata(null)); // not populate metadata to not include it in snapshot's comparation in UI
+      .withPieceSnapshot(piece.withMetadata(null)); // not populate metadata to not include it in snapshot's comparison in UI
   }
 
   private Future<Boolean> sendToKafka(AuditEventType eventType,
@@ -158,4 +160,10 @@ public class AuditEventProducer {
     return KafkaTopicNameHelper.formatTopicName(envId, KafkaTopicNameHelper.getDefaultNameSpace(),
       tenantId, eventType);
   }
+
+  private Metadata getMetadataOrThrow(Supplier<Metadata> metadata, String id) {
+    return Optional.ofNullable(metadata.get())
+      .orElseThrow(() -> new IllegalArgumentException("Metadata is null for entity with id: %s".formatted(id)));
+  }
+
 }

--- a/src/main/java/org/folio/event/service/AuditEventProducer.java
+++ b/src/main/java/org/folio/event/service/AuditEventProducer.java
@@ -4,10 +4,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.event.AuditEventType;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaTopicNameHelper;
@@ -28,10 +25,11 @@ import io.vertx.core.Vertx;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 @RequiredArgsConstructor
+@Log4j2
 public class AuditEventProducer {
-  private static final Logger log = LogManager.getLogger();
 
   private final KafkaConfig kafkaConfig;
 
@@ -92,7 +90,7 @@ public class AuditEventProducer {
   }
 
   private OrderAuditEvent getOrderEvent(PurchaseOrder order, OrderAuditEvent.Action eventAction) {
-    Metadata metadata = getMetadataOrThrow(order::getMetadata, order.getId());
+    Metadata metadata = getMetadataOrThrow(order.getMetadata(), order.getId());
     return new OrderAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -104,7 +102,7 @@ public class AuditEventProducer {
   }
 
   private OrderLineAuditEvent getOrderLineEvent(PoLine poLine, OrderLineAuditEvent.Action eventAction) {
-    Metadata metadata = getMetadataOrThrow(poLine::getMetadata, poLine.getId());
+    Metadata metadata = getMetadataOrThrow(poLine.getMetadata(), poLine.getId());
     return new OrderLineAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -117,7 +115,7 @@ public class AuditEventProducer {
   }
 
   private PieceAuditEvent getPieceEvent(Piece piece, PieceAuditEvent.Action eventAction) {
-    Metadata metadata = getMetadataOrThrow(piece::getMetadata, piece.getId());
+    Metadata metadata = getMetadataOrThrow(piece.getMetadata(), piece.getId());
     return new PieceAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -161,8 +159,8 @@ public class AuditEventProducer {
       tenantId, eventType);
   }
 
-  private Metadata getMetadataOrThrow(Supplier<Metadata> metadata, String id) {
-    return Optional.ofNullable(metadata.get())
+  private Metadata getMetadataOrThrow(Metadata metadata, String id) {
+    return Optional.ofNullable(metadata)
       .orElseThrow(() -> new IllegalArgumentException("Metadata is null for entity with id: %s".formatted(id)));
   }
 

--- a/src/main/java/org/folio/event/service/AuditOutboxService.java
+++ b/src/main/java/org/folio/event/service/AuditOutboxService.java
@@ -85,6 +85,9 @@ public class AuditOutboxService {
   private List<Future<Boolean>> getKafkaFutures(List<OutboxEventLog> eventLogs, Map<String, String> okapiHeaders) {
     return eventLogs.stream().map(eventLog -> {
       try {
+        if (eventLog.getEntityType() == null) {
+          throw new IllegalStateException("Entity type is null for event with id: " + eventLog.getEventId());
+        }
         switch (eventLog.getEntityType()) {
           case ORDER -> {
             PurchaseOrder entity = Json.decodeValue(eventLog.getPayload(), PurchaseOrder.class);

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -28,6 +28,7 @@ import org.folio.event.handler.InventoryCreateAsyncRecordHandlerTest;
 import org.folio.event.handler.InventoryUpdateAsyncRecordHandlerTest;
 import org.folio.event.handler.ItemCreateAsyncRecordHandlerTest;
 import org.folio.event.handler.ItemUpdateAsyncRecordHandlerTest;
+import org.folio.event.service.AuditOutboxServiceTest;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.orders.lines.update.OrderLineUpdateInstanceHandlerTest;
@@ -286,6 +287,8 @@ public class StorageTestSuite {
   class HoldingUpdateAsyncRecordHandlerTestNested extends HoldingUpdateAsyncRecordHandlerTest {}
   @Nested
   class ItemUpdateAsyncRecordHandlerTestNested extends ItemUpdateAsyncRecordHandlerTest {}
+  @Nested
+  class AuditOutboxServiceTestNested extends AuditOutboxServiceTest {}
   @Nested
   class KafkaEventUtilTestNested extends KafkaEventUtilTest {}
   @Nested

--- a/src/test/java/org/folio/event/service/AuditOutboxServiceTest.java
+++ b/src/test/java/org/folio/event/service/AuditOutboxServiceTest.java
@@ -1,0 +1,119 @@
+package org.folio.event.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.folio.CopilotGenerated;
+import org.folio.dao.InternalLockRepository;
+import org.folio.dao.PostgresClientFactory;
+import org.folio.dao.audit.AuditOutboxEventsLogRepository;
+import org.folio.rest.jaxrs.model.OutboxEventLog;
+import org.folio.rest.persist.Conn;
+import org.folio.rest.persist.PostgresClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.vertx.core.Future;
+
+@CopilotGenerated(partiallyGenerated = true)
+@ExtendWith(MockitoExtension.class)
+public class AuditOutboxServiceTest {
+
+  @Mock
+  private AuditOutboxEventsLogRepository outboxRepository;
+  @Mock
+  private InternalLockRepository lockRepository;
+  @Mock
+  private AuditEventProducer producer;
+  @Mock
+  private PostgresClientFactory pgClientFactory;
+  @Mock
+  private PostgresClient pgClient;
+  @Mock
+  private Conn conn;
+
+  @InjectMocks
+  private AuditOutboxService auditOutboxService;
+
+  @BeforeEach
+  void setUp() {
+    when(pgClientFactory.createInstance(any())).thenReturn(pgClient);
+    when(lockRepository.selectWithLocking(any(), any(), any())).thenReturn(Future.succeededFuture(1));
+    when(pgClient.withTrans(any())).thenAnswer(invocation -> invocation.<Function<Conn, Future<?>>>getArgument(0).apply(conn));
+  }
+
+  @Test
+  void processOutboxEventLogs_handlesEmptyLogsGracefully() {
+    Map<String, String> okapiHeaders = Map.of("x-okapi-tenant", "testTenant");
+    when(outboxRepository.fetchEventLogs(any(), any())).thenReturn(Future.succeededFuture(List.of()));
+
+    Future<Integer> result = auditOutboxService.processOutboxEventLogs(okapiHeaders);
+
+    assertTrue(result.succeeded());
+    assertEquals(0, result.result());
+  }
+
+  @Test
+  void processOutboxEventLogs_sendsEventsAndDeletesLogs() {
+    Map<String, String> okapiHeaders = Map.of("x-okapi-tenant", "testTenant");
+    OutboxEventLog eventLog = new OutboxEventLog()
+      .withEventId("eventId")
+      .withEntityType(OutboxEventLog.EntityType.ORDER)
+      .withAction("Create")
+      .withPayload("{}");
+    when(outboxRepository.fetchEventLogs(any(), any())).thenReturn(Future.succeededFuture(List.of(eventLog)));
+    when(outboxRepository.deleteBatch(any(), any(), any())).thenReturn(Future.succeededFuture(1));
+    when(producer.sendOrderEvent(any(), any(), any())).thenReturn(Future.succeededFuture(true));
+
+    Future<Integer> result = auditOutboxService.processOutboxEventLogs(okapiHeaders);
+
+    assertTrue(result.succeeded());
+    assertEquals(1, result.result());
+  }
+
+  @Test
+  void processOutboxEventLogs_handlesProducerFailure() {
+    Map<String, String> okapiHeaders = Map.of("x-okapi-tenant", "testTenant");
+    OutboxEventLog eventLog = new OutboxEventLog()
+      .withEventId("eventId")
+      .withEntityType(OutboxEventLog.EntityType.ORDER)
+      .withAction("Create")
+      .withPayload("{}");
+    when(outboxRepository.fetchEventLogs(any(), any())).thenReturn(Future.succeededFuture(List.of(eventLog)));
+    when(producer.sendOrderEvent(any(), any(), any())).thenThrow(new RuntimeException("Producer error"));
+
+    Future<Integer> result = auditOutboxService.processOutboxEventLogs(okapiHeaders);
+
+    assertTrue(result.failed());
+    assertEquals("Producer error", result.cause().getMessage());
+  }
+
+  @Test
+  void processOutboxEventLogs_handlesInvalidEntityType() {
+    Map<String, String> okapiHeaders = Map.of("x-okapi-tenant", "testTenant");
+    OutboxEventLog eventLog = new OutboxEventLog()
+      .withEventId("eventId")
+      .withEntityType(null)
+      .withAction("Create")
+      .withPayload("{}");
+    when(outboxRepository.fetchEventLogs(any(), any())).thenReturn(Future.succeededFuture(List.of(eventLog)));
+
+    Future<Integer> result = auditOutboxService.processOutboxEventLogs(okapiHeaders);
+
+    assertTrue(result.failed());
+    assertInstanceOf(IllegalStateException.class, result.cause());
+    assertEquals("Entity type is null for event with id: eventId", result.cause().getMessage());
+  }
+
+}


### PR DESCRIPTION
## Purpose
If only a single event log entity is missing a metadata field, processing halts for all other records

## Approach
Ensure that metadata field is present before sending kafka event, otherwise throw exception and handle it to keep record processing active
