### PR TITLE
[MODORDERS-1279] After move item in inventory piece Holding ID is updated but POL holding ID is not

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -25,6 +25,7 @@ import org.folio.service.UserService;
 import org.folio.services.configuration.TenantLocaleSettingsService;
 import org.folio.services.consortium.ConsortiumConfigurationService;
 import org.folio.services.inventory.InventoryUpdateService;
+import org.folio.services.inventory.OrderLineLocationUpdateService;
 import org.folio.services.lines.PoLineNumbersService;
 import org.folio.services.lines.PoLinesBatchService;
 import org.folio.services.lines.PoLinesService;
@@ -204,6 +205,11 @@ public class ApplicationConfig {
   @Bean
   SettingService settingService() {
     return new SettingService();
+  }
+
+  @Bean
+  OrderLineLocationUpdateService orderLineLocationUpdateService(PoLinesService poLinesService, PieceService pieceService) {
+    return new OrderLineLocationUpdateService(poLinesService, pieceService);
   }
 
   @Bean

--- a/src/main/java/org/folio/event/dto/ItemEventHolder.java
+++ b/src/main/java/org/folio/event/dto/ItemEventHolder.java
@@ -23,6 +23,7 @@ public class ItemEventHolder {
   private String tenantId;
 
   private String itemId;
+  private JsonObject item;
   private String holdingId;
   private Pair<String, String> holdingIdPair;
   private String centralTenantId;
@@ -30,6 +31,7 @@ public class ItemEventHolder {
   public void prepareAllIds() {
     var oldValue = JsonObject.mapFrom(resourceEvent.getOldValue());
     var newValue = JsonObject.mapFrom(resourceEvent.getNewValue());
+    setItem(newValue);
     setItemId(newValue.getString(ItemFields.ID.getValue()));
     setHoldingId(newValue.getString(ItemFields.HOLDINGS_RECORD_ID.getValue()));
     setHoldingIdPair(Pair.of(

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -1,36 +1,29 @@
 package org.folio.event.handler;
 
 import static org.folio.event.InventoryEventType.INVENTORY_ITEM_CREATE;
-import static org.folio.event.dto.ItemFields.EFFECTIVE_LOCATION_ID;
 import static org.folio.event.dto.ItemFields.HOLDINGS_RECORD_ID;
 import static org.folio.event.dto.ItemFields.ID;
-import static org.folio.util.HelperUtils.collectResultsOnSuccess;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import java.util.ArrayList;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
-import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PieceAuditEvent;
-import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
-import org.folio.services.lines.PoLinesService;
+import org.folio.services.inventory.OrderLineLocationUpdateService;
 import org.folio.services.piece.PieceService;
 import org.folio.spring.SpringContextUtil;
 import org.folio.util.HeaderUtils;
@@ -41,10 +34,8 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
 
   @Autowired
   private PieceService pieceService;
-
   @Autowired
-  private PoLinesService poLinesService;
-
+  private OrderLineLocationUpdateService orderLineLocationUpdateService;
   @Autowired
   private AuditOutboxService auditOutboxService;
 
@@ -59,14 +50,11 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
     var itemObject = JsonObject.mapFrom(resourceEvent.getNewValue());
     var itemId = itemObject.getString(ID.getValue());
     var tenantIdFromEvent = resourceEvent.getTenant();
+    var updatedHeaders = HeaderUtils.prepareHeaderForTenant(centralTenantId, headers);
     return dbClient.getPgClient()
-      .withTrans(conn -> {
-        var updatedHeaders = HeaderUtils.prepareHeaderForTenant(centralTenantId, headers);
-        return pieceService.getPiecesByItemId(itemId, conn)
-          .compose(pieces -> processPiecesUpdate(pieces, itemObject, tenantIdFromEvent, centralTenantId, updatedHeaders, conn))
-          .compose(updatedPieces -> processPoLinesUpdate(updatedPieces, itemObject, tenantIdFromEvent, centralTenantId, updatedHeaders, conn));
-        }
-      )
+      .withTrans(conn -> pieceService.getPiecesByItemId(itemId, conn)
+        .compose(pieces -> processPiecesUpdate(pieces, itemObject, tenantIdFromEvent, centralTenantId, updatedHeaders, conn))
+        .compose(updatedPieces -> processPoLinesUpdate(updatedPieces, itemObject, tenantIdFromEvent, centralTenantId, updatedHeaders, conn)))
       .onComplete(v -> auditOutboxService.processOutboxEventLogs(headers))
       .mapEmpty();
   }
@@ -130,96 +118,11 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
         itemObject.getString(ID.getValue()), tenantIdFromEvent, centralTenantId);
       return Future.succeededFuture();
     }
-    var poLineIds = pieces.stream()
-      .map(Piece::getPoLineId)
-      .distinct()
-      .toList();
+    var poLineIds = pieces.stream().map(Piece::getPoLineId).distinct().toList();
     log.debug("processPoLinesUpdate:: Preparing '{}' poLineIds for update processing", poLineIds.size());
-    return poLinesService.getPoLinesByLineIdsByChunks(poLineIds, conn)
-      .compose(poLines -> {
-        var poLinePiecePairsFutures = new ArrayList<Future<Pair<PoLine, List<Piece>>>>();
-        poLines.forEach(poLine -> {
-          var piecesFuture = pieceService.getPiecesByPoLineId(poLine.getId(), conn)
-            .map(allPieces -> Pair.of(poLine, allPieces));
-          poLinePiecePairsFutures.add(piecesFuture);
-        });
-        return collectResultsOnSuccess(poLinePiecePairsFutures);
-      })
-      .compose(poLinePiecePairs -> updatePoLines(poLinePiecePairs, itemObject, centralTenantId, headers, conn))
+    return orderLineLocationUpdateService.updatePoLineLocationData(poLineIds, itemObject, centralTenantId, headers, conn)
+      .compose(updatedPoLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, updatedPoLines, OrderLineAuditEvent.Action.EDIT, headers))
       .mapEmpty();
   }
 
-  // Update locations and searchLocationIds for each POL
-  private Future<List<PoLine>> updatePoLines(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, JsonObject itemObject,
-                                             String centralTenantId, Map<String, String> headers, Conn conn) {
-    log.info("updatePoLines:: Updating '{}' POL(s) for item: '{}' in centralTenant: '{}'",
-      poLinePiecePairs.size(), itemObject.getString(ID.getValue()), centralTenantId);
-    var updatedPoLines = processPoLinePiecePairs(poLinePiecePairs, itemObject);
-    if (CollectionUtils.isEmpty(updatedPoLines)) {
-      log.info("updatePoLines:: No POLs were changed to update for item: '{}'", itemObject.getString(ID.getValue()));
-      return Future.succeededFuture(List.of());
-    }
-    return poLinesService.updatePoLines(updatedPoLines, conn, centralTenantId, headers)
-      .compose(v -> auditOutboxService.saveOrderLinesOutboxLogs(conn, updatedPoLines, OrderLineAuditEvent.Action.EDIT, headers))
-      .mapEmpty();
-  }
-
-  private ArrayList<PoLine> processPoLinePiecePairs(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, JsonObject itemObject) {
-    var updatedPoLines = new ArrayList<PoLine>();
-    poLinePiecePairs.forEach(poLineListPair -> {
-      var poLine = poLineListPair.getLeft();
-      var pieces = poLineListPair.getRight();
-      var isLocationsUpdated = updatePoLineLocations(pieces, poLine);
-      var isSearchLocationIdsUpdated = updatePoLineSearchLocationIds(itemObject, poLine);
-      if (Boolean.TRUE.equals(isLocationsUpdated) || Boolean.TRUE.equals(isSearchLocationIdsUpdated)) {
-        updatedPoLines.add(poLine);
-      }
-    });
-    return updatedPoLines;
-  }
-
-  private boolean updatePoLineLocations(List<Piece> pieces, PoLine poLine) {
-    var locations = new ArrayList<Location>();
-    var piecesByTenantIdGrouped = pieces.stream().filter(Objects::nonNull)
-      .filter(piece -> Objects.nonNull(piece.getReceivingTenantId()))
-      .collect(Collectors.groupingBy(Piece::getReceivingTenantId, Collectors.toList()));
-    piecesByTenantIdGrouped.forEach((tenantId, piecesByTenant) -> {
-      var piecesByHoldingIdGrouped = piecesByTenant.stream().filter(Objects::nonNull)
-        .filter(piece -> Objects.nonNull(piece.getHoldingId()))
-        .collect(Collectors.groupingBy(Piece::getHoldingId, Collectors.toList()));
-      piecesByHoldingIdGrouped.forEach((holdingId, piecesByHoldings) -> {
-        var piecesByFormat = piecesByHoldings.stream().filter(Objects::nonNull)
-          .filter(piece -> Objects.nonNull(piece.getFormat()))
-          .collect(Collectors.groupingBy(Piece::getFormat, Collectors.toList()));
-        var location = new Location().withTenantId(tenantId)
-          .withHoldingId(holdingId)
-          .withQuantity(piecesByHoldings.size())
-          .withQuantityPhysical(piecesByFormat.getOrDefault(Piece.Format.PHYSICAL, List.of()).size())
-          .withQuantityElectronic(piecesByFormat.getOrDefault(Piece.Format.ELECTRONIC, List.of()).size());
-        locations.add(location);
-      });
-    });
-    if (locations.isEmpty() || Objects.equals(locations, poLine.getLocations())) {
-      log.info("updatePoLineLocations:: No POL locations were found to update, poLineId: {}", poLine.getId());
-      return false;
-    }
-    log.info("updatePoLineLocations:: Updating POL '{}' locations, old locations: '{}'", poLine.getId(), JsonArray.of(poLine.getLocations()).encode());
-    poLine.withLocations(locations);
-    log.info("updatePoLineLocations:: Updating POL '{}' locations, new locations: '{}'", poLine.getId(), JsonArray.of(locations).encode());
-    return true;
-  }
-
-  private boolean updatePoLineSearchLocationIds(JsonObject itemObject, PoLine poLine) {
-    var searchLocationIds = poLine.getSearchLocationIds();
-    var effectiveLocationId = itemObject.getString(EFFECTIVE_LOCATION_ID.getValue());
-    if (searchLocationIds.contains(effectiveLocationId)) {
-      log.info("updatePoLineSearchLocationIds:: No POL search locations were found to update, poLineId: {}", poLine.getId());
-      return false;
-    }
-    log.info("updatePoLineSearchLocationIds:: Updating POL '{}' searchLocationIds, old searchLocationIds: '{}'", poLine.getId(), poLine.getSearchLocationIds());
-    searchLocationIds.add(effectiveLocationId);
-    poLine.withSearchLocationIds(searchLocationIds);
-    log.info("updatePoLineSearchLocationIds:: Updating POL '{}' searchLocationIds, new searchLocationIds: '{}'", poLine.getId(), searchLocationIds);
-    return true;
-  }
 }

