### PR TITLE
[MODORDERS-1309] UUID of deleted order template category is displayed in Order template

### DIFF
--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -38,6 +38,7 @@ import org.folio.orders.lines.update.OrderLineUpdateInstanceStrategyResolver;
 import org.folio.orders.lines.update.PatchOperationHandler;
 import org.folio.orders.lines.update.instance.WithHoldingOrderLineUpdateInstanceStrategy;
 import org.folio.orders.lines.update.instance.WithoutHoldingOrderLineUpdateInstanceStrategy;
+import org.folio.services.order.OrderTemplateCategoryService;
 import org.folio.services.piece.PieceClaimingService;
 import org.folio.services.piece.PieceService;
 import org.folio.services.setting.CommonSettingsService;
@@ -216,6 +217,11 @@ public class ApplicationConfig {
   @Bean
   OrderLineLocationUpdateService orderLineLocationUpdateService(PoLinesService poLinesService, PieceService pieceService) {
     return new OrderLineLocationUpdateService(poLinesService, pieceService);
+  }
+
+  @Bean
+  OrderTemplateCategoryService orderTemplateCategoryService() {
+    return new OrderTemplateCategoryService();
   }
 
   @Bean

--- a/src/main/java/org/folio/rest/core/ResponseUtil.java
+++ b/src/main/java/org/folio/rest/core/ResponseUtil.java
@@ -15,6 +15,7 @@ import org.folio.rest.jaxrs.model.Errors;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Promise;
 import io.vertx.ext.web.handler.HttpException;
+import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 
 import org.folio.rest.persist.PgExceptionUtil;
@@ -22,6 +23,7 @@ import org.folio.rest.persist.PgExceptionUtil;
 import javax.ws.rs.core.Response;
 
 @Log4j2
+@UtilityClass
 public class ResponseUtil {
 
   public static void handleFailure(Promise<?> promise, Throwable throwable) {
@@ -85,7 +87,9 @@ public class ResponseUtil {
       .build();
   }
 
-  private ResponseUtil() {}
+  public static Future<Response> buildNoContentResponse() {
+    return Future.succeededFuture(Response.noContent().build());
+  }
 
 }
 

--- a/src/main/java/org/folio/rest/exceptions/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/exceptions/ErrorCodes.java
@@ -7,6 +7,7 @@ public enum ErrorCodes {
   GENERIC_ERROR_CODE("genericError", "Generic error"),
   POSTGRE_SQL_ERROR("pgException", "PostgreSQL exception"),
   TITLE_EXIST("titleExist", "The title for poLine already exist"),
+  ORDER_TEMPLATE_CATEGORY_IS_USED("orderTemplateCategoryIsUsed", "The order template category is used in some order template and cannot be deleted"),
   UNIQUE_FIELD_CONSTRAINT_ERROR("uniqueField{0}{1}Error", "Field {0} must be unique");
 
   private final String code;

--- a/src/main/java/org/folio/rest/impl/OrderTemplateCategoriesAPI.java
+++ b/src/main/java/org/folio/rest/impl/OrderTemplateCategoriesAPI.java
@@ -8,54 +8,58 @@ import java.util.Map;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import org.folio.rest.core.BaseApi;
 import org.folio.rest.jaxrs.model.OrderTemplateCategory;
-import org.folio.rest.jaxrs.model.OrderTemplateCategoryCollection;
 import org.folio.rest.jaxrs.resource.OrdersStorageOrderTemplateCategories;
 import org.folio.rest.persist.HelperUtils;
-import org.folio.rest.persist.PgUtil;
+import org.folio.services.order.OrderTemplateCategoryService;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class OrderTemplateCategoriesAPI extends BaseApi implements OrdersStorageOrderTemplateCategories {
-  private static final String ORDER_TEMPLATE_CATEGORIES_TABLE = "order_template_categories";
+
+  @Autowired
+  private OrderTemplateCategoryService orderTemplateCategoryService;
+
+  public OrderTemplateCategoriesAPI() {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
 
   @Override
   public void postOrdersStorageOrderTemplateCategories(OrderTemplateCategory entity, Map<String, String> okapiHeaders,
-                                                     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(ORDER_TEMPLATE_CATEGORIES_TABLE, entity, okapiHeaders, vertxContext,
-      PostOrdersStorageOrderTemplateCategoriesResponse.class, asyncResultHandler);
+                                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    orderTemplateCategoryService.createOrderTemplateCategory(entity, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   public void getOrdersStorageOrderTemplateCategories(String query, String totalRecords, int offset, int limit,
-                                                    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-                                                    Context vertxContext) {
-    PgUtil.get(ORDER_TEMPLATE_CATEGORIES_TABLE, OrderTemplateCategory.class, OrderTemplateCategoryCollection.class,
-      query, offset, limit, okapiHeaders, vertxContext, GetOrdersStorageOrderTemplateCategoriesResponse.class, asyncResultHandler);
+                                                      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                                      Context vertxContext) {
+    orderTemplateCategoryService.getOrderTemplateCategories(query, offset, limit, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   public void putOrdersStorageOrderTemplateCategoriesById(String id, OrderTemplateCategory entity, Map<String, String> okapiHeaders,
-                                                        Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.put(ORDER_TEMPLATE_CATEGORIES_TABLE, entity, id, okapiHeaders, vertxContext,
-      PutOrdersStorageOrderTemplateCategoriesByIdResponse.class, asyncResultHandler);
+                                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    orderTemplateCategoryService.updateOrderTemplateCategory(id, entity, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   public void getOrdersStorageOrderTemplateCategoriesById(String id, Map<String, String> okapiHeaders,
-                                                        Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.getById(ORDER_TEMPLATE_CATEGORIES_TABLE, OrderTemplateCategory.class, id, okapiHeaders,vertxContext,
-      GetOrdersStorageOrderTemplateCategoriesByIdResponse.class, asyncResultHandler);
+                                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    orderTemplateCategoryService.getOrderTemplateCategory(id, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   public void deleteOrdersStorageOrderTemplateCategoriesById(String id, Map<String, String> okapiHeaders,
-                                                           Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.deleteById(ORDER_TEMPLATE_CATEGORIES_TABLE, id, okapiHeaders, vertxContext,
-      DeleteOrdersStorageOrderTemplateCategoriesByIdResponse.class, asyncResultHandler);
+                                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    orderTemplateCategoryService.deleteOrderTemplateCategory(id, okapiHeaders, asyncResultHandler, vertxContext);
   }
 
   @Override
   protected String getEndpoint(Object entity) {
     return HelperUtils.getEndpoint(OrdersStorageOrderTemplateCategories.class) + mapFrom(entity).getString("id");
   }
+
 }

--- a/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
+++ b/src/main/java/org/folio/rest/impl/OrderTemplatesAPI.java
@@ -21,8 +21,10 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 
 public class OrderTemplatesAPI extends BaseApi implements OrdersStorageOrderTemplates {
+
   private static final Logger log = LogManager.getLogger();
-  private static final String ORDER_TEMPLATES_TABLE = "order_templates";
+
+  public static final String ORDER_TEMPLATES_TABLE = "order_templates";
 
   @Override
   @Validate

--- a/src/main/java/org/folio/services/order/OrderTemplateCategoryService.java
+++ b/src/main/java/org/folio/services/order/OrderTemplateCategoryService.java
@@ -1,0 +1,79 @@
+package org.folio.services.order;
+
+import static org.folio.rest.core.ResponseUtil.buildErrorResponse;
+import static org.folio.rest.core.ResponseUtil.buildNoContentResponse;
+import static org.folio.rest.exceptions.ErrorCodes.ORDER_TEMPLATE_CATEGORY_IS_USED;
+import static org.folio.rest.impl.OrderTemplatesAPI.ORDER_TEMPLATES_TABLE;
+import static org.folio.rest.persist.HelperUtils.getFullTableName;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.folio.rest.exceptions.HttpException;
+import org.folio.rest.jaxrs.model.OrderTemplateCategory;
+import org.folio.rest.jaxrs.model.OrderTemplateCategoryCollection;
+import org.folio.rest.jaxrs.resource.OrdersStorageOrderTemplateCategories;
+import org.folio.rest.persist.Conn;
+import org.folio.rest.persist.DBClient;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.util.DbUtils;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.Tuple;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OrderTemplateCategoryService {
+
+  private static final String ORDER_TEMPLATE_CATEGORIES_TABLE = "order_template_categories";
+  private static final String ORDER_TEMPLATE_COUNT_BY_TEMPLATE_ID_QUERY = "SELECT COUNT(*) FROM %s WHERE jsonb->'categoryIds' ? $1";
+
+  public void getOrderTemplateCategories(String query, int offset, int limit, Map<String, String> okapiHeaders,
+                                         Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.get(ORDER_TEMPLATE_CATEGORIES_TABLE, OrderTemplateCategory.class, OrderTemplateCategoryCollection.class,
+      query, offset, limit, okapiHeaders, vertxContext, OrdersStorageOrderTemplateCategories.GetOrdersStorageOrderTemplateCategoriesResponse.class, asyncResultHandler);
+  }
+
+  public void getOrderTemplateCategory(String id, Map<String, String> okapiHeaders,
+                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.getById(ORDER_TEMPLATE_CATEGORIES_TABLE, OrderTemplateCategory.class, id, okapiHeaders, vertxContext,
+      OrdersStorageOrderTemplateCategories.GetOrdersStorageOrderTemplateCategoriesByIdResponse.class, asyncResultHandler);
+  }
+
+  public void createOrderTemplateCategory(OrderTemplateCategory entity, Map<String, String> okapiHeaders,
+                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.post(ORDER_TEMPLATE_CATEGORIES_TABLE, entity, okapiHeaders, vertxContext,
+      OrdersStorageOrderTemplateCategories.PostOrdersStorageOrderTemplateCategoriesResponse.class, asyncResultHandler);
+  }
+
+
+  public void updateOrderTemplateCategory(String id, OrderTemplateCategory entity, Map<String, String> okapiHeaders,
+                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgUtil.put(ORDER_TEMPLATE_CATEGORIES_TABLE, entity, id, okapiHeaders, vertxContext,
+      OrdersStorageOrderTemplateCategories.PutOrdersStorageOrderTemplateCategoriesByIdResponse.class, asyncResultHandler);
+  }
+
+  public void deleteOrderTemplateCategory(String id, Map<String, String> okapiHeaders,
+                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    var tenantId = TenantTool.tenantId(okapiHeaders);
+    new DBClient(vertxContext, okapiHeaders).getPgClient()
+      .withTrans(conn -> getOrderTemplatesNumberByCategoryId(id, tenantId, conn)
+        .compose(count -> count > 0
+          ? Future.failedFuture(new HttpException(HttpStatus.SC_UNPROCESSABLE_ENTITY, ORDER_TEMPLATE_CATEGORY_IS_USED))
+          : conn.delete(ORDER_TEMPLATES_TABLE, id))
+        .onSuccess(s -> asyncResultHandler.handle(buildNoContentResponse()))
+        .onFailure(t -> asyncResultHandler.handle(buildErrorResponse(t))));
+  }
+
+  private Future<Long> getOrderTemplatesNumberByCategoryId(String categoryId, String tenantId, Conn conn) {
+    var query = ORDER_TEMPLATE_COUNT_BY_TEMPLATE_ID_QUERY.formatted(getFullTableName(tenantId, ORDER_TEMPLATES_TABLE));
+    return conn.execute(query, Tuple.of(categoryId))
+      .map(DbUtils::getRowSetAsCount);
+  }
+
+}


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1309] UUID of deleted order template category is displayed in Order template](https://folio-org.atlassian.net/browse/MODORDERS-1309)

### **Approach**
- Add OrderTemplateCategoryService and update API to use it for CRUD operations
- Add validation for remaining category usages before deletion

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
