### PR TITLE
[MODORDERS-1356] Prevent POL update to clear title next sequence number

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -89,7 +89,7 @@
           "permissionsRequired": ["orders-storage.titles.item.delete"]
         },
         {
-          "methods": ["POST"],
+          "methods": ["GET"],
           "pathPattern": "/orders-storage/titles/{id}/sequence-numbers",
           "permissionsRequired": ["orders-storage.titles.sequence-number.get"]
         }

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -539,7 +539,8 @@ public class PoLinesService {
   private boolean titleUpdateRequired(Title title, PoLine poLine, Map<String, String> headers) {
     return !title.equals(createTitleObject(poLine, title.getAcqUnitIds(), headers)
       .withId(title.getId())
-      .withMetadata(title.getMetadata()));
+      .withMetadata(title.getMetadata())
+      .withNextSequenceNumber(title.getNextSequenceNumber()));
   }
 
 }


### PR DESCRIPTION
### **Purpose**
[[MODORDERS-1356] Prevent POL update to clear title next sequence number](https://folio-org.atlassian.net/browse/MODORDERS-1356)

### **Approach**
- Fix endpoint method
- Add next sequence number to newly created title for comparison

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