--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -74,7 +74,7 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
     var piecesToUpdate = filterPiecesToUpdate(holder, pieces);
 
     if (CollectionUtils.isEmpty(piecesToUpdate)) {
-      log.info("updatePoLines:: No Pieces were found for holding to update, itemId: {}, holdingId: {}",
+      log.info("updatePieces:: No Pieces were found for holding to update, itemId: {}, holdingId: {}",
         holder.getItemId(), holder.getHoldingId());
       return Future.succeededFuture(List.of());
     }
@@ -86,9 +86,7 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
   private List<Piece> filterPiecesToUpdate(ItemEventHolder holder, List<Piece> pieces) {
     return pieces.stream()
       .filter(Objects::nonNull)
-      .filter(piece ->
-        ObjectUtils.notEqual(piece.getHoldingId(), holder.getHoldingId())
-          && Objects.isNull(piece.getLocationId()))
+      .filter(piece -> ObjectUtils.notEqual(piece.getHoldingId(), holder.getHoldingId()) && Objects.isNull(piece.getLocationId()))
       .toList();
   }
 
@@ -100,7 +98,7 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
     }
     var poLineIds = pieces.stream().map(Piece::getPoLineId).distinct().toList();
     log.debug("processPoLinesUpdate:: Preparing '{}' poLineIds for update processing", poLineIds.size());
-    return orderLineLocationUpdateService.updatePoLineLocationData(poLineIds, holder.getItem(), holder.getCentralTenantId(), holder.getHeaders(), conn)
+    return orderLineLocationUpdateService.updatePoLineLocationData(poLineIds, holder.getItem(), holder.getActiveTenantId(), holder.getHeaders(), conn)
       .compose(updatedPoLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, updatedPoLines, OrderLineAuditEvent.Action.EDIT, holder.getHeaders()))
       .mapEmpty();
   }

--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -16,9 +16,11 @@ import org.apache.commons.lang.ObjectUtils;
 import org.folio.event.dto.ItemEventHolder;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
+import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PieceAuditEvent;
 import org.folio.rest.persist.Conn;
+import org.folio.services.inventory.OrderLineLocationUpdateService;
 import org.folio.services.piece.PieceService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +30,8 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
 
   @Autowired
   private PieceService pieceService;
-
+  @Autowired
+  private OrderLineLocationUpdateService orderLineLocationUpdateService;
   @Autowired
   private AuditOutboxService auditOutboxService;
 
@@ -53,16 +56,18 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
     holder.setCentralTenantId(centralTenantId);
     var dbClient = createDBClient(holder.getActiveTenantId());
     return dbClient.getPgClient()
-      .withTrans(conn -> processPiecesUpdate(holder, conn))
+      .withTrans(conn -> processPiecesUpdate(holder, conn)
+        .compose(pieces -> processPoLinesUpdate(pieces, holder, conn)))
       .onComplete(v -> auditOutboxService.processOutboxEventLogs(holder.getHeaders()))
       .mapEmpty();
   }
 
