### PR TITLE
[MODORDSTOR-472]. Remove custom fields reference data loading

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -25,6 +25,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 public class TenantReferenceAPI extends TenantAPI {
+
   private static final Logger log = LogManager.getLogger();
   private static final String PARAMETER_LOAD_SAMPLE = "loadSample";
   private static final String PARAMETER_LOAD_SYSTEM = "loadSystem";
@@ -35,7 +36,8 @@ public class TenantReferenceAPI extends TenantAPI {
   }
 
   @Override
-  public Future<Integer> loadData(TenantAttributes attributes, String tenantId, Map<String, String> headers, Context vertxContext) {
+  public Future<Integer> loadData(TenantAttributes attributes, String tenantId,
+                                  Map<String, String> headers, Context vertxContext) {
     log.info("postTenant");
     Vertx vertx = vertxContext.owner();
     Parameter parameter = new Parameter().withKey(PARAMETER_LOAD_SYSTEM).withValue("true");
@@ -76,7 +78,6 @@ public class TenantReferenceAPI extends TenantAPI {
     if (isNew(tenantAttributes, "13.7.0")) {
       tl.withKey(PARAMETER_LOAD_SAMPLE)
         .withLead("data")
-        .add("custom-fields", "custom-fields")
         .add("purchase-orders", "orders-storage/purchase-orders")
         .add("po-lines", "orders-storage/po-lines")
         .add("titles", "orders-storage/titles")
@@ -120,14 +121,14 @@ public class TenantReferenceAPI extends TenantAPI {
   }
 
   @Override
-  public void deleteTenantByOperationId(String operationId, Map<String, String> headers, Handler<AsyncResult<Response>> hndlr,
-    Context cntxt) {
+  public void deleteTenantByOperationId(String operationId, Map<String, String> headers,
+                                        Handler<AsyncResult<Response>> handler, Context context) {
     log.info("deleteTenant, operationId={}", operationId);
     super.deleteTenantByOperationId(operationId, headers, res -> {
-      Vertx vertx = cntxt.owner();
+      Vertx vertx = context.owner();
       String tenantId = TenantTool.tenantId(headers);
       PostgresClient.getInstance(vertx, tenantId)
-        .closeClient(event -> hndlr.handle(res));
-    }, cntxt);
+        .closeClient(event -> handler.handle(res));
+    }, context);
   }
 }

--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -78,6 +78,8 @@ public class TenantReferenceAPI extends TenantAPI {
     if (isNew(tenantAttributes, "13.7.0")) {
       tl.withKey(PARAMETER_LOAD_SAMPLE)
         .withLead("data")
+        // Disabled in response to https://folio-org.atlassian.net/browse/MODORDSTOR-472
+        // .add("custom-fields", "custom-fields")
         .add("purchase-orders", "orders-storage/purchase-orders")
         .add("po-lines", "orders-storage/po-lines")
         .add("titles", "orders-storage/titles")

--- a/src/main/resources/data/po-lines/101101-1_pending_physical_checkin-true.json
+++ b/src/main/resources/data/po-lines/101101-1_pending_physical_checkin-true.json
@@ -87,6 +87,5 @@
     "vendorAccount": ""
   },
   "customFields": {
-    "membership": "opt_0"
   }
 }

--- a/src/main/resources/data/purchase-orders/101101_ongoing_pending.json
+++ b/src/main/resources/data/purchase-orders/101101_ongoing_pending.json
@@ -18,6 +18,5 @@
   "vendor": "14fb6608-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
   "customFields": {
-    "externalOrderNumber": "ABC123"
   }
 }

--- a/src/test/java/org/folio/rest/impl/CustomFieldsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsAPITest.java
@@ -64,8 +64,8 @@ public class CustomFieldsAPITest extends TestBase {
   void testCustomFieldStatisticCount() {
     populateSampleData();
 
-    assertEquals(2, getCustomFieldStatisticCount(customFieldsPO.get(0)));
-    assertEquals(3, getCustomFieldStatisticCount(customFieldsPOL.get(0)));
+    assertEquals(2, getCustomFieldStatisticCount(customFieldsPO.getFirst()));
+    assertEquals(3, getCustomFieldStatisticCount(customFieldsPOL.getFirst()));
   }
 
   @Test
@@ -81,7 +81,7 @@ public class CustomFieldsAPITest extends TestBase {
     populateSampleData();
 
     // delete custom field PO
-    deleteCustomField(customFieldsPO.get(0));
+    deleteCustomField(customFieldsPO.getFirst());
 
     // POs should be updated
     Map<String, PurchaseOrder> allPurchaseOrders = getAllPurchaseOrders();
@@ -101,31 +101,31 @@ public class CustomFieldsAPITest extends TestBase {
 
     // order template remains unchanged
     assertThat(
-      getAllOrderTemplates().get(orderTemplates.get(0).getId()),
-      samePropertyValuesAs(orderTemplates.get(0)));
+      getAllOrderTemplates().get(orderTemplates.getFirst().getId()),
+      samePropertyValuesAs(orderTemplates.getFirst()));
 
     // delete custom field POL
-    deleteCustomField(customFieldsPOL.get(0));
+    deleteCustomField(customFieldsPOL.getFirst());
 
     // POs remain unchanged
     allPurchaseOrders = getAllPurchaseOrders();
-    PurchaseOrder purchaseOrder1_1 = allPurchaseOrders.get(purchaseOrders.get(0).getId());
-    PurchaseOrder purchaseOrder2_1 = allPurchaseOrders.get(purchaseOrders.get(1).getId());
-    assertThat(purchaseOrder1_1, samePropertyValuesAs(purchaseOrder1));
-    assertThat(purchaseOrder2_1, samePropertyValuesAs(purchaseOrder2));
+    PurchaseOrder purchaseOrder11 = allPurchaseOrders.get(purchaseOrders.get(0).getId());
+    PurchaseOrder purchaseOrder21 = allPurchaseOrders.get(purchaseOrders.get(1).getId());
+    assertThat(purchaseOrder11, samePropertyValuesAs(purchaseOrder1));
+    assertThat(purchaseOrder21, samePropertyValuesAs(purchaseOrder2));
 
     // POLs should be updated
     allPoLines = getAllPoLines();
-    PoLine poLine1_1 = allPoLines.get(poLines.get(0).getId());
-    PoLine poLine2_1 = allPoLines.get(poLines.get(1).getId());
-    assertEquals(2, poLine1_1.getCustomFields().getAdditionalProperties().size());
-    assertNull(poLine1_1.getCustomFields().getAdditionalProperties().get("textbox_2"));
-    assertEquals(2, poLine2_1.getCustomFields().getAdditionalProperties().size());
-    assertNull(poLine2_1.getCustomFields().getAdditionalProperties().get("textbox_2"));
+    PoLine poLine1a = allPoLines.get(poLines.get(0).getId());
+    PoLine poLine2a = allPoLines.get(poLines.get(1).getId());
+    assertEquals(2, poLine1a.getCustomFields().getAdditionalProperties().size());
+    assertNull(poLine1a.getCustomFields().getAdditionalProperties().get("textbox_2"));
+    assertEquals(2, poLine2a.getCustomFields().getAdditionalProperties().size());
+    assertNull(poLine2a.getCustomFields().getAdditionalProperties().get("textbox_2"));
 
     // order template should be updated
     Map<String, OrderTemplate> allOrderTemplates = getAllOrderTemplates();
-    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.get(0).getId());
+    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.getFirst().getId());
     JsonObject customFieldData = getCustomFieldData(orderTemplate);
     assertEquals(4, customFieldData.size());
     assertNull(customFieldData.getValue("textbox"));
@@ -136,7 +136,7 @@ public class CustomFieldsAPITest extends TestBase {
     populateSampleData();
 
     // remove single option from custom field PO
-    customFieldsPO.get(1).getSelectField().getOptions().getValues().remove(0);
+    customFieldsPO.get(1).getSelectField().getOptions().getValues().removeFirst();
     putCustomField(customFieldsPO.get(1));
 
     // POs should be updated
@@ -156,33 +156,33 @@ public class CustomFieldsAPITest extends TestBase {
 
     // order template should be updated
     Map<String, OrderTemplate> allOrderTemplates = getAllOrderTemplates();
-    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.get(0).getId());
+    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.getFirst().getId());
     JsonObject customFieldData = getCustomFieldData(orderTemplate);
     assertEquals(4, customFieldData.size());
     assertNull(customFieldData.getValue("singleselect"));
 
     // remove single option from custom field POL
-    customFieldsPOL.get(1).getSelectField().getOptions().getValues().remove(0);
+    customFieldsPOL.get(1).getSelectField().getOptions().getValues().removeFirst();
     putCustomField(customFieldsPOL.get(1));
 
     // POs should remain unchanged
     allPurchaseOrders = getAllPurchaseOrders();
-    PurchaseOrder purchaseOrder1_1 = allPurchaseOrders.get(purchaseOrders.get(0).getId());
-    PurchaseOrder purchaseOrder2_1 = allPurchaseOrders.get(purchaseOrders.get(1).getId());
-    assertThat(purchaseOrder1_1, samePropertyValuesAs(purchaseOrder1));
-    assertThat(purchaseOrder2_1, samePropertyValuesAs(purchaseOrder2));
+    PurchaseOrder purchaseOrder1a = allPurchaseOrders.get(purchaseOrders.get(0).getId());
+    PurchaseOrder purchaseOrder2a = allPurchaseOrders.get(purchaseOrders.get(1).getId());
+    assertThat(purchaseOrder1a, samePropertyValuesAs(purchaseOrder1));
+    assertThat(purchaseOrder2a, samePropertyValuesAs(purchaseOrder2));
 
     // one POL should be updated
     allPoLines = getAllPoLines();
-    PoLine poLine1_1 = allPoLines.get(poLines.get(0).getId());
-    PoLine poLine2_1 = allPoLines.get(poLines.get(1).getId());
-    assertEquals(2, poLine1_1.getCustomFields().getAdditionalProperties().size());
-    assertNull(poLine1_1.getCustomFields().getAdditionalProperties().get("singleselect_2"));
-    assertThat(poLine2_1, samePropertyValuesAs(poLines.get(1)));
+    PoLine poLine1a = allPoLines.get(poLines.get(0).getId());
+    PoLine poLine2a = allPoLines.get(poLines.get(1).getId());
+    assertEquals(2, poLine1a.getCustomFields().getAdditionalProperties().size());
+    assertNull(poLine1a.getCustomFields().getAdditionalProperties().get("singleselect_2"));
+    assertThat(poLine2a, samePropertyValuesAs(poLines.get(1)));
 
     // order template should be updated
     allOrderTemplates = getAllOrderTemplates();
-    orderTemplate = allOrderTemplates.get(orderTemplates.get(0).getId());
+    orderTemplate = allOrderTemplates.get(orderTemplates.getFirst().getId());
     customFieldData = getCustomFieldData(orderTemplate);
     assertEquals(3, customFieldData.size());
     assertNull(customFieldData.getValue("singleselect_2"));
@@ -221,7 +221,7 @@ public class CustomFieldsAPITest extends TestBase {
 
     // order template should be updated
     Map<String, OrderTemplate> allOrderTemplates = getAllOrderTemplates();
-    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.get(0).getId());
+    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.getFirst().getId());
     JsonObject customFieldData = getCustomFieldData(orderTemplate);
     assertEquals(5, customFieldData.size());
     assertEquals(new JsonArray().add("opt_1"), customFieldData.getValue("multiselect"));
@@ -237,25 +237,25 @@ public class CustomFieldsAPITest extends TestBase {
 
     // POs remain unchanged
     allPurchaseOrders = getAllPurchaseOrders();
-    PurchaseOrder purchaseOrder1_1 = allPurchaseOrders.get(purchaseOrders.get(0).getId());
-    PurchaseOrder purchaseOrder2_1 = allPurchaseOrders.get(purchaseOrders.get(1).getId());
-    assertThat(purchaseOrder1_1, samePropertyValuesAs(purchaseOrder1));
-    assertThat(purchaseOrder2_1, samePropertyValuesAs(purchaseOrder2));
+    PurchaseOrder purchaseOrder1a = allPurchaseOrders.get(purchaseOrders.get(0).getId());
+    PurchaseOrder purchaseOrder2a = allPurchaseOrders.get(purchaseOrders.get(1).getId());
+    assertThat(purchaseOrder1a, samePropertyValuesAs(purchaseOrder1));
+    assertThat(purchaseOrder2a, samePropertyValuesAs(purchaseOrder2));
 
     // POLs should be updated
     allPoLines = getAllPoLines();
-    PoLine poLine1_1 = allPoLines.get(poLines.get(0).getId());
-    PoLine poLine2_1 = allPoLines.get(poLines.get(1).getId());
-    assertEquals(3, poLine1_1.getCustomFields().getAdditionalProperties().size());
+    PoLine poLine1a = allPoLines.get(poLines.get(0).getId());
+    PoLine poLine2a = allPoLines.get(poLines.get(1).getId());
+    assertEquals(3, poLine1a.getCustomFields().getAdditionalProperties().size());
     assertEquals(
       List.of("opt_1"),
-      poLine1_1.getCustomFields().getAdditionalProperties().get("multiselect_2"));
-    assertEquals(2, poLine2_1.getCustomFields().getAdditionalProperties().size());
-    assertNull(poLine2_1.getCustomFields().getAdditionalProperties().get("multiselect_2"));
+      poLine1a.getCustomFields().getAdditionalProperties().get("multiselect_2"));
+    assertEquals(2, poLine2a.getCustomFields().getAdditionalProperties().size());
+    assertNull(poLine2a.getCustomFields().getAdditionalProperties().get("multiselect_2"));
 
     // order template should be updated
     allOrderTemplates = getAllOrderTemplates();
-    orderTemplate = allOrderTemplates.get(orderTemplates.get(0).getId());
+    orderTemplate = allOrderTemplates.get(orderTemplates.getFirst().getId());
     customFieldData = getCustomFieldData(orderTemplate);
     assertEquals(5, customFieldData.size());
     assertEquals(new JsonArray().add("opt_1"), customFieldData.getValue("multiselect_2"));
@@ -267,7 +267,7 @@ public class CustomFieldsAPITest extends TestBase {
     populateSampleData();
 
     // remove opt from custom field using PutCustomFieldsCollection
-    customFieldsPO.get(1).getSelectField().getOptions().getValues().remove(0);
+    customFieldsPO.get(1).getSelectField().getOptions().getValues().removeFirst();
     putCustomFieldCollection(
       new PutCustomFieldCollection()
         .withCustomFields(customFieldsPO)
@@ -291,7 +291,7 @@ public class CustomFieldsAPITest extends TestBase {
 
     // order template should be updated
     Map<String, OrderTemplate> allOrderTemplates = getAllOrderTemplates();
-    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.get(0).getId());
+    OrderTemplate orderTemplate = allOrderTemplates.get(orderTemplates.getFirst().getId());
     JsonObject customFieldData = getCustomFieldData(orderTemplate);
     assertEquals(4, customFieldData.size());
     assertNull(customFieldData.getValue("singleselect"));

--- a/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
+++ b/src/test/java/org/folio/rest/impl/TenantSampleDataTest.java
@@ -5,6 +5,7 @@ import static org.folio.rest.utils.TenantApiTestUtil.deleteTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.postTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 import static org.folio.rest.utils.TenantApiTestUtil.purge;
+import static org.folio.rest.utils.TestEntities.CUSTOM_FIELDS;
 import static org.folio.rest.utils.TestEntities.EXPORT_HISTORY;
 import static org.folio.rest.utils.TestEntities.ORDER_TEMPLATE_CATEGORIES;
 import static org.folio.rest.utils.TestEntities.PREFIX;
@@ -113,6 +114,10 @@ public class TenantSampleDataTest extends TestBase {
         .filter(entity -> !EXPORT_HISTORY.equals(entity) && !ORDER_TEMPLATE_CATEGORIES.equals(entity))
         .toList();
       for (TestEntities entity : entitySamples) {
+        if (entity == CUSTOM_FIELDS) {
+          log.info("testPartialSampleDataLoading:: Ignoring custom fields validation");
+          continue;
+        }
         log.info("testPartialSampleDataLoading:: Test expected quantity for {}", entity.name());
 
         verifyCollectionQuantity(entity.getEndpoint(), entity.getInitialQuantity() + entity.getEstimatedSystemDataRecordsQuantity(), PARTIAL_TENANT_HEADER);
@@ -179,6 +184,10 @@ public class TenantSampleDataTest extends TestBase {
       .filter(entity -> !EXPORT_HISTORY.equals(entity) && !ORDER_TEMPLATE_CATEGORIES.equals(entity))
       .toList();
     for (TestEntities entity : entitySamples) {
+      if (entity == CUSTOM_FIELDS) {
+        log.info("upgradeTenantWithSampleDataLoad:: Ignoring custom fields validation");
+        continue;
+      }
       log.info("upgradeTenantWithSampleDataLoad:: Test expected quantity for name {}", entity.name());
 
       verifyCollectionQuantity(entity.getEndpoint(), entity.getEstimatedSystemDataRecordsQuantity() + entity.getInitialQuantity(), ANOTHER_TENANT_HEADER);
@@ -196,6 +205,10 @@ public class TenantSampleDataTest extends TestBase {
       .filter(entity -> !EXPORT_HISTORY.equals(entity) && !ORDER_TEMPLATE_CATEGORIES.equals(entity))
       .toList();
     for (TestEntities entity: entitySamples) {
+      if (entity == CUSTOM_FIELDS) {
+        log.info("upgradeTenantWithNoSampleDataLoad:: Ignoring custom fields validation");
+        continue;
+      }
       log.info("upgradeTenantWithNoSampleDataLoad:: Test expected quantity: 0 for name: {}", entity.name());
 
       verifyCollectionQuantity(entity.getEndpoint(), entity.getEstimatedSystemDataRecordsQuantity());


### PR DESCRIPTION
### **Purpose**

- <https://folio-org.atlassian.net/browse/MODORDSTOR-472>

### **Approach**

- Remove custom fields from PO and POL sample data
- Exclude custom fields in tenant integration tests
- Update and refactor deprecated methods
- Test locally using the [reinstall endpoint](https://s3.amazonaws.com/foliodocs/api/mgr-tenant-entitlements/s/mgr-tenant-entitlements.html#tag/reinstall/operation/moduleReinstall) that allows to recreate schema objects and reload samples:

```bash
curl --location 'http://localhost:8000/reinstall/modules?tenantParameters=loadReference%3Dtrue%2CloadSample%3Dtrue' \
--header 'Content-Type: application/json' \
--data '{
  "tenantId": "10699960-7d5f-4f45-9f4e-b4e0d1a443f1",
  "applicationId": "app-combined-1.0.0",
  "modules": [
    "mod-orders-storage-14.0.0-SNAPSHOT.438"
  ]
}'
```

- Order template samples are now successfully being loaded:

![image](https://github.com/user-attachments/assets/eb36f80c-b470-412b-ad51-f5e596d7027c)

- Custom field samples for both the Purchase Order and the Order Line are no longer loaded automatically:

![image](https://github.com/user-attachments/assets/5422ace1-11bc-4bea-af38-344edbb0d65b)
