### PR TITLE
[MODORDERS-1299] After changing instance in P/E mix order, new instance is not displayed and locations show "Invalid reference"

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -23,6 +23,7 @@ import org.folio.rest.jaxrs.model.CreateInventoryType;
 import org.folio.rest.jaxrs.model.OrderLinePatchOperationType;
 import org.folio.service.UserService;
 import org.folio.services.consortium.ConsortiumConfigurationService;
+import org.folio.services.inventory.HoldingsService;
 import org.folio.services.inventory.InventoryUpdateService;
 import org.folio.services.inventory.OrderLineLocationUpdateService;
 import org.folio.services.lines.PoLineNumbersService;
@@ -193,8 +194,13 @@ public class ApplicationConfig {
   }
 
   @Bean
-  InventoryUpdateService inventoryUpdateService(RestClient restClient) {
-    return new InventoryUpdateService(restClient);
+  InventoryUpdateService inventoryUpdateService(HoldingsService holdingsService, RestClient restClient) {
+    return new InventoryUpdateService(holdingsService, restClient);
+  }
+
+  @Bean
+  HoldingsService holdingsService(RestClient restClient) {
+    return new HoldingsService(restClient);
   }
 
   @Bean

--- a/src/main/java/org/folio/event/dto/HoldingFields.java
+++ b/src/main/java/org/folio/event/dto/HoldingFields.java
@@ -7,9 +7,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HoldingFields {
 
+  // HoldingRecord
   ID("id"),
   INSTANCE_ID("instanceId"),
-  PERMANENT_LOCATION_ID("permanentLocationId");
+  PERMANENT_LOCATION_ID("permanentLocationId"),
+  // HoldingRecords
+  HOLDINGS_RECORDS("holdingsRecords");
 
   private final String value;
 }

--- a/src/main/java/org/folio/services/inventory/HoldingsService.java
+++ b/src/main/java/org/folio/services/inventory/HoldingsService.java
@@ -1,0 +1,60 @@
+package org.folio.services.inventory;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import one.util.streamex.StreamEx;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.event.dto.HoldingFields;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.folio.dao.RepositoryConstants.MAX_IDS_FOR_GET_RQ_15;
+import static org.folio.services.inventory.InventoryUpdateService.HOLDINGS_RECORDS;
+import static org.folio.util.HelperUtils.collectResultsOnSuccess;
+import static org.folio.util.HelperUtils.convertIdsToCqlQuery;
+import static org.folio.util.ResourcePath.STORAGE_HOLDING_URL;
+
+@Log4j2
+@RequiredArgsConstructor
+public class HoldingsService {
+
+  private final RestClient restClient;
+
+  public Future<Pair<JsonObject, JsonObject>> getHoldingsPairByIds(Pair<String, String> holdingIds, RequestContext requestContext) {
+    return getHoldingsByIds(List.of(holdingIds.getLeft(), holdingIds.getRight()), requestContext)
+      .map(holdingsCollections -> {
+        var holdings = holdingsCollections.stream()
+          .flatMap(result -> result.getJsonArray(HOLDINGS_RECORDS).stream())
+          .map(JsonObject.class::cast)
+          .toList();
+        var holdingsById = StreamEx.of(holdings).toMap(h -> h.getString(HoldingFields.ID.getValue()), Function.identity());
+
+        return Pair.of(
+          holdingsById.getOrDefault(holdingIds.getLeft(), new JsonObject()),
+          holdingsById.getOrDefault(holdingIds.getRight(), new JsonObject())
+        );
+      });
+  }
+
+  public Future<List<JsonObject>> getHoldingsByIds(List<String> holdingIds, RequestContext requestContext) {
+    var futures = StreamEx.ofSubLists(holdingIds, MAX_IDS_FOR_GET_RQ_15)
+      .map(ids -> getHoldingsByIdsInChunks(ids, requestContext))
+      .toList();
+    return collectResultsOnSuccess(futures);
+  }
+
+  private Future<JsonObject> getHoldingsByIdsInChunks(List<String> holdingIds, RequestContext requestContext) {
+    var requestEntry = new RequestEntry(STORAGE_HOLDING_URL.getPath())
+      .withQuery(convertIdsToCqlQuery(holdingIds))
+      .withOffset(0)
+      .withLimit(MAX_IDS_FOR_GET_RQ_15);
+    return restClient.get(requestEntry, requestContext);
+  }
+
+}

--- a/src/main/java/org/folio/services/inventory/HoldingsService.java
+++ b/src/main/java/org/folio/services/inventory/HoldingsService.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static org.folio.dao.RepositoryConstants.MAX_IDS_FOR_GET_RQ_15;
-import static org.folio.services.inventory.InventoryUpdateService.HOLDINGS_RECORDS;
+import static org.folio.event.dto.HoldingFields.HOLDINGS_RECORDS;
 import static org.folio.util.HelperUtils.collectResultsOnSuccess;
 import static org.folio.util.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.util.ResourcePath.STORAGE_HOLDING_URL;
@@ -30,7 +30,7 @@ public class HoldingsService {
     return getHoldingsByIds(List.of(holdingIds.getLeft(), holdingIds.getRight()), requestContext)
       .map(holdingsCollections -> {
         var holdings = holdingsCollections.stream()
-          .flatMap(result -> result.getJsonArray(HOLDINGS_RECORDS).stream())
+          .flatMap(result -> result.getJsonArray(HOLDINGS_RECORDS.getValue()).stream())
           .map(JsonObject.class::cast)
           .toList();
         var holdingsById = StreamEx.of(holdings).toMap(h -> h.getString(HoldingFields.ID.getValue()), Function.identity());

--- a/src/main/java/org/folio/services/inventory/InventoryUpdateService.java
+++ b/src/main/java/org/folio/services/inventory/InventoryUpdateService.java
@@ -15,6 +15,7 @@ import org.folio.rest.core.models.RequestEntry;
 
 import java.util.List;
 
+import static org.folio.event.dto.HoldingFields.HOLDINGS_RECORDS;
 import static org.folio.event.dto.HoldingFields.INSTANCE_ID;
 import static org.folio.util.ResourcePath.STORAGE_BATCH_HOLDING_URL;
 import static org.folio.util.ResourcePath.STORAGE_INSTANCE_URL;
@@ -23,7 +24,6 @@ import static org.folio.util.ResourcePath.STORAGE_INSTANCE_URL;
 @RequiredArgsConstructor
 public class InventoryUpdateService {
 
-  public static final String HOLDINGS_RECORDS = "holdingsRecords";
   private static final String UPSERT = "upsert";
   private static final String TRUE = "true";
 
@@ -49,7 +49,7 @@ public class InventoryUpdateService {
       }
       updateResultNewInstanceId(getResults, newInstanceId);
       var batchPostRequestEntry = new RequestEntry(STORAGE_BATCH_HOLDING_URL.getPath()).withQueryParameter(UPSERT, TRUE);
-      var payload = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray(getResults));
+      var payload = new JsonObject().put(HOLDINGS_RECORDS.getValue(), new JsonArray(getResults));
       return restClient.post(batchPostRequestEntry, payload, ResponsePredicate.SC_CREATED, requestContext)
         .mapEmpty();
     });
@@ -57,7 +57,7 @@ public class InventoryUpdateService {
 
   private void updateResultNewInstanceId(List<JsonObject> results, String newInstanceId) {
     results.forEach(result ->
-      result.getJsonArray(HOLDINGS_RECORDS).stream()
+      result.getJsonArray(HOLDINGS_RECORDS.getValue()).stream()
         .filter(Objects::nonNull)
         .map(JsonObject.class::cast)
         .forEach(holding -> holding.put(INSTANCE_ID.getValue(), newInstanceId)));

--- a/src/main/java/org/folio/util/InventoryUtils.java
+++ b/src/main/java/org/folio/util/InventoryUtils.java
@@ -4,10 +4,13 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.event.dto.HoldingFields;
 import org.folio.rest.jaxrs.model.Contributor;
 import org.folio.rest.jaxrs.model.ProductId;
 
 import java.util.List;
+import java.util.Objects;
 
 import static org.folio.event.dto.InstanceFields.CONTRIBUTOR_NAME;
 import static org.folio.event.dto.InstanceFields.CONTRIBUTOR_NAME_TYPE_ID;
@@ -26,6 +29,12 @@ public class InventoryUtils {
 
   public static String getInstanceTitle(JsonObject instance) {
     return instance.getString(TITLE.getValue());
+  }
+
+  public static boolean isInstanceChanged(Pair<JsonObject, JsonObject> holdingsPair) {
+    String oldInstanceId = holdingsPair.getLeft().getString(HoldingFields.INSTANCE_ID.getValue());
+    String newInstanceId = holdingsPair.getRight().getString(HoldingFields.INSTANCE_ID.getValue());
+    return !Objects.equals(oldInstanceId, newInstanceId);
   }
 
   public static String getPublisher(JsonObject instance) {

--- a/src/main/java/org/folio/util/InventoryUtils.java
+++ b/src/main/java/org/folio/util/InventoryUtils.java
@@ -3,7 +3,6 @@ package org.folio.util;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import lombok.experimental.UtilityClass;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.event.dto.HoldingFields;
 import org.folio.rest.jaxrs.model.Contributor;
@@ -23,7 +22,6 @@ import static org.folio.event.dto.InstanceFields.PUBLICATION;
 import static org.folio.event.dto.InstanceFields.PUBLISHER;
 import static org.folio.event.dto.InstanceFields.TITLE;
 
-@Log4j2
 @UtilityClass
 public class InventoryUtils {
 

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -69,6 +69,7 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.services.consortium.ConsortiumConfigurationServiceTest;
+import org.folio.services.inventory.HoldingsServiceTest;
 import org.folio.services.inventory.InventoryUpdateServiceTest;
 import org.folio.services.lines.PoLIneServiceVertxTest;
 import org.folio.services.lines.PoLinesServiceTest;
@@ -343,6 +344,8 @@ public class StorageTestSuite {
   class ConsortiumConfigurationServiceTestNested extends ConsortiumConfigurationServiceTest {}
   @Nested
   class InventoryUpdateServiceTestNested extends InventoryUpdateServiceTest {}
+  @Nested
+  class HoldingsServiceTestNested extends HoldingsServiceTest {}
   @Nested
   class RestClientTestNested extends RestClientTest {}
   @Nested

--- a/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
@@ -31,7 +31,9 @@ import java.util.function.Function;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.tuple.Pair;
 import org.folio.TestUtils;
+import org.folio.event.dto.HoldingFields;
 import org.folio.event.dto.ItemFields;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
@@ -45,6 +47,7 @@ import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.services.consortium.ConsortiumConfigurationService;
+import org.folio.services.inventory.HoldingsService;
 import org.folio.services.inventory.OrderLineLocationUpdateService;
 import org.folio.services.lines.PoLinesService;
 import org.folio.services.piece.PieceService;
@@ -53,7 +56,7 @@ import org.folio.services.setting.util.SettingKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -78,6 +81,8 @@ public class ItemUpdateAsyncRecordHandlerTest {
   private ConsortiumConfigurationService consortiumConfigurationService;
   @Mock
   private SettingService settingService;
+  @Mock
+  private HoldingsService holdingsService;
   @InjectMocks
   private OrderLineLocationUpdateService orderLineLocationUpdateService;
 
@@ -90,6 +95,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
       var itemHandler = new ItemUpdateAsyncRecordHandler(vertx, mockContext(vertx));
       TestUtils.setInternalState(itemHandler, "pieceService", pieceService);
       TestUtils.setInternalState(itemHandler, "orderLineLocationUpdateService", orderLineLocationUpdateService);
+      TestUtils.setInternalState(itemHandler, "holdingsService", holdingsService);
       TestUtils.setInternalState(itemHandler, "auditOutboxService", auditOutboxService);
       TestUtils.setInternalState(itemHandler, "consortiumConfigurationService", consortiumConfigurationService);
       handler = spy(itemHandler);
@@ -99,6 +105,8 @@ public class ItemUpdateAsyncRecordHandlerTest {
         .when(consortiumConfigurationService).getConsortiumConfiguration(any());
       doReturn(Future.succeededFuture(DIKU_TENANT))
         .when(consortiumConfigurationService).getCentralTenantId(any(), any());
+      doReturn(Future.succeededFuture(Pair.of(new JsonObject(), new JsonObject())))
+        .when(holdingsService).getHoldingsPairByIds(any(), any());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(any(Conn.class), anyList(), any(), anyMap());
       doReturn(Future.succeededFuture(true)).when(auditOutboxService).processOutboxEventLogs(anyMap());
       doReturn(dbClient).when(handler).createDBClient(any());
@@ -108,8 +116,9 @@ public class ItemUpdateAsyncRecordHandlerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  void positive_shouldProcessItemUpdateEventWithHoldingsUpdate(boolean checkinItems) {
+  @CsvSource(value = {"true|true", "false|true", "true|false", "false|false"}, delimiter = '|')
+  void positive_shouldProcessItemUpdateEventWithHoldingsUpdate(boolean checkinItems, boolean instanceIdChanged) {
+    var shouldUpdatePol = !checkinItems || instanceIdChanged; // POL must be updated for synchronized workflow or if instanceId is changed
     var poLineId = UUID.randomUUID().toString();
     var pieceId1 = UUID.randomUUID().toString();
     var pieceId2 = UUID.randomUUID().toString();
@@ -124,7 +133,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
     var kafkaRecord = createKafkaRecordWithValues(oldItemValueBeforeUpdate, newItemValueBeforeUpdate);
 
     var poLine = createPoLine(poLineId, holdingId1, effectiveLocationId1).withCheckinItems(checkinItems);
-    var expectedPoLine = createPoLine(poLineId, holdingId2, effectiveLocationId1, effectiveLocationId2);
+    var expectedPoLine = createPoLine(poLineId, holdingId2, effectiveLocationId1, effectiveLocationId2).withCheckinItems(checkinItems);
 
     var actualPieces = List.of(
       createPiece(pieceId1, itemId, holdingId1, null).withPoLineId(poLineId),
@@ -134,6 +143,11 @@ public class ItemUpdateAsyncRecordHandlerTest {
       createPiece(pieceId1, itemId, holdingId2, null).withPoLineId(poLineId)
     );
 
+    var holdingsPair = Pair.of(
+      new JsonObject().put(HoldingFields.INSTANCE_ID.getValue(), "instanceId"),
+      new JsonObject().put(HoldingFields.INSTANCE_ID.getValue(), "instanceId" + (instanceIdChanged ? "Updated" : ""))
+    );
+
     doReturn(Future.succeededFuture(true)).when(pieceService).getPiecesByItemIdExist(eq(itemId), eq(DIKU_TENANT), any(Conn.class));
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByItemId(eq(itemId), any(Conn.class));
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByPoLineId(eq(poLineId), any(Conn.class));
@@ -141,6 +155,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
     doReturn(Future.succeededFuture(List.of(poLine))).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId)), eq(DIKU_TENANT), any(Conn.class));
     doReturn(Future.succeededFuture(1)).when(poLinesService).updatePoLines(eq(List.of(expectedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), anyList(), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    doReturn(Future.succeededFuture(holdingsPair)).when(holdingsService).getHoldingsPairByIds(any(), any());
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
@@ -149,9 +164,9 @@ public class ItemUpdateAsyncRecordHandlerTest {
     verify(pieceService).getPiecesByItemId(eq(itemId), any(Conn.class));
     verify(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
     verify(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId)), eq(DIKU_TENANT), any(Conn.class));
-    verify(pieceService, times(checkinItems ? 0 : 1)).getPiecesByPoLineId(eq(poLineId), any(Conn.class));
-    verify(poLinesService, times(checkinItems ? 0 : 1)).updatePoLines(eq(List.of(expectedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
-    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(checkinItems ? List.of() : List.of(expectedPoLine)), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(pieceService, times(shouldUpdatePol ? 1 : 0)).getPiecesByPoLineId(eq(poLineId), any(Conn.class));
+    verify(poLinesService, times(shouldUpdatePol ? 1 : 0)).updatePoLines(eq(List.of(expectedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
+    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(shouldUpdatePol ? List.of(expectedPoLine) : List.of()), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
   }
 
   @Test

--- a/src/test/java/org/folio/services/inventory/HoldingsServiceTest.java
+++ b/src/test/java/org/folio/services/inventory/HoldingsServiceTest.java
@@ -1,0 +1,168 @@
+package org.folio.services.inventory;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.CopilotGenerated;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.folio.event.dto.HoldingFields.ID;
+import static org.folio.services.inventory.InventoryUpdateService.HOLDINGS_RECORDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@CopilotGenerated(model = "Claude Sonnet 3.5")
+@ExtendWith(MockitoExtension.class)
+public class HoldingsServiceTest {
+
+  private static final String HOLDING_ID_1 = "holding-id-1";
+  private static final String HOLDING_ID_2 = "holding-id-2";
+
+  @Mock
+  private RestClient restClient;
+  @Mock
+  private RequestContext requestContext;
+  @InjectMocks
+  private HoldingsService holdingsService;
+
+  @Test
+  void shouldGetHoldingsPairByIds() {
+    // given
+    JsonObject holding1 = new JsonObject().put(ID.getValue(), HOLDING_ID_1);
+    JsonObject holding2 = new JsonObject().put(ID.getValue(), HOLDING_ID_2);
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(holding1).add(holding2));
+
+    when(restClient.get(any(RequestEntry.class), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(response));
+
+    // when
+    Future<Pair<JsonObject, JsonObject>> future = holdingsService
+      .getHoldingsPairByIds(Pair.of(HOLDING_ID_1, HOLDING_ID_2), requestContext);
+
+    // then
+    assertTrue(future.succeeded());
+    future.onComplete(result -> {
+      Pair<JsonObject, JsonObject> holdingsPair = result.result();
+      assertEquals(HOLDING_ID_1, holdingsPair.getLeft().getString(ID.getValue()));
+      assertEquals(HOLDING_ID_2, holdingsPair.getRight().getString(ID.getValue()));
+    });
+
+    verify(restClient).get(any(RequestEntry.class), eq(requestContext));
+  }
+
+  @Test
+  void shouldReturnEmptyJsonObjectsWhenHoldingsNotFound() {
+    // given
+    JsonObject response = new JsonObject()
+      .put(HOLDINGS_RECORDS, new JsonArray());
+
+    when(restClient.get(any(RequestEntry.class), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(response));
+
+    // when
+    Future<Pair<JsonObject, JsonObject>> future = holdingsService
+      .getHoldingsPairByIds(Pair.of(HOLDING_ID_1, HOLDING_ID_2), requestContext);
+
+    // then
+    assertTrue(future.succeeded());
+    future.onComplete(result -> {
+      Pair<JsonObject, JsonObject> holdingsPair = result.result();
+      assertTrue(holdingsPair.getLeft().isEmpty());
+      assertTrue(holdingsPair.getRight().isEmpty());
+    });
+  }
+
+  @Test
+  void shouldGetHoldingsByIds() {
+    // given
+    JsonObject holding1 = new JsonObject().put(ID.getValue(), HOLDING_ID_1);
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(holding1));
+
+    when(restClient.get(any(RequestEntry.class), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(response));
+
+    // when
+    Future<List<JsonObject>> future = holdingsService.getHoldingsByIds(List.of(HOLDING_ID_1), requestContext);
+
+    // then
+    assertTrue(future.succeeded());
+    future.onComplete(result -> {
+      List<JsonObject> holdings = result.result();
+      assertEquals(1, holdings.size());
+      assertEquals(HOLDING_ID_1, holdings.getFirst().getJsonArray(HOLDINGS_RECORDS)
+        .getJsonObject(0).getString(ID.getValue()));
+    });
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoHoldingsFound() {
+    // given
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray());
+
+    when(restClient.get(any(RequestEntry.class), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(response));
+
+    // when
+    Future<List<JsonObject>> future = holdingsService.getHoldingsByIds(List.of(HOLDING_ID_1), requestContext);
+
+    // then
+    assertTrue(future.succeeded());
+    future.onComplete(result -> {
+      List<JsonObject> holdings = result.result();
+      assertEquals(1, holdings.size());
+      assertTrue(holdings.getFirst().getJsonArray(HOLDINGS_RECORDS).isEmpty());
+    });
+  }
+
+  @Test
+  void shouldHandleRestClientError() {
+    // given
+    RuntimeException exception = new RuntimeException("REST client error");
+    when(restClient.get(any(RequestEntry.class), eq(requestContext)))
+      .thenReturn(Future.failedFuture(exception));
+
+    // when
+    Future<List<JsonObject>> future = holdingsService.getHoldingsByIds(List.of(HOLDING_ID_1), requestContext);
+
+    // then
+    assertTrue(future.failed());
+    assertEquals("REST client error", future.cause().getMessage());
+  }
+
+  @Test
+  void shouldHandleChunkedRequestsForLargeHoldingsList() {
+    // given
+    List<String> manyHoldingIds = List.of(HOLDING_ID_1, HOLDING_ID_2, "holding-id-3");
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(new JsonObject().put(ID.getValue(), HOLDING_ID_1)));
+
+    when(restClient.get(any(RequestEntry.class), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(response));
+
+    // when
+    Future<List<JsonObject>> future = holdingsService.getHoldingsByIds(manyHoldingIds, requestContext);
+
+    // then
+    assertTrue(future.succeeded());
+    future.onComplete(result -> {
+      List<JsonObject> holdings = result.result();
+      assertFalse(holdings.isEmpty());
+      verify(restClient).get(any(RequestEntry.class), eq(requestContext));
+    });
+  }
+
+}

--- a/src/test/java/org/folio/services/inventory/HoldingsServiceTest.java
+++ b/src/test/java/org/folio/services/inventory/HoldingsServiceTest.java
@@ -16,8 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static org.folio.event.dto.HoldingFields.HOLDINGS_RECORDS;
 import static org.folio.event.dto.HoldingFields.ID;
-import static org.folio.services.inventory.InventoryUpdateService.HOLDINGS_RECORDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +45,7 @@ public class HoldingsServiceTest {
     // given
     JsonObject holding1 = new JsonObject().put(ID.getValue(), HOLDING_ID_1);
     JsonObject holding2 = new JsonObject().put(ID.getValue(), HOLDING_ID_2);
-    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(holding1).add(holding2));
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS.getValue(), new JsonArray().add(holding1).add(holding2));
 
     when(restClient.get(any(RequestEntry.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(response));
@@ -68,8 +68,7 @@ public class HoldingsServiceTest {
   @Test
   void shouldReturnEmptyJsonObjectsWhenHoldingsNotFound() {
     // given
-    JsonObject response = new JsonObject()
-      .put(HOLDINGS_RECORDS, new JsonArray());
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS.getValue(), new JsonArray());
 
     when(restClient.get(any(RequestEntry.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(response));
@@ -91,7 +90,7 @@ public class HoldingsServiceTest {
   void shouldGetHoldingsByIds() {
     // given
     JsonObject holding1 = new JsonObject().put(ID.getValue(), HOLDING_ID_1);
-    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(holding1));
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS.getValue(), new JsonArray().add(holding1));
 
     when(restClient.get(any(RequestEntry.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(response));
@@ -104,7 +103,7 @@ public class HoldingsServiceTest {
     future.onComplete(result -> {
       List<JsonObject> holdings = result.result();
       assertEquals(1, holdings.size());
-      assertEquals(HOLDING_ID_1, holdings.getFirst().getJsonArray(HOLDINGS_RECORDS)
+      assertEquals(HOLDING_ID_1, holdings.getFirst().getJsonArray(HOLDINGS_RECORDS.getValue())
         .getJsonObject(0).getString(ID.getValue()));
     });
   }
@@ -112,7 +111,7 @@ public class HoldingsServiceTest {
   @Test
   void shouldReturnEmptyListWhenNoHoldingsFound() {
     // given
-    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray());
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS.getValue(), new JsonArray());
 
     when(restClient.get(any(RequestEntry.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(response));
@@ -125,7 +124,7 @@ public class HoldingsServiceTest {
     future.onComplete(result -> {
       List<JsonObject> holdings = result.result();
       assertEquals(1, holdings.size());
-      assertTrue(holdings.getFirst().getJsonArray(HOLDINGS_RECORDS).isEmpty());
+      assertTrue(holdings.getFirst().getJsonArray(HOLDINGS_RECORDS.getValue()).isEmpty());
     });
   }
 
@@ -148,7 +147,7 @@ public class HoldingsServiceTest {
   void shouldHandleChunkedRequestsForLargeHoldingsList() {
     // given
     List<String> manyHoldingIds = List.of(HOLDING_ID_1, HOLDING_ID_2, "holding-id-3");
-    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(new JsonObject().put(ID.getValue(), HOLDING_ID_1)));
+    JsonObject response = new JsonObject().put(HOLDINGS_RECORDS.getValue(), new JsonArray().add(new JsonObject().put(ID.getValue(), HOLDING_ID_1)));
 
     when(restClient.get(any(RequestEntry.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture(response));

--- a/src/test/java/org/folio/services/inventory/InventoryUpdateServiceTest.java
+++ b/src/test/java/org/folio/services/inventory/InventoryUpdateServiceTest.java
@@ -33,6 +33,8 @@ public class InventoryUpdateServiceTest {
   @Mock
   private RestClient restClient;
   @Mock
+  private HoldingsService holdingsService;
+  @Mock
   private RequestContext requestContext;
 
   @Test
@@ -58,17 +60,17 @@ public class InventoryUpdateServiceTest {
     var resourceEvent = new ResourceEvent();
     resourceEvent.setNewValue(new JsonObject().put(INSTANCE_ID.getValue(), UUID.randomUUID().toString()));
     var holdingObject = new JsonObject().put(ID.getValue(), UUID.randomUUID().toString());
-    var holdingRecordsJsonObject = new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(holdingObject));
+    var holdingRecordsJsonObjects = List.of(new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(holdingObject)));
     var holder = HoldingEventHolder.builder().resourceEvent(resourceEvent).build();
     var holdingIds = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
-    when(restClient.get(any(), any())).thenReturn(Future.succeededFuture(holdingRecordsJsonObject));
+    when(holdingsService.getHoldingsByIds(any(), any())).thenReturn(Future.succeededFuture(holdingRecordsJsonObjects));
     when(restClient.post(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
 
     var result = inventoryUpdateService.batchUpdateAdjacentHoldingsWithNewInstanceId(holder, holdingIds, requestContext);
 
     assertDoesNotThrow(result::result);
-    verify(restClient, times(1)).get(any(), any());
+    verify(holdingsService, times(1)).getHoldingsByIds(any(), any());
     verify(restClient, times(1)).post(any(), any(), any(), any());
   }
 

--- a/src/test/java/org/folio/services/inventory/InventoryUpdateServiceTest.java
+++ b/src/test/java/org/folio/services/inventory/InventoryUpdateServiceTest.java
@@ -17,9 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.UUID;
 
+import static org.folio.event.dto.HoldingFields.HOLDINGS_RECORDS;
 import static org.folio.event.dto.HoldingFields.ID;
 import static org.folio.event.dto.HoldingFields.INSTANCE_ID;
-import static org.folio.services.inventory.InventoryUpdateService.HOLDINGS_RECORDS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -60,7 +60,7 @@ public class InventoryUpdateServiceTest {
     var resourceEvent = new ResourceEvent();
     resourceEvent.setNewValue(new JsonObject().put(INSTANCE_ID.getValue(), UUID.randomUUID().toString()));
     var holdingObject = new JsonObject().put(ID.getValue(), UUID.randomUUID().toString());
-    var holdingRecordsJsonObjects = List.of(new JsonObject().put(HOLDINGS_RECORDS, new JsonArray().add(holdingObject)));
+    var holdingRecordsJsonObjects = List.of(new JsonObject().put(HOLDINGS_RECORDS.getValue(), new JsonArray().add(holdingObject)));
     var holder = HoldingEventHolder.builder().resourceEvent(resourceEvent).build();
     var holdingIds = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1299] After changing instance in P/E mix order, new instance is not displayed and locations show "Invalid reference"](https://folio-org.atlassian.net/browse/MODORDERS-1299)

### **Approach**
- Add holdings service to fetch holding records from inventory storage
- Fetch holdings for item update event handling to determine if independent workflow POLs need locations updated in case of an instance change with holdings being re-created, resulting in existing ones becoming invalid references
- Update existing tests and add new ones

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