-  private Future<Boolean> processPiecesUpdate(ItemEventHolder holder, Conn conn) {
+  private Future<List<Piece>> processPiecesUpdate(ItemEventHolder holder, Conn conn) {
     return pieceService.getPiecesByItemId(holder.getItemId(), conn)
       .compose(pieces -> updatePieces(holder, pieces, conn))
-      .compose(piecesToUpdate -> auditOutboxService.savePiecesOutboxLog(conn, piecesToUpdate, PieceAuditEvent.Action.EDIT,
-        holder.getHeaders()));
+      .compose(piecesToUpdate -> auditOutboxService
+        .savePiecesOutboxLog(conn, piecesToUpdate, PieceAuditEvent.Action.EDIT, holder.getHeaders())
+        .map(piecesToUpdate));
   }
 
   private Future<List<Piece>> updatePieces(ItemEventHolder holder, List<Piece> pieces, Conn conn) {
@@ -87,6 +92,19 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
       .toList();
   }
 
+  private Future<Void> processPoLinesUpdate(List<Piece> pieces, ItemEventHolder holder, Conn conn) {
+    if (CollectionUtils.isEmpty(pieces)) {
+      log.info("processPoLinesUpdate:: No updated pieces were found to update for item: '{}' and tenant: '{}' in centralTenant: {}",
+        holder.getItemId(), holder.getTenantId(), holder.getCentralTenantId());
+      return Future.succeededFuture();
+    }
+    var poLineIds = pieces.stream().map(Piece::getPoLineId).distinct().toList();
+    log.debug("processPoLinesUpdate:: Preparing '{}' poLineIds for update processing", poLineIds.size());
+    return orderLineLocationUpdateService.updatePoLineLocationData(poLineIds, holder.getItem(), holder.getCentralTenantId(), holder.getHeaders(), conn)
+      .compose(updatedPoLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, updatedPoLines, OrderLineAuditEvent.Action.EDIT, holder.getHeaders()))
+      .mapEmpty();
+  }
+
   private ItemEventHolder createItemEventHolder(ResourceEvent resourceEvent, Map<String, String> headers) {
     return ItemEventHolder.builder()
       .resourceEvent(resourceEvent)
@@ -94,4 +112,5 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
       .tenantId(extractTenantFromHeaders(headers))
       .build();
   }
