### PR TITLE
Trillium release v14.0.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## 14.0.2 - Released (Trillium R1 2026 - Bugfix)
+The primary focus of this release was to fix issues with nextPoLineNumber and nextInvoiceLineNumber usage.
+
+[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v14.0.1...v14.0.2)
+
+### Bug Fixes
+* [MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion
+
 ## 14.0.1 - Released (Trillium R1 2026 - Bugfix)
 The primary focus of this release was to remove cross-schema access from PO fiscal year migration.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>14.0.2-SNAPSHOT</version>
+  <version>14.0.2</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -634,7 +634,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v14.0.0</tag>
+    <tag>v14.0.2</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>14.0.2</version>
+  <version>14.0.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -634,7 +634,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v14.0.2</tag>
+    <tag>v14.0.0</tag>
   </scm>
 
 </project>

--- a/src/main/resources/templates/db_scripts/data-migration/15.0.0/fill_missing_next_pol_number.ftl
+++ b/src/main/resources/templates/db_scripts/data-migration/15.0.0/fill_missing_next_pol_number.ftl
@@ -1,0 +1,14 @@
+<#if mode.name() == "UPDATE">
+  WITH missing_next_numbers AS (
+    SELECT po.id, COALESCE(MAX(REGEXP_REPLACE(pol.jsonb ->> 'poLineNumber', '^[^-]+-([^-]+)$', '\1')::int), 0) + 1 AS number
+      FROM ${myuniversity}_${mymodule}.purchase_order po
+      LEFT JOIN ${myuniversity}_${mymodule}.po_line pol ON pol.purchaseOrderId = po.id
+      WHERE po.jsonb -> 'nextPolNumber' IS NULL
+      GROUP BY po.id
+  )
+
+  UPDATE ${myuniversity}_${mymodule}.purchase_order po
+  SET jsonb = jsonb_set(po.jsonb, '{nextPolNumber}', to_jsonb(mnn.number))
+  FROM missing_next_numbers mnn
+  WHERE po.id = mnn.id;
+</#if>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -199,7 +199,7 @@
     {
       "run": "after",
       "snippetPath": "data-migration/15.0.0/fill_missing_next_pol_number.ftl",
-      "fromModuleVersion": "mod-orders-storage-15.0.0"
+      "fromModuleVersion": "mod-orders-storage-14.0.2"
     }
   ],
   "tables": [

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -195,6 +195,11 @@
       "run": "after",
       "snippetPath": "data-migration/14.0.0/drop_internal_lock_table.ftl",
       "fromModuleVersion": "mod-orders-storage-14.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/15.0.0/fill_missing_next_pol_number.ftl",
+      "fromModuleVersion": "mod-orders-storage-15.0.0"
     }
   ],
   "tables": [


### PR DESCRIPTION
## 14.0.2 - Released (Trillium R1 2026 - Bugfix)
The primary focus of this release was to fix issues with nextPoLineNumber and nextInvoiceLineNumber usage.

[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v14.0.1...v14.0.2)

### Bug Fixes
* [MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion
