### PR TITLE
[MODINVOICE-647] Updated models + new migration

### DIFF
--- a/src/main/resources/templates/db_scripts/data-migration/15.0.0/fill_missing_next_pol_number.ftl
+++ b/src/main/resources/templates/db_scripts/data-migration/15.0.0/fill_missing_next_pol_number.ftl
@@ -1,6 +1,6 @@
 <#if mode.name() == "UPDATE">
   WITH missing_next_numbers AS (
-    SELECT po.id, COALESCE(MAX(REGEXP_REPLACE(pol.jsonb ->> 'poLineNumber', '^[^-]+-([^-])$', '\1')::int), 0) + 1 AS number
+    SELECT po.id, COALESCE(MAX(REGEXP_REPLACE(pol.jsonb ->> 'poLineNumber', '^[^-]+-([^-]+)$', '\1')::int), 0) + 1 AS number
       FROM ${myuniversity}_${mymodule}.purchase_order po
       LEFT JOIN ${myuniversity}_${mymodule}.po_line pol ON pol.purchaseOrderId = po.id
       WHERE po.jsonb -> 'nextPolNumber' IS NULL

--- a/src/main/resources/templates/db_scripts/data-migration/15.0.0/fill_missing_next_pol_number.ftl
+++ b/src/main/resources/templates/db_scripts/data-migration/15.0.0/fill_missing_next_pol_number.ftl
@@ -1,0 +1,14 @@
+<#if mode.name() == "UPDATE">
+  WITH missing_next_numbers AS (
+    SELECT po.id, COALESCE(MAX(REGEXP_REPLACE(pol.jsonb ->> 'poLineNumber', '^[^-]+-([^-])$', '\1')::int), 0) + 1 AS number
+      FROM ${myuniversity}_${mymodule}.purchase_order po
+      LEFT JOIN ${myuniversity}_${mymodule}.po_line pol ON pol.purchaseOrderId = po.id
+      WHERE po.jsonb -> 'nextPolNumber' IS NULL
+      GROUP BY po.id
+  )
+
+  UPDATE ${myuniversity}_${mymodule}.purchase_order po
+  SET jsonb = jsonb_set(po.jsonb, '{nextPolNumber}', to_jsonb(mnn.number))
+  FROM missing_next_numbers mnn
+  WHERE po.id = mnn.id;
+</#if>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -195,6 +195,11 @@
       "run": "after",
       "snippetPath": "data-migration/14.0.0/drop_internal_lock_table.ftl",
       "fromModuleVersion": "mod-orders-storage-14.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/15.0.0/fill_missing_next_pol_number.ftl",
+      "fromModuleVersion": "mod-orders-storage-15.0.0"
     }
   ],
   "tables": [


### PR DESCRIPTION
## Purpose
[MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion

## Approach
- Updated model removing the readonly attribute for `nextPolNumber`
- Added a migration to calculate missing next numbers from lines

## Related PRs
- [acq-models 1](https://github.com/folio-org/acq-models/pull/567), [acq-models 2](https://github.com/folio-org/acq-models/pull/568)
- [mod-invoice-storage](https://github.com/folio-org/mod-invoice-storage/pull/259)
- [mod-invoice](https://github.com/folio-org/mod-invoice/pull/622)
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1307)
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2352)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
