### PR TITLE
MODORDSTOR-488. Introduce header to bypath settings cache for Karate

### DIFF
--- a/src/main/java/org/folio/services/setting/SettingService.java
+++ b/src/main/java/org/folio/services/setting/SettingService.java
@@ -38,6 +38,7 @@ public class SettingService {
   private static final String SETTINGS_TABLE = "settings";
   private static final String SETTINGS_BY_KEY_QUERY = "key==%s";
   private static final String SETTINGS_CACHE_KEY = "%s.%s";
+  public static final String BYPASS_CACHE_HEADER = "x-okapi-bypass-cache";
 
   private AsyncCache<String, Optional<Setting>> asyncCache;
 
@@ -54,6 +55,9 @@ public class SettingService {
 
   public Future<Optional<Setting>> getSettingByKey(SettingKey settingKey, Map<String, String> okapiHeaders, Context vertxContext) {
     try {
+      if (isCacheBypassRequested(okapiHeaders)) {
+        return Future.fromCompletionStage(getSettingByKeyFromDB(settingKey, okapiHeaders, vertxContext));
+      }
       var settingCacheKey = String.format(SETTINGS_CACHE_KEY, TenantTool.tenantId(okapiHeaders), settingKey.getName());
       return Future.fromCompletionStage(asyncCache.get(settingCacheKey, (key, executor) ->
         getSettingByKeyFromDB(settingKey, okapiHeaders, vertxContext)));
@@ -61,6 +65,15 @@ public class SettingService {
       log.error("Error when retrieving setting with key: '{}'", settingKey.getName(), e);
       return Future.failedFuture(e);
     }
+  }
+
+  private static boolean isCacheBypassRequested(Map<String, String> okapiHeaders) {
+    if (okapiHeaders == null) {
+      return false;
+    }
+    return okapiHeaders.entrySet().stream()
+      .anyMatch(entry -> BYPASS_CACHE_HEADER.equalsIgnoreCase(entry.getKey())
+        && Boolean.parseBoolean(entry.getValue()));
   }
 
   private CompletableFuture<Optional<Setting>> getSettingByKeyFromDB(SettingKey settingKey, Map<String, String> okapiHeaders, Context vertxContext) {

--- a/src/test/java/org/folio/services/setting/SettingServiceTest.java
+++ b/src/test/java/org/folio/services/setting/SettingServiceTest.java
@@ -1,0 +1,145 @@
+package org.folio.services.setting;
+
+import static org.folio.services.setting.SettingService.BYPASS_CACHE_HEADER;
+import static org.folio.services.setting.util.SettingKey.CENTRAL_ORDERING_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.Setting;
+import org.folio.rest.jaxrs.model.SettingCollection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+public class SettingServiceTest {
+
+  private static final String TENANT_ID = "diku";
+
+  private SettingService settingService;
+  private Context context;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    context = Vertx.vertx().getOrCreateContext();
+    settingService = spy(new SettingService());
+    setCacheExpirationTime(settingService, 60L);
+    settingService.init();
+  }
+
+  private static void setCacheExpirationTime(SettingService target, long seconds) throws Exception {
+    Field field = SettingService.class.getDeclaredField("cacheExpirationTime");
+    field.setAccessible(true);
+    field.setLong(target, seconds);
+  }
+
+  @Test
+  void getSettingByKey_cachesResult_whenHeaderIsAbsent(VertxTestContext testContext) {
+    var headers = headersWithoutBypass();
+    stubDbResponse(settingValue("true"));
+
+    settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headers, context)
+      .compose(first -> settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headers, context)
+        .map(second -> {
+          assertTrue(first.isPresent());
+          assertTrue(second.isPresent());
+          assertEquals("true", first.get().getValue());
+          assertEquals("true", second.get().getValue());
+          verify(settingService, times(1)).getSettings(anyString(), anyInt(), anyInt(), any(), any(Context.class));
+          return second;
+        }))
+      .onComplete(testContext.succeedingThenComplete());
+  }
+
+  @Test
+  void getSettingByKey_bypassesCache_whenHeaderIsTrue(VertxTestContext testContext) {
+    var headers = headersWithBypass("true");
+    stubDbResponse(settingValue("true"));
+
+    settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headers, context)
+      .compose(first -> settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headers, context)
+        .map(second -> {
+          assertTrue(first.isPresent());
+          assertTrue(second.isPresent());
+          verify(settingService, times(2)).getSettings(anyString(), anyInt(), anyInt(), any(), any(Context.class));
+          return second;
+        }))
+      .onComplete(testContext.succeedingThenComplete());
+  }
+
+  @Test
+  void getSettingByKey_returnsFreshFromDb_whenHeaderIsTrueAndCachePopulated(VertxTestContext testContext) {
+    stubDbResponse(settingValue("stale"));
+
+    settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headersWithoutBypass(), context)
+      .compose(cached -> {
+        assertTrue(cached.isPresent());
+        assertEquals("stale", cached.get().getValue());
+        stubDbResponse(settingValue("fresh"));
+        return settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headersWithBypass("true"), context);
+      })
+      .map(refreshed -> {
+        assertTrue(refreshed.isPresent());
+        assertEquals("fresh", refreshed.get().getValue());
+        return refreshed;
+      })
+      .onComplete(testContext.succeedingThenComplete());
+  }
+
+  @Test
+  void getSettingByKey_usesCache_whenHeaderValueIsFalse(VertxTestContext testContext) {
+    var headers = headersWithBypass("false");
+    stubDbResponse(settingValue("v"));
+
+    settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headers, context)
+      .compose(first -> settingService.getSettingByKey(CENTRAL_ORDERING_ENABLED, headers, context)
+        .map(second -> {
+          verify(settingService, times(1)).getSettings(anyString(), anyInt(), anyInt(), any(), any(Context.class));
+          return second;
+        }))
+      .onComplete(testContext.succeedingThenComplete());
+  }
+
+  private void stubDbResponse(Setting setting) {
+    var collection = new SettingCollection().withTotalRecords(1).withSettings(java.util.List.of(setting));
+    var response = Response.ok(collection).build();
+    doReturn(Future.succeededFuture(response)).when(settingService)
+      .getSettings(anyString(), anyInt(), anyInt(), any(), any(Context.class));
+  }
+
+  private static Setting settingValue(String value) {
+    return new Setting().withKey(CENTRAL_ORDERING_ENABLED.getName()).withValue(value);
+  }
+
+  private static Map<String, String> headersWithoutBypass() {
+    var headers = new HashMap<String, String>();
+    headers.put(XOkapiHeaders.TENANT, TENANT_ID);
+    return headers;
+  }
+
+  private static Map<String, String> headersWithBypass(String value) {
+    var headers = headersWithoutBypass();
+    headers.put(BYPASS_CACHE_HEADER, value);
+    return headers;
+  }
+}


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODORDSTOR-488

### **Approach**

- When a request contains the header bypath-cache, the service must skip the cache and fetch data directly from the remote source.

- If the header is not present, the service should use the cache as usual.

- This feature should be leveraged in Karate tests to ensure fresh data is retrieved and cache is not used.

Related Karate PR: https://github.com/folio-org/folio-integration-tests/pull/2428

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
