### PR TITLE
[MODORDERS-1356] BE - Create Sequence field in receiving

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -91,7 +91,7 @@
         {
           "methods": ["POST"],
           "pathPattern": "/orders-storage/titles/{id}/sequence-numbers",
-          "permissionsRequired": ["orders-storage.titles.sequence-number.post"]
+          "permissionsRequired": ["orders-storage.titles.sequence-number.get"]
         }
       ]
     },
@@ -812,8 +812,8 @@
       "description" : "Delete a title"
     },
     {
-      "permissionName" : "orders-storage.titles.sequence-number.post",
-      "displayName" : "orders-storage.titles.sequence-number post",
+      "permissionName" : "orders-storage.titles.sequence-number.get",
+      "displayName" : "orders-storage.titles.sequence-number get",
       "description" : "Generate title sequence numbers"
     },
     {
@@ -826,7 +826,7 @@
         "orders-storage.titles.item.get",
         "orders-storage.titles.item.put",
         "orders-storage.titles.item.delete",
-        "orders-storage.titles.sequence-number.post"
+        "orders-storage.titles.sequence-number.get"
       ]
     },
     {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -87,6 +87,11 @@
           "methods": ["DELETE"],
           "pathPattern": "/orders-storage/titles/{id}",
           "permissionsRequired": ["orders-storage.titles.item.delete"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/orders-storage/titles/{id}/sequence-numbers",
+          "permissionsRequired": ["orders-storage.titles.sequence-number.post"]
         }
       ]
     },