+
 }

--- a/src/main/java/org/folio/services/inventory/OrderLineLocationUpdateService.java
+++ b/src/main/java/org/folio/services/inventory/OrderLineLocationUpdateService.java
@@ -1,0 +1,112 @@
+package org.folio.services.inventory;
+
+import static org.folio.event.dto.ItemFields.EFFECTIVE_LOCATION_ID;
+import static org.folio.event.dto.ItemFields.ID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.rest.jaxrs.model.Location;
+import org.folio.rest.jaxrs.model.Piece;
+import org.folio.rest.jaxrs.model.PoLine;
+import org.folio.rest.persist.Conn;
+import org.folio.services.lines.PoLinesService;
+import org.folio.services.piece.PieceService;
+import org.folio.util.HelperUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class OrderLineLocationUpdateService {
+
+  @Autowired
+  private PoLinesService poLinesService;
+  @Autowired
+  private PieceService pieceService;
+
+  public Future<List<PoLine>> updatePoLineLocationData(List<String> poLineIds, JsonObject item, String centralTenantId, Map<String, String> headers, Conn conn) {
+    return poLinesService.getPoLinesByLineIdsByChunks(poLineIds, conn)
+      .map(poLines -> poLines.stream().map(poLine -> pieceService
+          .getPiecesByPoLineId(poLine.getId(), conn)
+          .map(pieces -> Pair.of(poLine, pieces)))
+        .toList())
+      .compose(HelperUtils::collectResultsOnSuccess)
+      .compose(poLinePiecePairs -> updatePoLines(poLinePiecePairs, item, centralTenantId, headers, conn));
+  }
+
+  private Future<List<PoLine>> updatePoLines(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, JsonObject item,
+                                             String centralTenantId, Map<String, String> headers, Conn conn) {
+    log.info("updatePoLines:: Updating '{}' POL(s) for item: '{}' in centralTenant: '{}'",
+      poLinePiecePairs.size(), item.getString(ID.getValue()), centralTenantId);
+    var poLinesToUpdate = processPoLinePiecePairs(poLinePiecePairs, item);
+    if (CollectionUtils.isEmpty(poLinesToUpdate)) {
+      log.info("updatePoLines:: No POLs were changed to update for item: '{}'", item.getString(ID.getValue()));
+      return Future.succeededFuture(List.of());
+    }
+    return poLinesService.updatePoLines(poLinesToUpdate, conn, centralTenantId, headers)
+      .map(v -> poLinesToUpdate);
+  }
+
+  private List<PoLine> processPoLinePiecePairs(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, JsonObject itemObject) {
+    return poLinePiecePairs.stream().map(poLineListPair -> {
+        var poLine = poLineListPair.getLeft();
+        var pieces = poLineListPair.getRight();
+        var isLocationsUpdated = updatePoLineLocations(poLine, pieces);
+        var isSearchLocationIdsUpdated = updatePoLineSearchLocationIds(poLine, itemObject.getString(EFFECTIVE_LOCATION_ID.getValue()));
+        return isLocationsUpdated || isSearchLocationIdsUpdated
+          ? poLine
+          : null;
+      })
+      .filter(Objects::nonNull)
+      .toList();
+  }
+
+  private boolean updatePoLineLocations(PoLine poLine, List<Piece> pieces) {
+    var locations = new ArrayList<Location>();
+    var piecesByTenantIdGrouped = pieces.stream().filter(Objects::nonNull)
+      .filter(piece -> Objects.nonNull(piece.getReceivingTenantId()))
+      .collect(Collectors.groupingBy(Piece::getReceivingTenantId, Collectors.toList()));
+    piecesByTenantIdGrouped.forEach((tenantId, piecesByTenant) -> {
+      var piecesByHoldingIdGrouped = piecesByTenant.stream().filter(Objects::nonNull)
+        .filter(piece -> Objects.nonNull(piece.getHoldingId()))
+        .collect(Collectors.groupingBy(Piece::getHoldingId, Collectors.toList()));
+      piecesByHoldingIdGrouped.forEach((holdingId, piecesByHoldings) -> {
+        var piecesByFormat = piecesByHoldings.stream().filter(Objects::nonNull)
+          .filter(piece -> Objects.nonNull(piece.getFormat()))
+          .collect(Collectors.groupingBy(Piece::getFormat, Collectors.toList()));
+        locations.add(new Location().withTenantId(tenantId)
+          .withHoldingId(holdingId)
+          .withQuantity(piecesByHoldings.size())
+          .withQuantityPhysical(piecesByFormat.getOrDefault(Piece.Format.PHYSICAL, List.of()).size())
+          .withQuantityElectronic(piecesByFormat.getOrDefault(Piece.Format.ELECTRONIC, List.of()).size()));
+      });
+    });
+    if (locations.isEmpty() || Objects.equals(locations, poLine.getLocations())) {
+      return false;
+    }
+    log.info("updatePoLineLocations:: Replacing locations of POL: '{}' having old value: '{}' with new value: '{}'",
+      poLine.getId(), JsonArray.of(poLine.getLocations()).encode(), JsonArray.of(locations).encode());
+    poLine.withLocations(locations);
+    return true;
+  }
+
+  private boolean updatePoLineSearchLocationIds(PoLine poLine, String itemEffectiveLocation) {
+    if (poLine.getSearchLocationIds().contains(itemEffectiveLocation)) {
+      return false;
+    }
+    log.info("updatePoLineSearchLocationIds:: Updating POL: '{}' having searchLocationIds: '{}' with additional value: '{}'",
+      poLine.getId(), poLine.getSearchLocationIds(), itemEffectiveLocation);
+    poLine.getSearchLocationIds().add(itemEffectiveLocation);
+    return true;
+  }
+
+}

