### PR TITLE
[MODORDERS-1299] Select correct tenant id while fetching holdings for populating POL locations 

### DIFF
--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -2,6 +2,7 @@ package org.folio.event.handler;
 
 import static org.folio.event.InventoryEventType.INVENTORY_ITEM_UPDATE;
 import static org.folio.util.HeaderUtils.extractTenantFromHeaders;
+import static org.folio.util.HeaderUtils.prepareHeaderForTenant;
 import static org.folio.util.HelperUtils.asFuture;
 
 import java.util.List;
@@ -116,7 +117,8 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
   }
 
   private Future<Boolean> processInstanceIdsChange(ItemEventHolder holder) {
-    return holdingsService.getHoldingsPairByIds(holder.getHoldingIdPair(), new RequestContext(getContext(), holder.getHeaders()))
+    var holdingTenantHeaders = prepareHeaderForTenant(holder.getTenantId(), holder.getHeaders());
+    return holdingsService.getHoldingsPairByIds(holder.getHoldingIdPair(), new RequestContext(getContext(), holdingTenantHeaders))
       .map(InventoryUtils::isInstanceChanged)
       .onSuccess(instanceIdChanged -> {
         if (instanceIdChanged) {

--- a/src/main/java/org/folio/util/HeaderUtils.java
+++ b/src/main/java/org/folio/util/HeaderUtils.java
@@ -11,15 +11,14 @@ import java.util.Optional;
 
 import io.vertx.core.MultiMap;
 import io.vertx.kafka.client.producer.KafkaHeader;
+import lombok.experimental.UtilityClass;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.okapi.common.XOkapiHeaders;
 
+@UtilityClass
 public final class HeaderUtils {
 
   public static final String TENANT_NOT_SPECIFIED_MSG = "Tenant must be specified in the kafka record " + OKAPI_HEADER_TENANT;
-
-  private HeaderUtils() {
-  }
 
   public static String extractTenantFromHeaders(List<KafkaHeader> headers) {
     return Optional.ofNullable(extractValueFromHeaders(headers, OKAPI_HEADER_TENANT))


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1299] After changing instance in P/E mix order, new instance is not displayed and locations show "Invalid reference"](https://folio-org.atlassian.net/browse/MODORDERS-1299)

### **Approach**
Select correct tenant id while fetching holdings

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