@@ -807,6 +812,11 @@
       "description" : "Delete a title"
     },
     {
+      "permissionName" : "orders-storage.titles.sequence-number.post",
+      "displayName" : "orders-storage.titles.sequence-number post",
+      "description" : "Generate title sequence numbers"
+    },
+    {
       "permissionName" : "orders-storage.titles.all",
       "displayName" : "All orders-storage titles perms",
       "description" : "All permissions for the orders-storage-titles",
@@ -815,7 +825,8 @@
         "orders-storage.titles.item.post",
         "orders-storage.titles.item.get",
         "orders-storage.titles.item.put",
-        "orders-storage.titles.item.delete"
+        "orders-storage.titles.item.delete",
+        "orders-storage.titles.sequence-number.post"
       ]
     },
     {

--- a/ramls/titles.raml
+++ b/ramls/titles.raml
@@ -10,6 +10,7 @@ documentation:
 types:
     title: !include acq-models/mod-orders-storage/schemas/title.json
     title_collection: !include acq-models/mod-orders-storage/schemas/title_collection.json
+    title-sequence-numbers: !include acq-models/common/schemas/sequence_numbers.json
     UUID:
      type: string
      pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
@@ -44,4 +45,33 @@ resourceTypes:
       collection-item:
         exampleItem: !include acq-models/mod-orders-storage/examples/title_get.sample
         schema: title
+
+    /sequence-numbers:
+      uriParameters:
+        id:
+          description: The UUID of a Title
+          type: UUID
+      post:
+        description: Get next sequence numbers for the title
+        queryParameters:
+          sequenceNumbers:
+            description: Quantity of the next sequence numbers
+            type: integer
+            default: 1
+            example: 1
+        responses:
+          200:
+            body:
+              application/json:
+                type: title-sequence-numbers
+          400:
+            description: "Bad request, e.g. malformed request body or query parameter"
+            body:
+              text/plain:
+                example: "Unable to generate sequence numbers"
+          500:
+            description: "Internal server error, e.g. due to misconfiguration"
+            body:
+              text/plain:
+                example: "Internal server error, contact Administrator"
 

--- a/ramls/titles.raml
+++ b/ramls/titles.raml
@@ -51,7 +51,7 @@ resourceTypes:
         id:
           description: The UUID of a Title
           type: UUID
-      post:
+      get:
         description: Get next sequence numbers for the title
         queryParameters:
           sequenceNumbers:

--- a/src/main/java/org/folio/rest/impl/TitlesAPI.java
+++ b/src/main/java/org/folio/rest/impl/TitlesAPI.java
@@ -89,7 +89,7 @@ public class TitlesAPI extends BaseApi implements OrdersStorageTitles {
 
   @Override
   public void postOrdersStorageTitlesSequenceNumbersById(String id, int sequenceNumbers, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    pgClient.withConn(conn -> titleService.generateTitleNextSequenceNumbers(id, sequenceNumbers, conn))
+    pgClient.withTrans(conn -> titleService.generateTitleNextSequenceNumbers(id, sequenceNumbers, conn))
       .onComplete(ar -> asyncResultHandler.handle(ar.failed()
         ? buildErrorResponse(ar.cause())
         : buildOkResponse(ar.result())));

--- a/src/main/java/org/folio/rest/impl/TitlesAPI.java
+++ b/src/main/java/org/folio/rest/impl/TitlesAPI.java
@@ -88,6 +88,14 @@ public class TitlesAPI extends BaseApi implements OrdersStorageTitles {
   }
 
   @Override
+  public void postOrdersStorageTitlesSequenceNumbersById(String id, int sequenceNumbers, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    pgClient.withConn(conn -> titleService.generateTitleNextSequenceNumbers(id, sequenceNumbers, conn))
+      .onComplete(ar -> asyncResultHandler.handle(ar.failed()
+        ? buildErrorResponse(ar.cause())
+        : buildNoContentResponse()));
+  }
+
+  @Override
   protected String getEndpoint(Object entity) {
     return HelperUtils.getEndpoint(OrdersStorageTitles.class) + JsonObject.mapFrom(entity).getString("id");
   }

--- a/src/main/java/org/folio/rest/impl/TitlesAPI.java
+++ b/src/main/java/org/folio/rest/impl/TitlesAPI.java
@@ -92,7 +92,7 @@ public class TitlesAPI extends BaseApi implements OrdersStorageTitles {
     pgClient.withConn(conn -> titleService.generateTitleNextSequenceNumbers(id, sequenceNumbers, conn))
       .onComplete(ar -> asyncResultHandler.handle(ar.failed()
         ? buildErrorResponse(ar.cause())
-        : buildNoContentResponse()));
+        : buildOkResponse(ar.result())));
   }
 
   @Override

--- a/src/main/java/org/folio/rest/impl/TitlesAPI.java
+++ b/src/main/java/org/folio/rest/impl/TitlesAPI.java
@@ -88,7 +88,7 @@ public class TitlesAPI extends BaseApi implements OrdersStorageTitles {
   }
 
   @Override
-  public void postOrdersStorageTitlesSequenceNumbersById(String id, int sequenceNumbers, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getOrdersStorageTitlesSequenceNumbersById(String id, int sequenceNumbers, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     pgClient.withTrans(conn -> titleService.generateTitleNextSequenceNumbers(id, sequenceNumbers, conn))
       .onComplete(ar -> asyncResultHandler.handle(ar.failed()
         ? buildErrorResponse(ar.cause())

--- a/src/main/java/org/folio/services/title/TitleService.java
+++ b/src/main/java/org/folio/services/title/TitleService.java
@@ -122,14 +122,11 @@ public class TitleService {
     return conn.getByIdForUpdate(TITLES_TABLE, titleId, Title.class)
       .compose(title -> {
         var nextNumber = title.getNextSequenceNumber();
-        log.error("generateTitleNextSequenceNumbers: A title with an id={} was found with number {}", title.getId(), title.getNextSequenceNumber());
         var titleSequenceNumbers = new TitleSequenceNumbers()
           .withSequenceNumbers(IntStream.range(nextNumber, nextNumber + sequenceNumbers)
             .mapToObj(Integer::toString)
             .toList());
-        log.error("generateTitleNextSequenceNumbers: Generated sequence numbers: {}", titleSequenceNumbers);
         title.setNextSequenceNumber(nextNumber + sequenceNumbers);
-        log.error("generateTitleNextSequenceNumbers: Updated next sequence number to {}", title.getNextSequenceNumber());
         return conn.update(TITLES_TABLE, title, titleId).map(titleSequenceNumbers);
       })
       .onFailure(t -> log.error("generateTitleNextSequenceNumbers: Failed to generate sequence numbers for title: '{}'", titleId, t));

--- a/src/main/java/org/folio/services/title/TitleService.java
+++ b/src/main/java/org/folio/services/title/TitleService.java
@@ -127,7 +127,7 @@ public class TitleService {
             .mapToObj(Integer::toString)
             .toList());
         title.setNextSequenceNumber(nextNumber + sequenceNumbers);
-        return saveTitle(title, conn).map(titleSequenceNumbers);
+        return conn.update(TITLES_TABLE, title, titleId).map(titleSequenceNumbers);
       })
       .onFailure(t -> log.error("generateTitleNextSequenceNumbers: Failed to generate sequence numbers for title: '{}'", titleId, t));
   }

--- a/src/main/java/org/folio/services/title/TitleService.java
+++ b/src/main/java/org/folio/services/title/TitleService.java
@@ -122,11 +122,14 @@ public class TitleService {
     return conn.getByIdForUpdate(TITLES_TABLE, titleId, Title.class)
       .compose(title -> {
         var nextNumber = title.getNextSequenceNumber();
+        log.error("generateTitleNextSequenceNumbers: A title with an id={} was found with number {}", title.getId(), title.getNextSequenceNumber());
         var titleSequenceNumbers = new TitleSequenceNumbers()
           .withSequenceNumbers(IntStream.range(nextNumber, nextNumber + sequenceNumbers)
             .mapToObj(Integer::toString)
             .toList());
+        log.error("generateTitleNextSequenceNumbers: Generated sequence numbers: {}", titleSequenceNumbers);
         title.setNextSequenceNumber(nextNumber + sequenceNumbers);
+        log.error("generateTitleNextSequenceNumbers: Updated next sequence number to {}", title.getNextSequenceNumber());
         return conn.update(TITLES_TABLE, title, titleId).map(titleSequenceNumbers);
       })
       .onFailure(t -> log.error("generateTitleNextSequenceNumbers: Failed to generate sequence numbers for title: '{}'", titleId, t));

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -61,6 +61,7 @@ import org.folio.rest.impl.SearchOrderLinesTest;
 import org.folio.rest.impl.SuffixDeprecatedQueryTest;
 import org.folio.rest.impl.TenantReferenceDataTest;
 import org.folio.rest.impl.TenantSampleDataTest;
+import org.folio.rest.impl.TitleSequenceNumberTest;
 import org.folio.rest.impl.WrapperPiecesAPITest;
 import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.rest.persist.DBClientTest;
@@ -286,6 +287,8 @@ public class StorageTestSuite {
   class PurchaseOrderNumberUniquenessTestNested extends PurchaseOrderNumberUniquenessTest {}
   @Nested
   class ReceivingHistoryTestNested extends ReceivingHistoryTest {}
+  @Nested
+  class TitleSequenceNumberTestNested extends TitleSequenceNumberTest {}
   @Nested
   class SearchOrderLinesTestNested extends SearchOrderLinesTest {}
   @Nested

--- a/src/test/java/org/folio/rest/impl/TitleSequenceNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/TitleSequenceNumberTest.java
@@ -58,7 +58,7 @@ public class TitleSequenceNumberTest extends TestBase {
       .pathParam("id", id)
       .queryParam("sequenceNumbers", sequenceNumbers)
       .header(TENANT_HEADER)
-      .post(storageUrl(TITLE_SEQUENCE_NUMBERS_ENDPOINT))
+      .get(storageUrl(TITLE_SEQUENCE_NUMBERS_ENDPOINT))
       .then().statusCode(200)
       .extract().as(PoLineNumber.class)
       .getSequenceNumbers();

--- a/src/test/java/org/folio/rest/impl/TitleSequenceNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/TitleSequenceNumberTest.java
@@ -49,8 +49,8 @@ public class TitleSequenceNumberTest extends TestBase {
     title = getTitle(titleId);
     assertEquals(5, title.getNextSequenceNumber());
 
-    deleteData(PURCHASE_ORDER.getEndpointWithId(), poId);
-    deleteData(PO_LINE.getEndpointWithId(), poLineId);
+    deleteDataSuccess(PO_LINE.getEndpointWithId(), poLineId);
+    deleteDataSuccess(PURCHASE_ORDER.getEndpointWithId(), poId);
   }
 
   private List<String> generateTitleSequenceNumbers(String id, int sequenceNumbers) throws MalformedURLException {

--- a/src/test/java/org/folio/rest/impl/TitleSequenceNumberTest.java
+++ b/src/test/java/org/folio/rest/impl/TitleSequenceNumberTest.java
@@ -1,0 +1,74 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.given;
+import static org.folio.StorageTestSuite.storageUrl;
+import static org.folio.rest.utils.TestEntities.PO_LINE;
+import static org.folio.rest.utils.TestEntities.PURCHASE_ORDER;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.MalformedURLException;
+import java.util.List;
+
+import org.folio.rest.jaxrs.model.PoLineNumber;
+import org.folio.rest.jaxrs.model.Title;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.http.ContentType;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class TitleSequenceNumberTest extends TestBase {
+
+  private static final String TITLE_ENDPOINT = "/orders-storage/titles";
+  private static final String TITLE_BY_ID_ENDPOINT = TITLE_ENDPOINT + "/{id}";
+  private static final String TITLE_SEQUENCE_NUMBERS_ENDPOINT = TITLE_BY_ID_ENDPOINT + "/sequence-numbers";
+  private static final String TITLE_SAMPLE_FILE_PATH = "mockdata/titles/title.json";
+
+  @Test
+  public void testGenerateTitleSequenceNumbers() throws MalformedURLException {
+    String poId = postData(PURCHASE_ORDER.getEndpoint(), getFile(PURCHASE_ORDER.getSampleFileName()))
+      .then().extract().path("id");
+    String poLineId = postData(PO_LINE.getEndpoint(), getFile(PO_LINE.getSampleFileName()))
+      .then().extract().path("id");
+    String titleId = postData(TITLE_ENDPOINT, getFile(TITLE_SAMPLE_FILE_PATH))
+      .then().statusCode(201).extract().path("id");
+
+    var title = getTitle(titleId);
+    assertEquals(1, title.getNextSequenceNumber());
+
+    var sequenceNumbers = generateTitleSequenceNumbers(titleId, 1);
+    assertEquals(List.of("1"), sequenceNumbers);
+
+    title = getTitle(titleId);
+    assertEquals(2, title.getNextSequenceNumber());
+
+    sequenceNumbers = generateTitleSequenceNumbers(titleId, 3);
+    assertEquals(List.of("2", "3", "4"), sequenceNumbers);
+
+    title = getTitle(titleId);
+    assertEquals(5, title.getNextSequenceNumber());
+
+    deleteData(PURCHASE_ORDER.getEndpointWithId(), poId);
+    deleteData(PO_LINE.getEndpointWithId(), poLineId);
+  }
+
+  private List<String> generateTitleSequenceNumbers(String id, int sequenceNumbers) throws MalformedURLException {
+    return given().accept(ContentType.JSON)
+      .pathParam("id", id)
+      .queryParam("sequenceNumbers", sequenceNumbers)
+      .header(TENANT_HEADER)
+      .post(storageUrl(TITLE_SEQUENCE_NUMBERS_ENDPOINT))
+      .then().statusCode(200)
+      .extract().as(PoLineNumber.class)
+      .getSequenceNumbers();
+  }
+
+  private Title getTitle(String id) throws MalformedURLException {
+    return getDataById(TITLE_BY_ID_ENDPOINT, id)
+      .then().statusCode(200)
+      .body("id", equalTo(id))
+      .extract().as(Title.class);
+  }
+
+}

--- a/src/test/java/org/folio/services/title/TitleServiceTest.java
+++ b/src/test/java/org/folio/services/title/TitleServiceTest.java
@@ -9,6 +9,7 @@ import static org.folio.rest.utils.TenantApiTestUtil.prepareTenant;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.MalformedURLException;
 import java.util.List;
@@ -16,11 +17,13 @@ import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.CopilotGenerated;
 import org.folio.rest.impl.TestBase;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.rest.jaxrs.model.Title;
+import org.folio.rest.jaxrs.model.TitleSequenceNumbers;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.Tx;
 import org.junit.jupiter.api.AfterEach;
@@ -36,6 +39,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
+@CopilotGenerated(partiallyGenerated = true, model = "Claude Sonnet 4")
 @ExtendWith(VertxExtension.class)
 public class TitleServiceTest extends TestBase {
   private static final Logger log = LogManager.getLogger();
@@ -309,6 +313,101 @@ public class TitleServiceTest extends TestBase {
         String exception = String.format("Title with poLineId=%s was not found", incorrectPoLineId);
         testContext.verify(() -> {
           assertEquals(event.getMessage(), exception);
+        });
+        testContext.completeNow();
+      });
+  }
+
+  @Test
+  void shouldGenerateTitleNextSequenceNumbers(Vertx vertx, VertxTestContext testContext) {
+    String poLineId = UUID.randomUUID().toString();
+    String titleId = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
+    String purchaseOrderId = UUID.randomUUID().toString();
+    int sequenceNumbersToGenerate = 5;
+    int initialNextSequenceNumber = 10;
+
+    PurchaseOrder purchaseOrder = new PurchaseOrder()
+      .withId(purchaseOrderId)
+      .withAcqUnitIds(List.of("First", "Second"));
+
+    PoLine poLine = new PoLine()
+      .withId(poLineId)
+      .withIsPackage(false)
+      .withPurchaseOrderId(purchaseOrderId)
+      .withTitleOrPackage("Title name")
+      .withClaimingActive(true)
+      .withClaimingInterval(1);
+
+    Title title = new Title()
+      .withId(titleId)
+      .withPoLineId(poLineId)
+      .withInstanceId(instanceId)
+      .withNextSequenceNumber(initialNextSequenceNumber);
+
+    Promise<Void> saveOrderPromise = Promise.promise();
+    final DBClient client = new DBClient(vertx, TEST_TENANT);
+    client.getPgClient().save(PURCHASE_ORDER_TABLE, purchaseOrderId, purchaseOrder, event -> {
+      saveOrderPromise.complete();
+      log.info("PurchaseOrder was saved");
+    });
+
+    Promise<Void> saveOrderLinePromise = Promise.promise();
+    saveOrderPromise.future().onComplete(v -> client.getPgClient().save(PO_LINE_TABLE, poLineId, poLine, event -> {
+      saveOrderLinePromise.complete();
+      log.info("PoLine was saved");
+    }));
+
+    Promise<Void> saveTitlePromise = Promise.promise();
+    saveOrderLinePromise.future().onComplete(v -> client.getPgClient().save(TITLES_TABLE, titleId, title, ar -> {
+      if (ar.failed()) {
+        saveTitlePromise.fail(ar.cause());
+      } else {
+        saveTitlePromise.complete();
+        log.info("Title was saved");
+      }
+    }));
+
+    testContext.assertComplete(saveTitlePromise.future()
+        .compose(o -> client.getPgClient().withConn(conn ->
+          titleService.generateTitleNextSequenceNumbers(titleId, sequenceNumbersToGenerate, conn))))
+      .onComplete(ar -> {
+        TitleSequenceNumbers result = ar.result();
+        testContext.verify(() -> {
+          assertNotNull(result);
+          assertNotNull(result.getSequenceNumbers());
+          assertEquals(sequenceNumbersToGenerate, result.getSequenceNumbers().size());
+          assertEquals("10", result.getSequenceNumbers().get(0));
+          assertEquals("11", result.getSequenceNumbers().get(1));
+          assertEquals("12", result.getSequenceNumbers().get(2));
+          assertEquals("13", result.getSequenceNumbers().get(3));
+          assertEquals("14", result.getSequenceNumbers().get(4));
+        });
+
+        // Verify that the title's nextSequenceNumber was updated
+        titleService.getTitleByPoLineId(poLineId, client)
+          .onComplete(titleAr -> {
+            Title updatedTitle = titleAr.result();
+            testContext.verify(() -> {
+              assertEquals(initialNextSequenceNumber + sequenceNumbersToGenerate, updatedTitle.getNextSequenceNumber());
+            });
+            testContext.completeNow();
+          });
+      });
+  }
+
+  @Test
+  void shouldFailGenerateTitleNextSequenceNumbersForNonExistentTitle(Vertx vertx, VertxTestContext testContext) {
+    String nonExistentTitleId = UUID.randomUUID().toString();
+    int sequenceNumbersToGenerate = 3;
+    final DBClient client = new DBClient(vertx, TEST_TENANT);
+
+    testContext.assertFailure(client.getPgClient().withConn(conn ->
+      titleService.generateTitleNextSequenceNumbers(nonExistentTitleId, sequenceNumbersToGenerate, conn)))
+      .onFailure(throwable -> {
+        testContext.verify(() -> {
+          assertNotNull(throwable);
+          // The exact error message may vary depending on implementation
         });
         testContext.completeNow();
       });

--- a/src/test/resources/mockdata/titles/title.json
+++ b/src/test/resources/mockdata/titles/title.json
@@ -1,0 +1,6 @@
+{
+  "id": "c8b8789f-ad4b-4d4a-9c49-bf453ac6d9dc",
+  "title": "Test Title",
+  "poLineId": "baec48dd-1594-2712-be8f-de336bc83fcc",
+  "instanceId": "e3038b08-ba84-4c24-ae18-67904ac11416"
+}


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1356] BE - Create Sequence field in receiving](https://folio-org.atlassian.net/browse/MODORDERS-1356)

### **Approach**
- Add new endpoint for generating sequence numbers for pieces
- Implement the endpoint logic and cover with tests

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
