### PR TITLE
Remove create internal_lock table

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -113,11 +113,6 @@
     },
     {
       "run": "after",
-      "snippetPath": "tables/create_internal_lock_table.sql",
-      "fromModuleVersion": "mod-orders-storage-13.5.0"
-    },
-    {
-      "run": "after",
       "snippetPath": "data-migration/13.6.0/replace_po_sequences.ftl",
       "fromModuleVersion": "mod-orders-storage-13.6.0"
     },

--- a/src/main/resources/templates/db_scripts/tables/create_internal_lock_table.sql
+++ b/src/main/resources/templates/db_scripts/tables/create_internal_lock_table.sql
@@ -1,5 +1,0 @@
-CREATE TABLE IF NOT EXISTS internal_lock (
-  lock_name text NOT NULL PRIMARY KEY
-);
-
-INSERT INTO internal_lock(lock_name) VALUES ('audit_outbox') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
### **Purpose**

- Remove create `internal_lock` table

### **Approach**

- The command was always creating the now redundant table
- The proposed changes will avoid the creation of `internal_lock` table on fresh installs
