### PR TITLE
Sunflower Service patch v13.9.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 ## 14.0.0 - Unreleased
 
+## 13.9.8 - Released (Sunflower R1 2025 Hot Fix)
+
+[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v13.9.7...v13.9.8)
+
+### Bug Fixes
+* [MODORDSTOR-511](https://folio-org.atlassian.net/browse/MODORDSTOR-511) - Sunflower Backport - Updating receiptDate does not update updatedDate in POL audit history
+
 ## 13.9.7 - Released (Sunflower R1 2025 Hot Fix)
 
 [Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v13.9.6...v13.9.7)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>13.9.8</version>
+  <version>13.9.9-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -641,7 +641,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v13.9.8</tag>
+    <tag>v13.9.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>13.9.8-SNAPSHOT</version>
+  <version>13.9.8</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -641,7 +641,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v13.9.0</tag>
+    <tag>v13.9.8</tag>
   </scm>
 
 </project>

--- a/src/main/java/org/folio/services/lines/PoLinesBatchService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesBatchService.java
@@ -1,6 +1,7 @@
 package org.folio.services.lines;
 
 import static org.folio.models.TableNames.PO_LINE_TABLE;
+import static org.folio.util.MetadataUtils.populateMetadata;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ public class PoLinesBatchService {
       log.warn("poLinesBatchUpdate:: po line list is empty");
       return Future.succeededFuture();
     }
+    poLines.forEach(poLine -> populateMetadata(poLine::getMetadata, poLine::withMetadata, okapiHeaders));
     return pgClient.withTrans(conn ->
       conn.updateBatch(PO_LINE_TABLE, poLines)
         .compose(rowSet -> poLinesService.updateTitles(conn, poLines, okapiHeaders))


### PR DESCRIPTION
## 13.9.8 - Released (Sunflower R1 2025 Hot Fix)

[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v13.9.7...v13.9.8)

### Bug Fixes
* [MODORDSTOR-511](https://folio-org.atlassian.net/browse/MODORDSTOR-511) - Sunflower Backport - Updating receiptDate does not update updatedDate in POL audit history
* 
Original ticket https://folio-org.atlassian.net/browse/MODORDSTOR-498.