--- a/src/main/java/org/folio/services/inventory/OrderLineLocationUpdateService.java
+++ b/src/main/java/org/folio/services/inventory/OrderLineLocationUpdateService.java
@@ -18,20 +18,19 @@ import org.folio.rest.persist.Conn;
 import org.folio.services.lines.PoLinesService;
 import org.folio.services.piece.PieceService;
 import org.folio.util.HelperUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
+@AllArgsConstructor
 @Log4j2
 public class OrderLineLocationUpdateService {
 
-  @Autowired
-  private PoLinesService poLinesService;
-  @Autowired
-  private PieceService pieceService;
+  private final PoLinesService poLinesService;
+  private final PieceService pieceService;
 
   public Future<List<PoLine>> updatePoLineLocationData(List<String> poLineIds, JsonObject item, String centralTenantId, Map<String, String> headers, Conn conn) {
     return poLinesService.getPoLinesByLineIdsByChunks(poLineIds, conn)

--- a/src/main/java/org/folio/util/InventoryUtils.java
+++ b/src/main/java/org/folio/util/InventoryUtils.java
@@ -2,6 +2,7 @@ package org.folio.util;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import org.folio.rest.jaxrs.model.Contributor;
 import org.folio.rest.jaxrs.model.ProductId;
@@ -20,10 +21,8 @@ import static org.folio.event.dto.InstanceFields.PUBLISHER;
 import static org.folio.event.dto.InstanceFields.TITLE;
 
 @Log4j2
+@UtilityClass
 public class InventoryUtils {
-
-  private InventoryUtils() {
-  }
 
   public static String getInstanceTitle(JsonObject instance) {
     return instance.getString(TITLE.getValue());
@@ -72,4 +71,5 @@ public class InventoryUtils {
         .withProductIdType(jsonObject.getString(IDENTIFIER_TYPE_ID.getValue())))
       .toList();
   }
+
 }

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -496,11 +496,13 @@ public class ItemCreateAsyncRecordHandlerTest {
       piecesByHoldingIdGrouped.forEach((holdingId, piecesByHolding) -> {
         var piecesByFormat = piecesByHolding.stream()
           .collect(groupingBy(Piece::getFormat, Collectors.toList()));
+        var qtyPhysical = piecesByFormat.getOrDefault(Piece.Format.PHYSICAL, List.of()).size();
+        var qtyElectronic = piecesByFormat.getOrDefault(Piece.Format.ELECTRONIC, List.of()).size();
         var location = new Location().withTenantId(tenantId)
           .withHoldingId(holdingId)
           .withQuantity(piecesByHolding.size())
-          .withQuantityPhysical(piecesByFormat.getOrDefault(Piece.Format.PHYSICAL, List.of()).size())
-          .withQuantityElectronic(piecesByFormat.getOrDefault(Piece.Format.ELECTRONIC, List.of()).size());
+          .withQuantityPhysical(qtyPhysical > 0 ? qtyPhysical : null)
+          .withQuantityElectronic(qtyElectronic > 0 ? qtyElectronic : null);
         oldLocations.add(location);
       });
     });

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -55,6 +55,7 @@ import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.services.consortium.ConsortiumConfigurationService;
+import org.folio.services.inventory.OrderLineLocationUpdateService;
 import org.folio.services.lines.PoLinesService;
 import org.folio.services.piece.PieceService;
 import org.folio.services.setting.SettingService;
@@ -73,6 +74,8 @@ public class ItemCreateAsyncRecordHandlerTest {
   private PieceService pieceService;
   @Mock
   private PoLinesService poLinesService;
+  @Spy
+  private OrderLineLocationUpdateService orderLineLocationUpdateService;
   @Mock
   private ConsortiumConfigurationService consortiumConfigurationService;
   @Mock
@@ -92,9 +95,11 @@ public class ItemCreateAsyncRecordHandlerTest {
       var vertx = Vertx.vertx();
       var itemHandler = new ItemCreateAsyncRecordHandler(vertx, mockContext(vertx));
       TestUtils.setInternalState(itemHandler, "pieceService", pieceService);
-      TestUtils.setInternalState(itemHandler, "poLinesService", poLinesService);
+      TestUtils.setInternalState(itemHandler, "orderLineLocationUpdateService", orderLineLocationUpdateService);
       TestUtils.setInternalState(itemHandler, "consortiumConfigurationService", consortiumConfigurationService);
       TestUtils.setInternalState(itemHandler, "auditOutboxService", auditOutboxService);
+      TestUtils.setInternalState(orderLineLocationUpdateService, "pieceService", pieceService);
+      TestUtils.setInternalState(orderLineLocationUpdateService, "poLinesService", poLinesService);
       handler = spy(itemHandler);
       doReturn(Future.succeededFuture(Optional.of(new Setting().withValue("true"))))
         .when(settingService).getSettingByKey(eq(SettingKey.CENTRAL_ORDERING_ENABLED), any(), any());

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -62,6 +62,7 @@ import org.folio.services.setting.SettingService;
 import org.folio.services.setting.util.SettingKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -74,8 +75,6 @@ public class ItemCreateAsyncRecordHandlerTest {
   private PieceService pieceService;
   @Mock
   private PoLinesService poLinesService;
-  @Spy
-  private OrderLineLocationUpdateService orderLineLocationUpdateService;
   @Mock
   private ConsortiumConfigurationService consortiumConfigurationService;
   @Mock
@@ -86,6 +85,8 @@ public class ItemCreateAsyncRecordHandlerTest {
   private PostgresClient pgClient;
   @Mock
   private Conn conn;
+  @InjectMocks
+  private OrderLineLocationUpdateService orderLineLocationUpdateService;
 
   private InventoryCreateAsyncRecordHandler handler;
 
@@ -98,8 +99,6 @@ public class ItemCreateAsyncRecordHandlerTest {
       TestUtils.setInternalState(itemHandler, "orderLineLocationUpdateService", orderLineLocationUpdateService);
       TestUtils.setInternalState(itemHandler, "consortiumConfigurationService", consortiumConfigurationService);
       TestUtils.setInternalState(itemHandler, "auditOutboxService", auditOutboxService);
-      TestUtils.setInternalState(orderLineLocationUpdateService, "pieceService", pieceService);
-      TestUtils.setInternalState(orderLineLocationUpdateService, "poLinesService", poLinesService);
       handler = spy(itemHandler);
       doReturn(Future.succeededFuture(Optional.of(new Setting().withValue("true"))))
         .when(settingService).getSettingByKey(eq(SettingKey.CENTRAL_ORDERING_ENABLED), any(), any());

--- a/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
@@ -53,6 +53,7 @@ import org.folio.services.setting.SettingService;
 import org.folio.services.setting.util.SettingKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -66,8 +67,6 @@ public class ItemUpdateAsyncRecordHandlerTest {
   private PieceService pieceService;
   @Mock
   private PoLinesService poLinesService;
-  @Spy
-  private OrderLineLocationUpdateService orderLineLocationUpdateService;
   @Mock
   private AuditOutboxService auditOutboxService;
   @Mock
@@ -80,6 +79,8 @@ public class ItemUpdateAsyncRecordHandlerTest {
   private ConsortiumConfigurationService consortiumConfigurationService;
   @Mock
   private SettingService settingService;
+  @InjectMocks
+  private OrderLineLocationUpdateService orderLineLocationUpdateService;
 
   private InventoryUpdateAsyncRecordHandler handler;
 
@@ -92,8 +93,6 @@ public class ItemUpdateAsyncRecordHandlerTest {
       TestUtils.setInternalState(itemHandler, "orderLineLocationUpdateService", orderLineLocationUpdateService);
       TestUtils.setInternalState(itemHandler, "auditOutboxService", auditOutboxService);
       TestUtils.setInternalState(itemHandler, "consortiumConfigurationService", consortiumConfigurationService);
-      TestUtils.setInternalState(orderLineLocationUpdateService, "pieceService", pieceService);
-      TestUtils.setInternalState(orderLineLocationUpdateService, "poLinesService", poLinesService);
       handler = spy(itemHandler);
       doReturn(Future.succeededFuture(Optional.of(new Setting().withValue("true"))))
         .when(settingService).getSettingByKey(eq(SettingKey.CENTRAL_ORDERING_ENABLED), any(), any());

--- a/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
@@ -123,9 +123,8 @@ public class ItemUpdateAsyncRecordHandlerTest {
     var newItemValueBeforeUpdate = createItem(itemId, holdingId2).put(ItemFields.EFFECTIVE_LOCATION_ID.getValue(), effectiveLocationId2);
     var kafkaRecord = createKafkaRecordWithValues(oldItemValueBeforeUpdate, newItemValueBeforeUpdate);
 
-    var poLine = createPoLine(poLineId, holdingId1);
-    var expectedPoLine = createPoLine(poLineId, holdingId1);
-    expectedPoLine.getSearchLocationIds().add(effectiveLocationId2);
+    var poLine = createPoLine(poLineId, holdingId1, effectiveLocationId1);
+    var expectedPoLine = createPoLine(poLineId, holdingId2, effectiveLocationId1, effectiveLocationId2);
 
     var actualPieces = List.of(
       createPiece(pieceId1, itemId, holdingId1, null).withPoLineId(poLineId),
@@ -235,9 +234,9 @@ public class ItemUpdateAsyncRecordHandlerTest {
     verifyNoInteractions(pieceService);
   }
 
-  private static PoLine createPoLine(String poLineId, String holdingId) {
+  private static PoLine createPoLine(String poLineId, String holdingId, String... effectiveLocationIds) {
     return new PoLine().withId(poLineId)
-      .withSearchLocationIds(new ArrayList<>(List.of(holdingId)))
+      .withSearchLocationIds(new ArrayList<>(List.of(effectiveLocationIds)))
       .withLocations(new ArrayList<>(List.of(new Location().withHoldingId(holdingId).withQuantity(1).withQuantityPhysical(1))));
   }
 


### PR DESCRIPTION
## Purpose
[[MODORDERS-1279] After move item in inventory piece Holding ID is updated but POL holding ID is not](https://folio-org.atlassian.net/browse/MODORDERS-1279)

## Approach
- Create a new service for updating po line location fields after item creation/update
- Update po line location fields in kafka event listeners
- Update tests