### PR TITLE
[MODORDSTOR-516] Add old object for EDIT audit events for PO, PO Line and Piece

### DIFF
--- a/src/main/java/org/folio/event/dto/AuditEntityWrapper.java
+++ b/src/main/java/org/folio/event/dto/AuditEntityWrapper.java
@@ -3,10 +3,6 @@ package org.folio.event.dto;
 import java.util.List;
 import java.util.function.Function;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Accessors;
 import one.util.streamex.StreamEx;
 
 public record AuditEntityWrapper<T> (T entity, T originalEntity) {

--- a/src/main/java/org/folio/event/dto/AuditEntityWrapper.java
+++ b/src/main/java/org/folio/event/dto/AuditEntityWrapper.java
@@ -1,0 +1,33 @@
+package org.folio.event.dto;
+
+import java.util.List;
+import java.util.function.Function;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import one.util.streamex.StreamEx;
+
+public record AuditEntityWrapper<T> (T entity, T originalEntity) {
+
+  public static <T> AuditEntityWrapper<T> of(T entity, T originalEntity) {
+    return new AuditEntityWrapper<>(entity, originalEntity);
+  }
+
+  public static <T> AuditEntityWrapper<T> of(T entity) {
+    return new AuditEntityWrapper<>(entity, null);
+  }
+
+  public static <T> List<AuditEntityWrapper<T>> listOf(List<T> entities) {
+    return entities.stream().map(AuditEntityWrapper::of).toList();
+  }
+
+  public static <T> List<AuditEntityWrapper<T>> listOf(List<T> entities, List<T> originalEntities, Function<T, String> entityIdExtractor) {
+    var originalEntitiesMap = StreamEx.of(originalEntities).toMap(entityIdExtractor, Function.identity());
+    return entities.stream()
+      .map(entity -> AuditEntityWrapper.of(entity, originalEntitiesMap.get(entityIdExtractor.apply(entity))))
+      .toList();
+  }
+
+}

--- a/src/main/java/org/folio/event/dto/HoldingUpdate.java
+++ b/src/main/java/org/folio/event/dto/HoldingUpdate.java
@@ -17,7 +17,7 @@ public class HoldingUpdate {
   private int affectedRows;
   private boolean isInstanceIdUpdated;
   private boolean isSearchLocationIdsUpdated;
-  private List<PoLine> poLinesWithUpdatedInstanceId;
-  private List<PoLine> poLinesWithUpdatedSearchLocationIds;
+  private List<AuditEntityWrapper<PoLine>> poLinesWithUpdatedInstanceId;
+  private List<AuditEntityWrapper<PoLine>> poLinesWithUpdatedSearchLocationIds;
   private List<String> adjacentHoldingIds;
 }

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
@@ -71,7 +72,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
                                             Conn conn) {
     return poLinesService.getPoLinesByCqlQuery(String.format(PO_LINE_LOCATIONS_HOLDING_ID_CQL, holdingId), conn)
       .compose(poLines -> updatePoLines(poLines, holdingId, permanentLocationId, tenantIdFromEvent, centralTenantId, conn, headers))
-      .compose(poLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, poLines, OrderLineAuditEvent.Action.EDIT, headers))
+      .compose(wrappedPoLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, wrappedPoLines, OrderLineAuditEvent.Action.EDIT, headers))
       .mapEmpty();
   }
 
@@ -83,9 +84,9 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
       .mapEmpty();
   }
 
-  private Future<List<PoLine>> updatePoLines(List<PoLine> poLines, String holdingId, String permanentLocationId,
-                                             String tenantIdFromEvent, String centralTenantId, Conn conn,
-                                             Map<String, String> headers) {
+  private Future<List<AuditEntityWrapper<PoLine>>> updatePoLines(List<PoLine> poLines, String holdingId, String permanentLocationId,
+                                                                 String tenantIdFromEvent, String centralTenantId, Conn conn,
+                                                                 Map<String, String> headers) {
     if (CollectionUtils.isEmpty(poLines)) {
       log.info("updatePoLines:: No poLines to update for holding: '{}' and tenant: '{}' in centralTenant: '{}'",
         holdingId, tenantIdFromEvent, centralTenantId);
@@ -104,8 +105,9 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
       }
     });
 
-    return poLinesService.updatePoLines(poLines, conn, centralTenantId, headers)
-      .map(v -> poLines);
+    return poLinesService.getPoLinesByIdsForUpdate(poLines.stream().map(PoLine::getId).toList(), centralTenantId, conn)
+      .compose(originalPoLines -> poLinesService.updatePoLines(poLines, conn, centralTenantId, headers)
+        .map(AuditEntityWrapper.listOf(poLines, originalPoLines, PoLine::getId)));
   }
 
   private Future<List<AuditEntityWrapper<Piece>>> updatePieces(List<Piece> pieces, String holdingId, String tenantIdFromEvent, String centralTenantId, Conn conn) {

--- a/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingCreateAsyncRecordHandler.java
@@ -79,7 +79,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
                                            String centralTenantId, Map<String, String> headers, Conn conn) {
     return pieceService.getPiecesByHoldingId(holdingId, conn)
       .compose(pieces -> updatePieces(pieces, holdingId, tenantIdFromEvent, centralTenantId, conn))
-      .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.EDIT, headers))
+      .compose(wrappedPieces -> auditOutboxService.savePiecesOutboxLog(conn, wrappedPieces, PieceAuditEvent.Action.EDIT, headers))
       .mapEmpty();
   }
 
@@ -108,8 +108,7 @@ public class HoldingCreateAsyncRecordHandler extends InventoryCreateAsyncRecordH
       .map(v -> poLines);
   }
 
-  private Future<List<Piece>> updatePieces(List<Piece> pieces, String holdingId, String tenantIdFromEvent,
-                                           String centralTenantId, Conn conn) {
+  private Future<List<AuditEntityWrapper<Piece>>> updatePieces(List<Piece> pieces, String holdingId, String tenantIdFromEvent, String centralTenantId, Conn conn) {
     if (CollectionUtils.isEmpty(pieces)) {
       log.info("updatePieces:: No pieces to update were found for holding: '{}' and tenant: '{}' in centralTenant: '{}",
         holdingId, tenantIdFromEvent, centralTenantId);

--- a/src/main/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.dto.HoldingEventHolder;
 import org.folio.event.dto.HoldingUpdate;
 import org.folio.event.dto.ResourceEvent;
@@ -30,6 +31,7 @@ import java.util.Objects;
 
 import static org.folio.event.InventoryEventType.INVENTORY_HOLDING_UPDATE;
 import static org.folio.util.HeaderUtils.extractTenantFromHeaders;
+import static org.folio.util.HelperUtils.mapTo;
 
 @Log4j2
 public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHandler {
@@ -88,18 +90,15 @@ public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordH
     return inventoryUpdateService.getAndSetHolderInstanceByIdIfRequired(holder, requestContext)
       .compose(v -> poLinesService.getPoLinesByCqlQuery(PO_LINE_LOCATIONS_HOLDING_ID_CQL.formatted(holder.getHoldingId()), conn))
       .compose(poLines -> updatePoLines(holder, poLines, conn))
-      .compose(dto -> updateTitles(holder, dto.getPoLinesWithUpdatedInstanceId(), conn).map(dto))
+      .compose(dto -> updateTitles(holder, mapTo(dto.getPoLinesWithUpdatedInstanceId(), AuditEntityWrapper::entity), conn).map(dto))
       .compose(dto -> saveOrderLinesOutboxLogsConditionally(holder, conn, dto));
   }
 
   // Supported 2 operations: Move instance in "member tenant" & edit holding in "central tenant"
   private Future<HoldingUpdate> saveOrderLinesOutboxLogsConditionally(HoldingEventHolder holder, Conn conn, HoldingUpdate dto) {
-    List<PoLine> poLinesToLog;
-    if (Boolean.TRUE.equals(dto.isInstanceIdUpdated()) && Boolean.FALSE.equals(dto.isSearchLocationIdsUpdated())) {
-      poLinesToLog = dto.getPoLinesWithUpdatedInstanceId();
-    } else {
-      poLinesToLog = dto.getPoLinesWithUpdatedSearchLocationIds();
-    }
+    var poLinesToLog = Boolean.TRUE.equals(dto.isInstanceIdUpdated()) && Boolean.FALSE.equals(dto.isSearchLocationIdsUpdated())
+      ? dto.getPoLinesWithUpdatedInstanceId()
+      : dto.getPoLinesWithUpdatedSearchLocationIds();
     if (poLinesToLog.isEmpty()) {
       log.info("saveOrderLinesOutboxLogsConditionally:: No updated POLs were found to log, holdingId: {}, instanceId: {}, searchLocationIds: {}",
         holder.getHoldingId(), dto.isInstanceIdUpdated(), dto.isSearchLocationIdsUpdated());
@@ -121,7 +120,8 @@ public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordH
       log.info("updatePoLines:: No POLs were updated for holding, holdingId: {}, POLs retrieved: {}", holder.getHoldingId(), poLines.size());
       return Future.succeededFuture(createNoUpdatedPoLinesDto());
     }
-    return poLinesService.updatePoLines(poLines, conn, holder.getTenantId(), holder.getHeaders())
+    return poLinesService.getPoLinesByIdsForUpdate(mapTo(poLines, PoLine::getId), holder.getTenantId(), conn)
+        .compose(originalPoLines -> poLinesService.updatePoLines(poLines, conn, holder.getTenantId(), holder.getHeaders())
       .map(affectedRows -> {
         log.info("updatePoLines:: Successfully updated POLs for holdingId: {}, POLs updated: {}/{}", holder.getHoldingId(), affectedRows, poLines.size());
         // Very important to return an empty poLine array in cases where no
@@ -130,10 +130,12 @@ public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordH
           .affectedRows(affectedRows)
           .isInstanceIdUpdated(isInstanceIdUpdated.getLeft())
           .isSearchLocationIdsUpdated(isSearchLocationIdsUpdated)
-          .poLinesWithUpdatedInstanceId(Boolean.TRUE.equals(isInstanceIdUpdated.getLeft()) ? isInstanceIdUpdated.getRight() : List.of())
-          .poLinesWithUpdatedSearchLocationIds(poLines)
+          .poLinesWithUpdatedSearchLocationIds(AuditEntityWrapper.listOf(poLines, originalPoLines, PoLine::getId))
+          .poLinesWithUpdatedInstanceId(Boolean.TRUE.equals(isInstanceIdUpdated.getLeft())
+            ? AuditEntityWrapper.listOf(isInstanceIdUpdated.getRight(), originalPoLines, PoLine::getId)
+            : List.of())
           .build();
-      });
+      }));
   }
 
   private HoldingUpdate createNoUpdatedPoLinesDto() {
@@ -155,6 +157,7 @@ public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordH
   // will exclude the current holdingId coming from the kafka event
   private void extractDistinctAdjacentHoldingsToUpdate(HoldingEventHolder holder, HoldingUpdate dto) {
     dto.setAdjacentHoldingIds(dto.getPoLinesWithUpdatedInstanceId().stream()
+      .map(AuditEntityWrapper::entity)
       .map(PoLine::getLocations)
       .flatMap(Collection::stream)
       .map(Location::getHoldingId)
@@ -222,11 +225,11 @@ public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordH
   private Future<Void> processPoLinesUpdateInCentralTenant(HoldingEventHolder holder, Conn conn, Map<String, String> updatedHeaders) {
     return poLinesService.getPoLinesByCqlQuery(String.format(PO_LINE_LOCATIONS_HOLDING_ID_CQL, holder.getHoldingId()), conn)
       .compose(poLines -> updatePoLinesInCentralTenant(holder, poLines, conn))
-      .compose(poLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, poLines, OrderLineAuditEvent.Action.EDIT, updatedHeaders).map(poLines))
+      .compose(wrappedPoLines -> auditOutboxService.saveOrderLinesOutboxLogs(conn, wrappedPoLines, OrderLineAuditEvent.Action.EDIT, updatedHeaders))
       .mapEmpty();
   }
 
-  private Future<List<PoLine>> updatePoLinesInCentralTenant(HoldingEventHolder holder, List<PoLine> poLines, Conn conn) {
+  private Future<List<AuditEntityWrapper<PoLine>>> updatePoLinesInCentralTenant(HoldingEventHolder holder, List<PoLine> poLines, Conn conn) {
     if (CollectionUtils.isEmpty(poLines)) {
       log.info("updatePoLinesInCentralTenant:: No POLs were found for holding to update, holdingId: {}", holder.getHoldingId());
       return Future.succeededFuture(List.of());
@@ -236,10 +239,11 @@ public class HoldingUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordH
       log.info("updatePoLinesInCentralTenant:: No POLs were updated for holding, holdingId: {}, POLs retrieved: {}", holder.getHoldingId(), poLines.size());
       return Future.succeededFuture(List.of());
     }
-    return poLinesService.updatePoLines(poLines, conn, holder.getCentralTenantId(), holder.getHeaders())
-      .map(affectedRows -> {
-        log.info("updatePoLinesInCentralTenant:: Successfully updated POLs for holdingId: {}, POLs updated: {}/{}", holder.getHoldingId(), affectedRows, poLines.size());
-        return poLines;
-      });
+    return poLinesService.getPoLinesByIdsForUpdate(mapTo(poLines, PoLine::getId), holder.getCentralTenantId(), conn)
+        .compose(originalPoLines -> poLinesService.updatePoLines(poLines, conn, holder.getCentralTenantId(), holder.getHeaders())
+            .map(affectedRows -> {
+              log.info("updatePoLinesInCentralTenant:: Successfully updated POLs for holdingId: {}, POLs updated: {}/{}", holder.getHoldingId(), affectedRows, poLines.size());
+              return AuditEntityWrapper.listOf(poLines, originalPoLines, PoLine::getId);
+            }));
   }
 }

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -135,14 +135,14 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
     // The skipFiltering is set to true to update all POLs regardless of the checkinItems flag, as items could be located in
     // different tenants and to keep consistency, POLs must be updated regardless of the checkinItems flag (Receiving Workflow)
     return orderLineLocationUpdateService.updatePoLineLocationData(poLineIds, itemObject, true, centralTenantId, headers, conn)
-      .compose(updatedPoLines -> {
+      .compose(wrappedPoLines -> {
         // Only save POL outbox logs if NOT in batch mode OR if this is the last item in batch
         if (batchHolder.isBatchMode() && !batchHolder.isLastInBatch()) {
           log.debug("processPoLinesUpdate:: Batch mode enabled and not last item, skipping POL outbox save");
           return Future.succeededFuture(false);
         } else {
           log.debug("processPoLinesUpdate:: Saving POLs to outbox (non-batch mode or last item in batch)");
-          return auditOutboxService.saveOrderLinesOutboxLogs(conn, updatedPoLines, OrderLineAuditEvent.Action.EDIT, headers);
+          return auditOutboxService.saveOrderLinesOutboxLogs(conn, wrappedPoLines, OrderLineAuditEvent.Action.EDIT, headers);
         }
       })
       .mapEmpty();

--- a/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemCreateAsyncRecordHandler.java
@@ -96,7 +96,8 @@ public class ItemCreateAsyncRecordHandler extends InventoryCreateAsyncRecordHand
         "in centralTenant: '{}'", updateRequiredPieces.size(), tenantIdFromEvent, holdingId, centralTenantId);
 
     return pieceService.updatePiecesInventoryData(updateRequiredPieces, conn, centralTenantId)
-      .compose(v -> auditOutboxService.savePiecesOutboxLog(conn, updateRequiredPieces, PieceAuditEvent.Action.EDIT, headers).map(updateRequiredPieces));
+      .compose(wrappedPieces -> auditOutboxService.savePiecesOutboxLog(conn, wrappedPieces, PieceAuditEvent.Action.EDIT, headers))
+      .map(updateRequiredPieces);
   }
 
   private List<Piece> filterPiecesToUpdate(List<Piece> pieces, String holdingId, String tenantIdFromEvent) {

--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -122,14 +122,14 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
     log.debug("processPoLinesUpdate:: Updating POLs, batchId='{}', isBatchMode={}, isLastInBatch={}",
       holder.getBatchHolder().getBatchId(), holder.getBatchHolder().isBatchMode(), holder.getBatchHolder().isLastInBatch());
     return orderLineLocationUpdateService.updatePoLineLocationData(poLineIds, holder.getItem(), false, holder.getOrderTenantId(), holder.getHeaders(), conn)
-      .compose(updatedPoLines -> {
+      .compose(wrappedPoLines -> {
         // Only save POL outbox logs if NOT in batch mode OR if this is the last item in batch
         if (holder.getBatchHolder().isBatchMode() && !holder.getBatchHolder().isLastInBatch()) {
           log.debug("processPoLinesUpdate:: Batch mode enabled and not last item, skipping POL outbox save");
           return Future.succeededFuture(false);
         } else {
           log.debug("processPoLinesUpdate:: Saving POLs to outbox (non-batch mode or last item in batch)");
-          return auditOutboxService.saveOrderLinesOutboxLogs(conn, updatedPoLines, OrderLineAuditEvent.Action.EDIT, holder.getHeaders());
+          return auditOutboxService.saveOrderLinesOutboxLogs(conn, wrappedPoLines, OrderLineAuditEvent.Action.EDIT, holder.getHeaders());
         }
       })
       .mapEmpty();

--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -3,6 +3,7 @@ package org.folio.event.handler;
 import static org.folio.event.InventoryEventType.INVENTORY_ITEM_UPDATE;
 import static org.folio.util.HeaderUtils.extractTenantFromHeaders;
 import static org.folio.util.HelperUtils.asFuture;
+import static org.folio.util.HelperUtils.mapTo;
 
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.ObjectUtils;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.services.batch.BatchTrackingService;
 import org.folio.event.dto.ItemEventHolder;
 import org.folio.event.dto.ResourceEvent;
@@ -83,10 +85,10 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
       .compose(pieces -> updatePieces(holder, pieces, conn))
       .compose(piecesToUpdate -> auditOutboxService
         .savePiecesOutboxLog(conn, piecesToUpdate, PieceAuditEvent.Action.EDIT, holder.getHeaders())
-        .map(piecesToUpdate));
+        .map(mapTo(piecesToUpdate, AuditEntityWrapper::entity)));
   }
 
-  private Future<List<Piece>> updatePieces(ItemEventHolder holder, List<Piece> pieces, Conn conn) {
+  private Future<List<AuditEntityWrapper<Piece>>> updatePieces(ItemEventHolder holder, List<Piece> pieces, Conn conn) {
     var piecesToUpdate = filterPiecesToUpdate(holder, pieces);
 
     if (CollectionUtils.isEmpty(piecesToUpdate)) {

--- a/src/main/java/org/folio/event/service/AuditEventProducer.java
+++ b/src/main/java/org/folio/event/service/AuditEventProducer.java
@@ -1,16 +1,18 @@
 package org.folio.event.service;
 
+import static org.folio.util.AuditUtils.buildTopicName;
+import static org.folio.util.AuditUtils.getMetadataOrThrow;
+import static org.folio.util.AuditUtils.withNullMetadata;
+
 import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 import org.folio.event.AuditEventType;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.kafka.KafkaConfig;
-import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.kafka.SimpleKafkaProducerManager;
 import org.folio.kafka.services.KafkaProducerRecordBuilder;
-import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.OrderAuditEvent;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import org.folio.rest.jaxrs.model.OutboxEventLog.EntityType;
@@ -24,6 +26,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
@@ -42,10 +46,11 @@ public class AuditEventProducer {
    * @param okapiHeaders the okapi headers
    * @return future with true if sending was success or failed future in another case
    */
-  public Future<Boolean> sendOrderEvent(PurchaseOrder order,
+  public Future<Boolean> sendOrderEvent(AuditEntityWrapper<PurchaseOrder> orderWrapper,
                                         OrderAuditEvent.Action eventAction,
                                         Map<String, String> okapiHeaders) {
-    OrderAuditEvent event = getOrderEvent(order, eventAction);
+    var order = orderWrapper.entity();
+    var event = getOrderEvent(order, orderWrapper.originalEntity(), eventAction);
     log.info("Starting to send event with id: {} for Order to Kafka for orderId: {}", event.getId(), order.getId());
     return sendToKafka(AuditEventType.ACQ_ORDER_CHANGED, event, okapiHeaders, event.getOrderId(), EntityType.ORDER)
       .onFailure(t -> log.warn("sendOrderEvent failed, order id={}", order.getId(), t));
@@ -60,12 +65,12 @@ public class AuditEventProducer {
    * @param okapiHeaders the okapi headers
    * @return future with true if sending was success or failed future otherwise
    */
-  public Future<Boolean> sendOrderLineEvent(PoLine poLine,
+  public Future<Boolean> sendOrderLineEvent(AuditEntityWrapper<PoLine> poLineWrapper,
                                             OrderLineAuditEvent.Action eventAction,
                                             Map<String, String> okapiHeaders) {
-    OrderLineAuditEvent event = getOrderLineEvent(poLine, eventAction);
-    log.info("Starting to send event with id: {} for Order Line to Kafka for orderLineId: {}", event.getId(),
-      poLine.getId());
+    var poLine = poLineWrapper.entity();
+    var event = getOrderLineEvent(poLine, poLineWrapper.originalEntity(), eventAction);
+    log.info("Starting to send event with id: {} for Order Line to Kafka for orderLineId: {}", event.getId(), poLine.getId());
     return sendToKafka(AuditEventType.ACQ_ORDER_LINE_CHANGED, event, okapiHeaders, event.getOrderLineId(), EntityType.ORDER_LINE)
       .onFailure(t -> log.warn("sendOrderLineEvent failed, poLine id={}", poLine.getId(), t));
   }
@@ -79,18 +84,18 @@ public class AuditEventProducer {
    * @param okapiHeaders the okapi headers
    * @return future with true if sending was success or failed future otherwise
    */
-  public Future<Boolean> sendPieceEvent(Piece piece,
+  public Future<Boolean> sendPieceEvent(AuditEntityWrapper<Piece> pieceWrapper,
                                         PieceAuditEvent.Action eventAction,
                                         Map<String, String> okapiHeaders) {
-    PieceAuditEvent event = getPieceEvent(piece, eventAction);
-    log.info("Starting to send event with id: {} for Piece to Kafka for pieceId: {}", event.getId(),
-      piece.getId());
+    var piece = pieceWrapper.entity();
+    var event = getPieceEvent(piece, pieceWrapper.originalEntity(), eventAction);
+    log.info("Starting to send event with id: {} for Piece to Kafka for pieceId: {}", event.getId(), piece.getId());
     return sendToKafka(AuditEventType.ACQ_PIECE_CHANGED, event, okapiHeaders, event.getPieceId(), EntityType.PIECE)
       .onFailure(t -> log.warn("sendPieceEvent failed, piece id={}", piece.getId(), t));
   }
 
-  private OrderAuditEvent getOrderEvent(PurchaseOrder order, OrderAuditEvent.Action eventAction) {
-    Metadata metadata = getMetadataOrThrow(order.getMetadata(), order.getId());
+  private OrderAuditEvent getOrderEvent(@Nonnull PurchaseOrder order, @Nullable PurchaseOrder originalOrder, OrderAuditEvent.Action eventAction) {
+    var metadata = getMetadataOrThrow(order::getMetadata, order::getId);
     return new OrderAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -98,11 +103,12 @@ public class AuditEventProducer {
       .withEventDate(new Date())
       .withActionDate(metadata.getUpdatedDate())
       .withUserId(metadata.getUpdatedByUserId())
-      .withOrderSnapshot(order.withMetadata(null)); // not populate metadata to not include it in snapshot's comparison in UI
+      .withOriginalOrderSnapshot(withNullMetadata(originalOrder, PurchaseOrder::withMetadata))
+      .withOrderSnapshot(withNullMetadata(order, PurchaseOrder::withMetadata)); // not populate metadata to not include it in snapshot's comparison in UI
   }
 
-  private OrderLineAuditEvent getOrderLineEvent(PoLine poLine, OrderLineAuditEvent.Action eventAction) {
-    Metadata metadata = getMetadataOrThrow(poLine.getMetadata(), poLine.getId());
+  private OrderLineAuditEvent getOrderLineEvent(@Nonnull PoLine poLine, @Nullable PoLine originalPoLine, OrderLineAuditEvent.Action eventAction) {
+    var metadata = getMetadataOrThrow(poLine::getMetadata, poLine::getId);
     return new OrderLineAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -111,11 +117,12 @@ public class AuditEventProducer {
       .withEventDate(new Date())
       .withActionDate(metadata.getUpdatedDate())
       .withUserId(metadata.getUpdatedByUserId())
-      .withOrderLineSnapshot(poLine.withMetadata(null)); // not populate metadata to not include it in snapshot's comparison in UI
+      .withOriginalOrderLineSnapshot(withNullMetadata(originalPoLine, PoLine::withMetadata))
+      .withOrderLineSnapshot(withNullMetadata(poLine, PoLine::withMetadata)); // not populate metadata to not include it in snapshot's comparison in UI
   }
 
-  private PieceAuditEvent getPieceEvent(Piece piece, PieceAuditEvent.Action eventAction) {
-    Metadata metadata = getMetadataOrThrow(piece.getMetadata(), piece.getId());
+  private PieceAuditEvent getPieceEvent(@Nonnull Piece piece, @Nullable Piece originalPiece, PieceAuditEvent.Action eventAction) {
+    var metadata = getMetadataOrThrow(piece::getMetadata, piece::getId);
     return new PieceAuditEvent()
       .withId(UUID.randomUUID().toString())
       .withAction(eventAction)
@@ -123,7 +130,8 @@ public class AuditEventProducer {
       .withEventDate(new Date())
       .withActionDate(metadata.getUpdatedDate())
       .withUserId(metadata.getUpdatedByUserId())
-      .withPieceSnapshot(piece.withMetadata(null)); // not populate metadata to not include it in snapshot's comparison in UI
+      .withOriginalPieceSnapshot(withNullMetadata(originalPiece, Piece::withMetadata))
+      .withPieceSnapshot(withNullMetadata(piece, Piece::withMetadata)); // not populate metadata to not include it in snapshot's comparison in UI
   }
 
   private Future<Boolean> sendToKafka(AuditEventType eventType,
@@ -152,16 +160,6 @@ public class AuditEventProducer {
           log.error("Producer write error for event '{}' for {} id: '{}' for kafka topic '{}'", eventType, entityType, key, topicName, reply.cause());
         }
       });
-  }
-
-  private String buildTopicName(String envId, String tenantId, String eventType) {
-    return KafkaTopicNameHelper.formatTopicName(envId, KafkaTopicNameHelper.getDefaultNameSpace(),
-      tenantId, eventType);
-  }
-
-  private Metadata getMetadataOrThrow(Metadata metadata, String id) {
-    return Optional.ofNullable(metadata)
-      .orElseThrow(() -> new IllegalArgumentException("Metadata is null for entity with id: %s".formatted(id)));
   }
 
 }

--- a/src/main/java/org/folio/event/service/AuditOutboxService.java
+++ b/src/main/java/org/folio/event/service/AuditOutboxService.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.PostgresClientFactory;
 import org.folio.dao.audit.AuditOutboxEventsLogRepository;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.rest.jaxrs.model.OrderAuditEvent;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import org.folio.rest.jaxrs.model.OutboxEventLog;
@@ -24,6 +25,7 @@ import org.folio.rest.tools.utils.TenantTool;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.jackson.DatabindCodec;
 
 public class AuditOutboxService {
 
@@ -84,19 +86,19 @@ public class AuditOutboxService {
         }
         switch (eventLog.getEntityType()) {
           case ORDER -> {
-            PurchaseOrder entity = Json.decodeValue(eventLog.getPayload(), PurchaseOrder.class);
+            var entityWrapper = decodeOutboxPayload(eventLog.getPayload(), PurchaseOrder.class);
             OrderAuditEvent.Action action = OrderAuditEvent.Action.fromValue(eventLog.getAction());
-            return producer.sendOrderEvent(entity, action, okapiHeaders);
+            return producer.sendOrderEvent(entityWrapper, action, okapiHeaders);
           }
           case ORDER_LINE -> {
-            PoLine entity = Json.decodeValue(eventLog.getPayload(), PoLine.class);
+            var entityWrapper = decodeOutboxPayload(eventLog.getPayload(), PoLine.class);
             OrderLineAuditEvent.Action action = OrderLineAuditEvent.Action.fromValue(eventLog.getAction());
-            return producer.sendOrderLineEvent(entity, action, okapiHeaders);
+            return producer.sendOrderLineEvent(entityWrapper, action, okapiHeaders);
           }
           case PIECE -> {
-            Piece entity = Json.decodeValue(eventLog.getPayload(), Piece.class);
+            var entityWrapper = decodeOutboxPayload(eventLog.getPayload(), Piece.class);
             PieceAuditEvent.Action action = PieceAuditEvent.Action.fromValue(eventLog.getAction());
-            return producer.sendPieceEvent(entity, action, okapiHeaders);
+            return producer.sendPieceEvent(entityWrapper, action, okapiHeaders);
           }
           default -> throw new IllegalStateException("Missing handler for events with entityType: " + eventLog.getEntityType());
         }
@@ -112,13 +114,26 @@ public class AuditOutboxService {
    * Saves order outbox log.
    *
    * @param conn         connection in transaction
-   * @param entity       the purchase order
+   * @param order       the purchase order
    * @param action       the event action
    * @param okapiHeaders okapi headers
    * @return future with saved outbox log in the same transaction
    */
-  public Future<Boolean> saveOrderOutboxLog(Conn conn, PurchaseOrder entity, OrderAuditEvent.Action action, Map<String, String> okapiHeaders) {
-    return saveOutboxLog(conn, okapiHeaders, action.value(), EntityType.ORDER, entity.getId(), entity);
+  public Future<Boolean> saveOrderOutboxLog(Conn conn, AuditEntityWrapper<PurchaseOrder> order, OrderAuditEvent.Action action, Map<String, String> okapiHeaders) {
+    return saveOutboxLog(conn, okapiHeaders, action.value(), EntityType.ORDER, order.entity().getId(), order);
+  }
+
+  /**
+   * Saves order line outbox log.
+   *
+   * @param conn         connection in transaction
+   * @param pol          the poLine
+   * @param action       the event action
+   * @param okapiHeaders okapi headers
+   * @return future with saved outbox log in the same transaction
+   */
+  public Future<Boolean> saveOrderLineOutboxLog(Conn conn, AuditEntityWrapper<PoLine> pol, OrderLineAuditEvent.Action action, Map<String, String> okapiHeaders) {
+    return saveOutboxLog(conn, okapiHeaders, action.value(), EntityType.ORDER_LINE, pol.entity().getId(), pol);
   }
 
   /**
@@ -130,9 +145,9 @@ public class AuditOutboxService {
    * @param okapiHeaders the okapi headers
    * @return future with saved outbox log in the same transaction
    */
-  public Future<Boolean> saveOrderLinesOutboxLogs(Conn conn, List<PoLine> poLines, OrderLineAuditEvent.Action action, Map<String, String> okapiHeaders) {
+  public Future<Boolean> saveOrderLinesOutboxLogs(Conn conn, List<AuditEntityWrapper<PoLine>> poLines, OrderLineAuditEvent.Action action, Map<String, String> okapiHeaders) {
     var futures = poLines.stream()
-      .map(poLine -> saveOutboxLog(conn, okapiHeaders, action.value(), EntityType.ORDER_LINE, poLine.getId(), poLine))
+      .map(poLine -> saveOrderLineOutboxLog(conn, poLine, action, okapiHeaders))
       .toList();
 
     return Future.join(futures)
@@ -149,10 +164,7 @@ public class AuditOutboxService {
    * @param okapiHeaders the okapi headers
    * @return future with saved outbox log in the same transaction
    */
-  public Future<Boolean> savePiecesOutboxLog(Conn conn,
-                                             List<Piece> pieces,
-                                             PieceAuditEvent.Action action,
-                                             Map<String, String> okapiHeaders) {
+  public Future<Boolean> savePiecesOutboxLog(Conn conn, List<AuditEntityWrapper<Piece>> pieces, PieceAuditEvent.Action action, Map<String, String> okapiHeaders) {
     var futures = pieces.stream()
       .map(piece -> savePieceOutboxLog(conn, piece, action, okapiHeaders))
       .toList();
@@ -172,18 +184,18 @@ public class AuditOutboxService {
    * @return future with saved outbox log in the same transaction
    */
   public Future<Boolean> savePieceOutboxLog(Conn conn,
-                                            Piece piece,
+                                            AuditEntityWrapper<Piece> piece,
                                             PieceAuditEvent.Action action,
                                             Map<String, String> okapiHeaders) {
-    return saveOutboxLog(conn, okapiHeaders, action.value(), EntityType.PIECE, piece.getId(), piece);
+    return saveOutboxLog(conn, okapiHeaders, action.value(), EntityType.PIECE, piece.entity().getId(), piece);
   }
 
-  private Future<Boolean> saveOutboxLog(Conn conn,
-                                        Map<String, String> okapiHeaders,
-                                        String action,
-                                        EntityType entityType,
-                                        String entityId,
-                                        Object entity) {
+  private <T> Future<Boolean> saveOutboxLog(Conn conn,
+                                            Map<String, String> okapiHeaders,
+                                            String action,
+                                            EntityType entityType,
+                                            String entityId,
+                                            AuditEntityWrapper<T> auditEntityWrapper) {
     log.debug("saveOutboxLog:: for {} with id: {}", entityType, entityId);
 
     String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -192,10 +204,27 @@ public class AuditOutboxService {
       .withEventId(UUID.randomUUID().toString())
       .withAction(action)
       .withEntityType(entityType)
-      .withPayload(Json.encode(entity));
+      .withPayload(Json.encode(auditEntityWrapper));
 
     return outboxRepository.saveEventLog(conn, eventLog, tenantId)
       .onSuccess(reply -> log.info("Outbox log has been saved for {} with id: {}", entityType, entityId))
       .onFailure(e -> log.warn("Could not save outbox audit log for {} with id: {}", entityType, entityId, e));
   }
+
+  private <T> AuditEntityWrapper<T> decodeOutboxPayload(String payload, Class<T> entityClass) {
+    try {
+      var mapper = DatabindCodec.mapper();
+      var wrapperType = mapper.getTypeFactory().constructParametricType(AuditEntityWrapper.class, entityClass);
+      AuditEntityWrapper<T> wrapper = mapper.readValue(payload, wrapperType);
+      if (wrapper.entity() != null) {
+        return wrapper;
+      }
+    } catch (Exception ignored) {
+      log.debug("decodeOutboxPayload:: Failed to decode payload: {}", payload);
+    }
+    log.info("decodeOutboxPayload:: Falling back to decode payload as {}", entityClass.getSimpleName());
+    T entity = Json.decodeValue(payload, entityClass);
+    return AuditEntityWrapper.of(entity);
+  }
+
 }

--- a/src/main/java/org/folio/rest/impl/PiecesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PiecesAPI.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.PostgresClientFactory;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.core.BaseApi;
@@ -64,7 +65,7 @@ public class PiecesAPI extends BaseApi implements OrdersStoragePieces, OrdersSto
   public void postOrdersStoragePieces(Piece entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     pgClient.withTrans(conn -> pieceService.createPiece(conn, entity, pgClient.getTenantId())
-      .compose(ignore -> auditOutboxService.savePieceOutboxLog(conn, entity, PieceAuditEvent.Action.CREATE, okapiHeaders)))
+      .compose(ignore -> auditOutboxService.savePieceOutboxLog(conn, AuditEntityWrapper.of(entity), PieceAuditEvent.Action.CREATE, okapiHeaders)))
       .onComplete(ar -> {
         if (ar.succeeded()) {
           log.info("Create piece complete, id={}", entity.getId());
@@ -92,7 +93,7 @@ public class PiecesAPI extends BaseApi implements OrdersStoragePieces, OrdersSto
       pieceService.getPieceById(id, conn)
         .compose(piece -> pieceService.deletePiece(id, conn)
           .map(v -> populateMetadata(piece::getMetadata, piece::withMetadata, okapiHeaders)))
-        .compose(piece -> auditOutboxService.savePieceOutboxLog(conn, piece, PieceAuditEvent.Action.DELETE, okapiHeaders)))
+        .compose(piece -> auditOutboxService.savePieceOutboxLog(conn, AuditEntityWrapper.of(piece), PieceAuditEvent.Action.DELETE, okapiHeaders)))
       .onComplete(ar -> {
         if (ar.succeeded()) {
           log.info("Delete piece complete, id={}", id);
@@ -110,7 +111,7 @@ public class PiecesAPI extends BaseApi implements OrdersStoragePieces, OrdersSto
   public void putOrdersStoragePiecesById(String id, Piece entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     pgClient.withTrans(conn -> pieceService.updatePiece(id, entity, conn, pgClient.getTenantId())
-      .compose(ignore -> auditOutboxService.savePieceOutboxLog(conn, entity, PieceAuditEvent.Action.EDIT, okapiHeaders)))
+      .compose(wrappedPiece -> auditOutboxService.savePieceOutboxLog(conn, wrappedPiece, PieceAuditEvent.Action.EDIT, okapiHeaders)))
       .onComplete(ar -> {
         if (ar.succeeded()) {
           log.info("Update piece complete, id={}", id);
@@ -129,7 +130,7 @@ public class PiecesAPI extends BaseApi implements OrdersStoragePieces, OrdersSto
     log.info("postOrdersStoragePiecesBatch:: Batch creating {} pieces", piecesCollection.getPieces().size());
     pgClient
       .withTrans(conn -> pieceService.createPieces(piecesCollection.getPieces(), conn, okapiHeaders)
-        .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.CREATE, okapiHeaders)))
+        .compose(pieces -> auditOutboxService.savePiecesOutboxLog(conn, AuditEntityWrapper.listOf(pieces), PieceAuditEvent.Action.CREATE, okapiHeaders)))
       .onComplete(ar -> {
         if (ar.succeeded()) {
           log.info("Create '{}' pieces completed", piecesCollection.getPieces());
@@ -149,7 +150,7 @@ public class PiecesAPI extends BaseApi implements OrdersStoragePieces, OrdersSto
     var pieces = piecesCollection.getPieces().stream().map(piece -> populateMetadata(piece::getMetadata, piece::withMetadata, okapiHeaders)).toList();
     log.info("putOrdersStoragePiecesBatch:: Batch updating {} pieces: {}", piecesIds.size(), piecesIds);
     pgClient.withTrans(conn -> pieceService.updatePieces(pieces, conn, TenantTool.tenantId(okapiHeaders))
-        .compose(v -> auditOutboxService.savePiecesOutboxLog(conn, pieces, PieceAuditEvent.Action.EDIT, okapiHeaders)))
+        .compose(wrappedPieces -> auditOutboxService.savePiecesOutboxLog(conn, wrappedPieces, PieceAuditEvent.Action.EDIT, okapiHeaders)))
       .onComplete(ar -> {
         if (ar.succeeded()) {
           log.info("putOrdersStoragePiecesBatch:: Successfully updated pieces: {}", piecesIds);

--- a/src/main/java/org/folio/rest/impl/PoLineBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoLineBatchAPI.java
@@ -47,8 +47,7 @@ public class PoLineBatchAPI extends BaseApi implements OrdersStoragePoLinesBatch
     Future.all(poLineCollection.getPoLines().stream()
         .map(poLine -> validateCustomFields(vertxContext, okapiHeaders, poLine))
         .toList())
-      .compose(cf ->
-        poLinesBatchService.poLinesBatchUpdate(poLineCollection.getPoLines(), pgClient, okapiHeaders))
+      .compose(cf -> poLinesBatchService.poLinesBatchUpdate(poLineCollection.getPoLines(), pgClient, okapiHeaders))
       .onComplete(ar -> {
         var poLineIds = extractEntityFields(poLineCollection.getPoLines(), PoLine::getId);
         if (ar.failed()) {

--- a/src/main/java/org/folio/rest/impl/PoLinesAPI.java
+++ b/src/main/java/org/folio/rest/impl/PoLinesAPI.java
@@ -2,7 +2,6 @@ package org.folio.rest.impl;
 
 import static org.folio.models.TableNames.PO_LINE_TABLE;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
@@ -10,6 +9,7 @@ import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.PostgresClientFactory;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.orders.lines.update.OrderLinePatchOperationService;
 import org.folio.rest.annotations.Validate;
@@ -68,7 +68,7 @@ public class PoLinesAPI extends BaseApi implements OrdersStoragePoLines {
       validateCustomFields(vertxContext, okapiHeaders, poLine)
         .compose(v ->
           pgClient.withTrans(conn -> poLinesService.createPoLine(conn, poLine)
-            .compose(poLineId -> auditOutboxService.saveOrderLinesOutboxLogs(conn, List.of(poLine), OrderLineAuditEvent.Action.CREATE, okapiHeaders)
+            .compose(poLineId -> auditOutboxService.saveOrderLineOutboxLog(conn, AuditEntityWrapper.of(poLine), OrderLineAuditEvent.Action.CREATE, okapiHeaders)
               .map(b -> poLineId))))
         .onComplete(ar -> {
           if (ar.failed()) {
@@ -93,7 +93,7 @@ public class PoLinesAPI extends BaseApi implements OrdersStoragePoLines {
         .compose(v ->
           pgClient.withTrans(conn -> poLinesService.createPoLine(conn, poLine)
             .compose(poLineId -> poLinesService.createTitle(conn, poLine, okapiHeaders))
-            .compose(title -> auditOutboxService.saveOrderLinesOutboxLogs(conn, List.of(poLine), OrderLineAuditEvent.Action.CREATE, okapiHeaders))))
+            .compose(title -> auditOutboxService.saveOrderLineOutboxLog(conn, AuditEntityWrapper.of(poLine), OrderLineAuditEvent.Action.CREATE, okapiHeaders))))
         .onComplete(ar -> {
           if (ar.failed()) {
             log.error("Order Line and Title creation failed", ar.cause());
@@ -147,7 +147,7 @@ public class PoLinesAPI extends BaseApi implements OrdersStoragePoLines {
       validateCustomFields(vertxContext, okapiHeaders, poLine)
         .compose(v ->
           pgClient.withTrans(conn -> poLinesService.updatePoLine(poLine, conn)
-            .compose(line -> auditOutboxService.saveOrderLinesOutboxLogs(conn, List.of(line), OrderLineAuditEvent.Action.EDIT, okapiHeaders))))
+            .compose(wrappedPoLine -> auditOutboxService.saveOrderLineOutboxLog(conn, wrappedPoLine, OrderLineAuditEvent.Action.EDIT, okapiHeaders))))
         .onComplete(ar -> {
           if (ar.failed()) {
             log.error("Update package order line failed, id={}", id, ar.cause());

--- a/src/main/java/org/folio/rest/impl/PurchaseOrdersAPI.java
+++ b/src/main/java/org/folio/rest/impl/PurchaseOrdersAPI.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.PostgresClientFactory;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.models.TableNames;
 import org.folio.rest.annotations.Validate;
@@ -70,9 +71,8 @@ public class PurchaseOrdersAPI extends BaseApi implements OrdersStoragePurchaseO
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     log.debug("Creating a new purchase order");
     validateCustomFields(vertxContext, okapiHeaders, order)
-      .compose(v ->
-        pgClient.withTrans(conn -> createPurchaseOrder(conn, order)
-          .compose(v2 -> auditOutboxService.saveOrderOutboxLog(conn, order, OrderAuditEvent.Action.CREATE, okapiHeaders))))
+      .compose(v -> pgClient.withTrans(conn -> createPurchaseOrder(conn, order)
+        .compose(v2 -> auditOutboxService.saveOrderOutboxLog(conn, AuditEntityWrapper.of(order), OrderAuditEvent.Action.CREATE, okapiHeaders))))
       .onComplete(ar -> {
         if (ar.failed()) {
           log.error("Order creation failed", ar.cause());
@@ -147,14 +147,13 @@ public class PurchaseOrdersAPI extends BaseApi implements OrdersStoragePurchaseO
   private Future<Response> updateOrder(String id, PurchaseOrder order, Map<String, String> okapiHeaders) {
     log.info("Update purchase order with id={}", order.getId());
     Promise<Response> promise = Promise.promise();
-    pgClient.withTrans(conn ->
-      conn.update(TableNames.PURCHASE_ORDER_TABLE, order, id)
-      .compose(reply -> {
+    pgClient.withTrans(conn -> conn.getByIdForUpdate(TableNames.PURCHASE_ORDER_TABLE, id, PurchaseOrder.class)
+      .compose(originalOrder -> conn.update(TableNames.PURCHASE_ORDER_TABLE, order, id).compose(reply -> {
         if (reply.rowCount() == 0) {
           return Future.failedFuture(new HttpException(Response.Status.NOT_FOUND.getStatusCode(), Response.Status.NOT_FOUND.getReasonPhrase()));
         }
-        return auditOutboxService.saveOrderOutboxLog(conn, order, OrderAuditEvent.Action.EDIT, okapiHeaders);
-      }))
+        return auditOutboxService.saveOrderOutboxLog(conn, AuditEntityWrapper.of(order, originalOrder), OrderAuditEvent.Action.EDIT, okapiHeaders);
+      })))
       .onComplete(ar -> {
         if (ar.succeeded()) {
           log.info("Purchase order successfully updated, id={}", id);

--- a/src/main/java/org/folio/rest/persist/HelperUtils.java
+++ b/src/main/java/org/folio/rest/persist/HelperUtils.java
@@ -27,6 +27,7 @@ import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.Criteria.GroupedCriterias;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.folio.rest.persist.interfaces.Results;
 
@@ -69,12 +70,24 @@ public class HelperUtils {
     }
   }
 
-  public static Criterion getCriterionByFieldNameAndValue(String filedName, String fieldValue) {
+  public static Criteria getCriteriaByFieldNameAndValue(String filedName, String fieldValue) {
     Criteria a = new Criteria();
     a.addField("'" + filedName + "'");
     a.setOperation("=");
     a.setVal(fieldValue);
-    return new Criterion(a);
+    return a;
+  }
+
+  public static Criterion getCriterionByFieldNameAndValue(String filedName, String fieldValue) {
+    return new Criterion(getCriteriaByFieldNameAndValue(filedName, fieldValue));
+  }
+
+  public static Criterion getCriterionByFieldNameAndValues(String filedName, List<String> fieldValues) {
+    var groupedCriterias = new GroupedCriterias();
+    fieldValues.stream()
+      .map(val -> getCriteriaByFieldNameAndValue(filedName, val))
+      .forEach(groupedCriterias::addCriteria);
+    return new Criterion().addGroupOfCriterias(groupedCriterias);
   }
 
   public static Criterion getCriteriaByFieldNameAndValueNotJsonb(String fieldName, String fieldValue) {

--- a/src/main/java/org/folio/services/inventory/OrderLineLocationUpdateService.java
+++ b/src/main/java/org/folio/services/inventory/OrderLineLocationUpdateService.java
@@ -4,6 +4,7 @@ import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static org.folio.event.dto.ItemFields.EFFECTIVE_LOCATION_ID;
 import static org.folio.event.dto.ItemFields.ID;
+import static org.folio.util.HelperUtils.mapTo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.acq.Location;
@@ -48,7 +50,7 @@ public class OrderLineLocationUpdateService {
    * @param conn          connection to be used for the request
    * @return a future with the list of updated POLs
    */
-  public Future<List<PoLine>> updatePoLineLocationData(List<String> poLineIds, JsonObject item, boolean skipFiltering, String tenantId, Map<String, String> headers, Conn conn) {
+  public Future<List<AuditEntityWrapper<PoLine>>> updatePoLineLocationData(List<String> poLineIds, JsonObject item, boolean skipFiltering, String tenantId, Map<String, String> headers, Conn conn) {
     log.info("processPoLinesUpdate:: Fetching '{}' POL(s) to update location data", poLineIds.size());
     return poLinesService.getPoLinesByIdsForUpdate(poLineIds, tenantId, conn)
       .map(poLines -> poLines.stream()
@@ -61,8 +63,7 @@ public class OrderLineLocationUpdateService {
       .compose(poLinePiecePairs -> updatePoLines(poLinePiecePairs, item, tenantId, headers, conn));
   }
 
-  private Future<List<PoLine>> updatePoLines(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, JsonObject item,
-                                             String tenantId, Map<String, String> headers, Conn conn) {
+  private Future<List<AuditEntityWrapper<PoLine>>> updatePoLines(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, JsonObject item, String tenantId, Map<String, String> headers, Conn conn) {
     var poLinesToUpdate = processPoLinePiecePairs(poLinePiecePairs, item);
     if (CollectionUtils.isEmpty(poLinesToUpdate)) {
       log.info("updatePoLines:: No POLs were changed to update for item: '{}' in tenant: '{}'", item.getString(ID.getValue()), tenantId);
@@ -70,8 +71,9 @@ public class OrderLineLocationUpdateService {
     }
     log.info("updatePoLines:: Updating '{}' POL(s) for item: '{}' in tenant: '{}'",
       poLinesToUpdate.size(), item.getString(ID.getValue()), tenantId);
-    return poLinesService.updatePoLines(poLinesToUpdate, conn, tenantId, headers)
-      .map(v -> poLinesToUpdate);
+    return poLinesService.getPoLinesByIdsForUpdate(mapTo(poLinesToUpdate, PoLine::getId), tenantId, conn)
+      .compose(originalPoLines -> poLinesService.updatePoLines(poLinesToUpdate, conn, tenantId, headers)
+        .map(AuditEntityWrapper.listOf(poLinesToUpdate, originalPoLines, PoLine::getId)));
   }
 
   private List<PoLine> processPoLinePiecePairs(List<Pair<PoLine, List<Piece>>> poLinePiecePairs, JsonObject itemObject) {

--- a/src/main/java/org/folio/services/lines/PoLinesBatchService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesBatchService.java
@@ -1,6 +1,7 @@
 package org.folio.services.lines;
 
 import static org.folio.models.TableNames.PO_LINE_TABLE;
+import static org.folio.util.HelperUtils.mapTo;
 import static org.folio.util.MetadataUtils.populateMetadata;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Map;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
 import org.folio.rest.jaxrs.model.PoLine;
@@ -34,10 +36,10 @@ public class PoLinesBatchService {
       return Future.succeededFuture();
     }
     poLines.forEach(poLine -> populateMetadata(poLine::getMetadata, poLine::withMetadata, okapiHeaders));
-    return pgClient.withTrans(conn ->
-      conn.updateBatch(PO_LINE_TABLE, poLines)
+    return pgClient.withTrans(conn -> poLinesService.getPoLinesByIdsForUpdate(mapTo(poLines, PoLine::getId), pgClient.getTenantId(), conn)
+      .compose(originalPoLines -> conn.updateBatch(PO_LINE_TABLE, poLines)
         .compose(rowSet -> poLinesService.updateTitles(conn, poLines, okapiHeaders))
-        .compose(rowSet -> auditOutboxService.saveOrderLinesOutboxLogs(conn, poLines, OrderLineAuditEvent.Action.EDIT, okapiHeaders))
-        .mapEmpty());
+        .compose(rowSet -> auditOutboxService.saveOrderLinesOutboxLogs(conn, AuditEntityWrapper.listOf(poLines, originalPoLines, PoLine::getId), OrderLineAuditEvent.Action.EDIT, okapiHeaders))
+        .mapEmpty()));
   }
 }

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -371,7 +371,7 @@ public class PoLinesService {
           ? Future.failedFuture(new HttpException(Response.Status.NOT_FOUND.getStatusCode(), Response.Status.NOT_FOUND.getReasonPhrase()))
           : Future.succeededFuture(AuditEntityWrapper.of(poLine, originalPoLine.orElse(null)))))
       .onSuccess(v -> log.info("updatePoLine:: Complete, poLineId={}", poLine.getId()))
-      .onComplete(t -> log.error("updatePoLine:: Failed, poLineId={}", poLine.getId(), t.cause()));
+      .onFailure(t -> log.error("updatePoLine:: Failed, poLineId={}", poLine.getId(), t));
   }
 
   private Future<PoLine> createTitleAndSave(Conn conn, PoLine poLine, List<String> acqUnitIds, Map<String, String> headers) {

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -32,11 +32,13 @@ import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.dao.lines.PoLinesDAO;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.models.CriterionBuilder;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Details;
 import org.folio.rest.jaxrs.model.OrderLineAuditEvent;
+import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
 import org.folio.rest.jaxrs.model.PurchaseOrder;
 import org.folio.rest.jaxrs.model.Title;
@@ -105,8 +107,8 @@ public class PoLinesService {
     poLine.setId(id);
 
     updatePoLine(poLine, conn)
-        .compose(line -> updateTitle(conn, line, requestContext.getHeaders()))
-        .compose(line -> auditOutboxService.saveOrderLinesOutboxLogs(conn, List.of(line), OrderLineAuditEvent.Action.EDIT, okapiHeaders))
+        .compose(wrappedPoLine -> updateTitle(conn, wrappedPoLine.entity(), requestContext.getHeaders())
+          .compose(line -> auditOutboxService.saveOrderLineOutboxLog(conn, AuditEntityWrapper.of(line, wrappedPoLine.originalEntity()), OrderLineAuditEvent.Action.EDIT, okapiHeaders)))
         .onComplete(ar -> {
           if (ar.succeeded()) {
             log.info("POLine and associated data were successfully updated, id={}", id);
@@ -301,10 +303,15 @@ public class PoLinesService {
     return promise.future();
   }
 
+  public Future<Optional<PoLine>> getPoLineByIdForUpdate(String id, Conn conn) {
+    log.debug("getPoLineByIdForUpdate:: Getting POL for update: '{}'", id);
+    return conn.getByIdForUpdate(PO_LINE_TABLE, id, PoLine.class).map(Optional::ofNullable);
+  }
+
   public Future<PoLine> updateInstanceIdForPoLine(PoLine poLine, JsonObject instance, Conn conn, Map<String, String> headers) {
     updateInstanceFieldsForPoLine(poLine, instance);
     return doUpdatePoLine(poLine, conn)
-      .compose(storedPol -> auditOutboxService.saveOrderLinesOutboxLogs(conn, List.of(storedPol), OrderLineAuditEvent.Action.EDIT, headers))
+      .compose(wrappedPoLine -> auditOutboxService.saveOrderLineOutboxLog(conn, wrappedPoLine, OrderLineAuditEvent.Action.EDIT, headers))
       .map(v -> poLine);
   }
 
@@ -347,7 +354,7 @@ public class PoLinesService {
       .mapEmpty();
   }
 
-  public Future<PoLine> updatePoLine(PoLine poLine, Conn conn) {
+  public Future<AuditEntityWrapper<PoLine>> updatePoLine(PoLine poLine, Conn conn) {
     if (poLine.getPurchaseOrderId() == null) {
       log.error("Can't update po line: missing purchaseOrderId");
       return Future.failedFuture(new HttpException(Response.Status.BAD_REQUEST.getStatusCode(), "Can't update po line: missing purchaseOrderId"));
@@ -355,13 +362,14 @@ public class PoLinesService {
     return doUpdatePoLine(poLine, conn);
   }
 
-  public Future<PoLine> doUpdatePoLine(PoLine poLine, Conn conn) {
+  public Future<AuditEntityWrapper<PoLine>> doUpdatePoLine(PoLine poLine, Conn conn) {
     var criterion = getCriteriaByFieldNameAndValueNotJsonb(ID_FIELD_NAME, poLine.getId());
-    return conn.update(PO_LINE_TABLE, poLine, JSONB, criterion.toString(), true)
-      .recover(t -> Future.failedFuture(httpHandleFailure(t)))
-      .compose(rows -> rows.rowCount() == 0
-        ? Future.failedFuture(new HttpException(Response.Status.NOT_FOUND.getStatusCode(), Response.Status.NOT_FOUND.getReasonPhrase()))
-        : Future.succeededFuture(poLine))
+    return getPoLineByIdForUpdate(poLine.getId(), conn)
+      .compose(originalPoLine -> conn.update(PO_LINE_TABLE, poLine, JSONB, criterion.toString(), true)
+        .recover(t -> Future.failedFuture(httpHandleFailure(t)))
+        .compose(rows -> rows.rowCount() == 0
+          ? Future.failedFuture(new HttpException(Response.Status.NOT_FOUND.getStatusCode(), Response.Status.NOT_FOUND.getReasonPhrase()))
+          : Future.succeededFuture(AuditEntityWrapper.of(poLine, originalPoLine.orElse(null)))))
       .onSuccess(v -> log.info("updatePoLine:: Complete, poLineId={}", poLine.getId()))
       .onComplete(t -> log.error("updatePoLine:: Failed, poLineId={}", poLine.getId(), t.cause()));
   }

--- a/src/main/java/org/folio/services/piece/PieceService.java
+++ b/src/main/java/org/folio/services/piece/PieceService.java
@@ -11,6 +11,7 @@ import static org.folio.util.DbUtils.getEntitiesByField;
 import static org.folio.util.HelperUtils.chainCall;
 import static org.folio.util.HelperUtils.collectResultsOnSuccess;
 import static org.folio.util.HelperUtils.extractEntityFields;
+import static org.folio.util.HelperUtils.mapTo;
 import static org.folio.util.MetadataUtils.populateMetadata;
 
 import javax.ws.rs.core.Response;
@@ -19,10 +20,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.models.TableNames;
 import org.folio.rest.jaxrs.model.Piece;
 import org.folio.rest.jaxrs.model.PoLine;
@@ -39,8 +42,6 @@ import org.folio.util.SerializerUtil;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.HttpException;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
 import lombok.extern.log4j.Log4j2;
 import one.util.streamex.StreamEx;
@@ -53,6 +54,7 @@ public class PieceService {
   private static final String HOLDING_ID_FIELD = "holdingId";
   private static final String PIECE_NOT_UPDATED = "Pieces with poLineId={} not presented, skipping the update";
 
+  private static final String PIECES_BY_ID_FOR_UPDATE_SQL = "SELECT * FROM %s WHERE id = ANY($1) FOR UPDATE;";
   private static final String PIECES_BATCH_UPDATE_SQL = "UPDATE %s AS pieces SET jsonb = b.jsonb FROM (VALUES  %s) AS b (id, jsonb) WHERE b.id::uuid = pieces.id RETURNING pieces.*;";
   private static final String PIECES_BY_ITEM_ID_COUNT_SQL = "SELECT COUNT(*) FROM %s WHERE left(lower(%s.f_unaccent(jsonb->>'itemId')), 600) = $1;";
   private static final String PIECES_SHIFT_SEQUENCE_NUMBERS =
@@ -96,6 +98,14 @@ public class PieceService {
     return getEntitiesByField(PIECES_TABLE, Piece.class, criterion, conn);
   }
 
+  public Future<List<Piece>> getPiecesByIdsForUpdate(List<String> pieceIds, String tenantId, Conn conn) {
+    var ids = mapTo(pieceIds, UUID::fromString).toArray(UUID[]::new);
+    return conn.execute(PIECES_BY_ID_FOR_UPDATE_SQL.formatted(getFullTableName(tenantId, PIECES_TABLE)), Tuple.of(ids))
+      .map(rows -> DbUtils.getRowSetAsList(rows, Piece.class))
+      .onSuccess(result -> log.info("getPiecesByIdsForUpdate:: Successfully fetched {} piece(s) for update using tenantId: '{}'", result.size(), tenantId))
+      .onFailure(t -> log.error("Failed fetching piece(s) for update using tenantId: '{}'", tenantId, t));
+  }
+
   public Future<String> createPiece(Conn conn, Piece piece, String tenantId) {
     piece.setStatusUpdatedDate(new Date());
     if (StringUtils.isBlank(piece.getId())) {
@@ -128,11 +138,13 @@ public class PieceService {
       .onFailure(t -> log.error("createPieces:: Failed pieces: {}", pieceIds, t));
   }
 
-  public Future<RowSet<Row>> updatePiece(String id, Piece piece, Conn conn, String tenantId) {
+  public Future<AuditEntityWrapper<Piece>> updatePiece(String id, Piece piece, Conn conn, String tenantId) {
     log.debug("updatePiece:: Updating piece: '{}'", id);
     return shiftSequenceNumbersIfNeeded(id, piece, conn, tenantId)
-      .compose(v -> conn.update(TableNames.PIECES_TABLE, piece, id))
-      .compose(DbUtils::failOnNoUpdateOrDelete)
+      .compose(v -> getPieceByIdForUpdate(id, conn))
+      .compose(originalPiece -> conn.update(TableNames.PIECES_TABLE, piece, id)
+        .compose(DbUtils::failOnNoUpdateOrDelete)
+        .map(AuditEntityWrapper.of(piece, originalPiece.orElse(null))))
       .onSuccess(rowSet -> log.info("updatePiece:: Piece successfully updated: '{}'", id))
       .onFailure(e -> log.error("updatePiece:: Update piece failed: '{}'", id, e));
   }
@@ -144,6 +156,11 @@ public class PieceService {
       .compose(piece -> piece == null
         ? Future.failedFuture(new HttpException(Response.Status.NOT_FOUND.getStatusCode(), "Piece not found: " + id))
         : Future.succeededFuture(piece));
+  }
+
+  public Future<Optional<Piece>> getPieceByIdForUpdate(String id, Conn conn) {
+    log.debug("getPieceByIdForUpdate:: Getting piece for update: '{}'", id);
+    return conn.getByIdForUpdate(PIECES_TABLE, id, Piece.class).map(Optional::ofNullable);
   }
 
   public Future<Void> deletePiece(String id, Conn conn) {
@@ -169,14 +186,16 @@ public class PieceService {
       .mapEmpty();
   }
 
-  public Future<List<Piece>> updatePieces(List<Piece> pieces, Conn conn, String tenantId) {
+  public Future<List<AuditEntityWrapper<Piece>>> updatePieces(List<Piece> pieces, Conn conn, String tenantId) {
     if (CollectionUtils.isEmpty(pieces)) {
       log.warn("updatePieces:: Pieces list is empty, skipping the update");
       return Future.succeededFuture(List.of());
     }
     String query = buildUpdatePieceBatchQuery(pieces, tenantId);
-    return conn.execute(query)
-      .map(rows -> DbUtils.getRowSetAsList(rows, Piece.class))
+    return getPiecesByIdsForUpdate(mapTo(pieces, Piece::getId), tenantId, conn)
+      .compose(originalPieces -> conn.execute(query)
+        .map(rows -> DbUtils.getRowSetAsList(rows, Piece.class))
+        .map(updatedPieces -> AuditEntityWrapper.listOf(updatedPieces, originalPieces, Piece::getId)))
       .onSuccess(ar -> log.info("updatePieces:: completed, query={}", query))
       .onFailure(t -> log.error("updatePieces:: failed, query={}", query, t));
   }
@@ -198,7 +217,7 @@ public class PieceService {
    * @param tenantId Tenant identifier
    * @return Future with the list of updated pieces
    */
-  public Future<List<Piece>> updatePiecesInventoryData(List<Piece> pieces, Conn conn, String tenantId) {
+  public Future<List<AuditEntityWrapper<Piece>>> updatePiecesInventoryData(List<Piece> pieces, Conn conn, String tenantId) {
     if (CollectionUtils.isEmpty(pieces)) {
       log.warn("updatePiecesInventoryFieldsOnly:: Pieces list is empty, skipping the update");
       return Future.succeededFuture(List.of());
@@ -208,19 +227,22 @@ public class PieceService {
     return collectResultsOnSuccess(updateFutures);
   }
 
-  private Future<Piece> updatePieceInventoryData(Piece piece, Conn conn, String tenantId) {
+  private Future<AuditEntityWrapper<Piece>> updatePieceInventoryData(Piece piece, Conn conn, String tenantId) {
     var updateQuery = PIECES_UPDATE_INVENTORY_DATA.formatted(getFullTableName(tenantId, PIECES_TABLE));
     var params = Tuple.of(piece.getHoldingId(), piece.getReceivingTenantId(), piece.getBarcode(), piece.getCallNumber(), piece.getAccessionNumber(), piece.getId());
-    return conn.execute(updateQuery, params).map(rows -> {
-      if (rows.rowCount() == 0) {
-        log.warn("updateSinglePieceInventoryFields:: No piece updated with id: {}", piece.getId());
-        return piece;
-      }
-      var updatedPiece = DbUtils.getRowSetAsEntity(rows, Piece.class);
-      log.info("updateSinglePieceInventoryFields:: Successfully updated piece: {} with holdingId: {}, receivingTenantId: {}, barcode: {}, callNumber: {}, accessionNumber: {}",
-        piece.getId(), piece.getHoldingId(), piece.getReceivingTenantId(), piece.getBarcode(), piece.getCallNumber(), piece.getAccessionNumber());
-      return updatedPiece;
-    }).onFailure(e -> log.error("updateSinglePieceInventoryFields:: Failed to update piece: {}", piece.getId(), e));
+    return getPieceByIdForUpdate(piece.getId(), conn)
+      .compose(originalPiece -> conn.execute(updateQuery, params).map(rows -> {
+          if (rows.rowCount() == 0) {
+            log.warn("updateSinglePieceInventoryFields:: No piece updated with id: {}", piece.getId());
+            return piece;
+          }
+          var updatedPiece = DbUtils.getRowSetAsEntity(rows, Piece.class);
+          log.info("updateSinglePieceInventoryFields:: Successfully updated piece: {} with holdingId: {}, receivingTenantId: {}, barcode: {}, callNumber: {}, accessionNumber: {}",
+            piece.getId(), piece.getHoldingId(), piece.getReceivingTenantId(), piece.getBarcode(), piece.getCallNumber(), piece.getAccessionNumber());
+          return updatedPiece;
+        })
+        .map(updatedPiece -> AuditEntityWrapper.of(updatedPiece, originalPiece.orElse(null))))
+      .onFailure(e -> log.error("updateSinglePieceInventoryFields:: Failed to update piece: {}", piece.getId(), e));
   }
 
   public Future<Void> updatePieces(PoLine poLine, ReplaceInstanceRef replaceInstanceRef, Conn conn, String tenantId) {

--- a/src/main/java/org/folio/services/piece/PieceService.java
+++ b/src/main/java/org/folio/services/piece/PieceService.java
@@ -232,16 +232,15 @@ public class PieceService {
     var params = Tuple.of(piece.getHoldingId(), piece.getReceivingTenantId(), piece.getBarcode(), piece.getCallNumber(), piece.getAccessionNumber(), piece.getId());
     return getPieceByIdForUpdate(piece.getId(), conn)
       .compose(originalPiece -> conn.execute(updateQuery, params).map(rows -> {
-          if (rows.rowCount() == 0) {
-            log.warn("updateSinglePieceInventoryFields:: No piece updated with id: {}", piece.getId());
-            return piece;
-          }
-          var updatedPiece = DbUtils.getRowSetAsEntity(rows, Piece.class);
-          log.info("updateSinglePieceInventoryFields:: Successfully updated piece: {} with holdingId: {}, receivingTenantId: {}, barcode: {}, callNumber: {}, accessionNumber: {}",
-            piece.getId(), piece.getHoldingId(), piece.getReceivingTenantId(), piece.getBarcode(), piece.getCallNumber(), piece.getAccessionNumber());
-          return updatedPiece;
-        })
-        .map(updatedPiece -> AuditEntityWrapper.of(updatedPiece, originalPiece.orElse(null))))
+        if (rows.rowCount() == 0) {
+          log.warn("updateSinglePieceInventoryFields:: No piece updated with id: {}", piece.getId());
+          return AuditEntityWrapper.of(piece, originalPiece.orElse(null));
+        }
+        var updatedPiece = DbUtils.getRowSetAsEntity(rows, Piece.class);
+        log.info("updateSinglePieceInventoryFields:: Successfully updated piece: {} with holdingId: {}, receivingTenantId: {}, barcode: {}, callNumber: {}, accessionNumber: {}",
+          piece.getId(), piece.getHoldingId(), piece.getReceivingTenantId(), piece.getBarcode(), piece.getCallNumber(), piece.getAccessionNumber());
+        return AuditEntityWrapper.of(updatedPiece, originalPiece.orElse(null));
+      }))
       .onFailure(e -> log.error("updateSinglePieceInventoryFields:: Failed to update piece: {}", piece.getId(), e));
   }
 

--- a/src/main/java/org/folio/util/AuditUtils.java
+++ b/src/main/java/org/folio/util/AuditUtils.java
@@ -1,0 +1,30 @@
+package org.folio.util;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.rest.jaxrs.model.Metadata;
+
+import jakarta.annotation.Nullable;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class AuditUtils {
+
+  public static String buildTopicName(String envId, String tenantId, String eventType) {
+    return KafkaTopicNameHelper.formatTopicName(envId, KafkaTopicNameHelper.getDefaultNameSpace(), tenantId, eventType);
+  }
+
+  public static <T> Metadata getMetadataOrThrow(Supplier<Metadata> metadataGetter, Supplier<String> idGetter) {
+    return Optional.ofNullable(metadataGetter.get())
+      .orElseThrow(() -> new IllegalArgumentException("Metadata is null for entity with id: %s".formatted(idGetter.get())));
+  }
+
+  @Nullable
+  public static <T> T withNullMetadata(T entity, BiFunction<T, Metadata, T> setter) {
+    return Optional.ofNullable(entity).map(e -> setter.apply(e, null)).orElse(null);
+  }
+
+}

--- a/src/main/java/org/folio/util/AuditUtils.java
+++ b/src/main/java/org/folio/util/AuditUtils.java
@@ -17,7 +17,7 @@ public class AuditUtils {
     return KafkaTopicNameHelper.formatTopicName(envId, KafkaTopicNameHelper.getDefaultNameSpace(), tenantId, eventType);
   }
 
-  public static <T> Metadata getMetadataOrThrow(Supplier<Metadata> metadataGetter, Supplier<String> idGetter) {
+  public static Metadata getMetadataOrThrow(Supplier<Metadata> metadataGetter, Supplier<String> idGetter) {
     return Optional.ofNullable(metadataGetter.get())
       .orElseThrow(() -> new IllegalArgumentException("Metadata is null for entity with id: %s".formatted(idGetter.get())));
   }

--- a/src/main/java/org/folio/util/HelperUtils.java
+++ b/src/main/java/org/folio/util/HelperUtils.java
@@ -72,4 +72,8 @@ public class HelperUtils {
     return f;
   }
 
+  public static <T, R> List<R> mapTo(List<T> list, Function<T, R> mapper) {
+    return list.stream().map(mapper).collect(Collectors.toList());
+  }
+
 }

--- a/src/main/java/org/folio/util/HelperUtils.java
+++ b/src/main/java/org/folio/util/HelperUtils.java
@@ -73,7 +73,7 @@ public class HelperUtils {
   }
 
   public static <T, R> List<R> mapTo(List<T> list, Function<T, R> mapper) {
-    return list.stream().map(mapper).collect(Collectors.toList());
+    return list.stream().map(mapper).toList();
   }
 
 }

--- a/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingCreateAsyncRecordHandlerTest.java
@@ -129,6 +129,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     );
 
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(anyList(), anyString(), any(Conn.class));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     doReturn(Future.succeededFuture(expectedPieces)).when(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT), any());
@@ -206,6 +207,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     );
 
     doReturn(Future.succeededFuture(List.of())).when(pieceService).getPiecesByHoldingId(eq(holdingId1), any(Conn.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(anyList(), anyString(), any(Conn.class));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT), any());
 
@@ -261,6 +263,7 @@ public class HoldingCreateAsyncRecordHandlerTest {
     var expectedPoLines = List.of(createPoLineWithSearchLocationId(poLineId, List.of(createLocation(holdingId, DIKU_TENANT), createLocation(holdingId, DIKU_TENANT))));
 
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByHoldingId(eq(holdingId), any(Conn.class));
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(anyList(), anyString(), any(Conn.class));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(anyString(), any(Conn.class));
     doThrow(new RuntimeException("Piece save failed")).when(pieceService).updatePieces(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
     doThrow(new RuntimeException("PoLine save failed")).when(poLinesService).updatePoLines(eq(expectedPoLines), any(Conn.class), eq(DIKU_TENANT), any());

--- a/src/test/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/HoldingUpdateAsyncRecordHandlerTest.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonObject;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.folio.TestUtils;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.dto.InstanceFields;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
@@ -179,12 +180,14 @@ public class HoldingUpdateAsyncRecordHandlerTest {
       createPoLine(poLineId1, instanceId1, List.of(newHoldingValueAfterUpdate), List.of(permanentSearchLocationId1), TITLE_1, PUBLISHER_1, DATE_OF_PUBLICATION_1, CONTRIBUTOR_1, CONTRIBUTOR_NAME_TYPE_ID_1, IDENTIFIER_TYPE_VALUE_1, IDENTIFIER_TYPE_ID_1),
       createPoLine(poLineId2, instanceId1, List.of(newHoldingValueAfterUpdate), List.of(permanentSearchLocationId1), TITLE_1, PUBLISHER_1, DATE_OF_PUBLICATION_1, CONTRIBUTOR_1, CONTRIBUTOR_NAME_TYPE_ID_1, IDENTIFIER_TYPE_VALUE_1, IDENTIFIER_TYPE_ID_1)
     );
+    var expectedAuditEntities = AuditEntityWrapper.listOf(expectedPoLines, actualPoLines, PoLine::getId);
 
     doReturn(Future.succeededFuture()).when(inventoryUpdateService).getAndSetHolderInstanceByIdIfRequired(any(), any());
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId1, poLineId2)), eq(UNIVERSITY_TENANT), eq(conn));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(eq(query), eq(conn));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(conn), eq(UNIVERSITY_TENANT), any());
     doReturn(Future.succeededFuture()).when(poLinesService).updateTitles(eq(conn), eq(List.of()), anyMap());
-    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), eq(expectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), eq(expectedAuditEntities), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
@@ -235,13 +238,15 @@ public class HoldingUpdateAsyncRecordHandlerTest {
       createPoLine(poLineId1, instanceId2, List.of(newHoldingValueAfterUpdate), TITLE_2, PUBLISHER_2, DATE_OF_PUBLICATION_2, CONTRIBUTOR_2, CONTRIBUTOR_NAME_TYPE_ID_2, IDENTIFIER_TYPE_VALUE_2, IDENTIFIER_TYPE_ID_2),
       createPoLine(poLineId2, instanceId2, List.of(newHoldingValueAfterUpdate), TITLE_2, PUBLISHER_2, DATE_OF_PUBLICATION_2, CONTRIBUTOR_2, CONTRIBUTOR_NAME_TYPE_ID_2, IDENTIFIER_TYPE_VALUE_2, IDENTIFIER_TYPE_ID_2)
     );
+    var expectedAuditEntities = AuditEntityWrapper.listOf(expectedPoLines, actualPoLines, PoLine::getId);
 
     doCallRealMethod().when(inventoryUpdateService).getAndSetHolderInstanceByIdIfRequired(any(), any());
     doReturn(Future.succeededFuture(newInstance)).when(instancesService).getInstanceById(any(), any());
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId1, poLineId2)), eq(UNIVERSITY_TENANT), eq(conn));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(eq(query), eq(conn));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(conn), eq(UNIVERSITY_TENANT), any());
     doReturn(Future.succeededFuture()).when(poLinesService).updateTitles(eq(conn), eq(expectedPoLines), anyMap());
-    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), eq(expectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), eq(expectedAuditEntities), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
@@ -298,13 +303,15 @@ public class HoldingUpdateAsyncRecordHandlerTest {
       createPoLine(poLineId1, instanceId2, List.of(newHoldingValueAfterUpdate), List.of(permanentSearchLocationId1), TITLE_2, PUBLISHER_2, DATE_OF_PUBLICATION_2, CONTRIBUTOR_2, CONTRIBUTOR_NAME_TYPE_ID_2, IDENTIFIER_TYPE_VALUE_2, IDENTIFIER_TYPE_ID_2),
       createPoLine(poLineId2, instanceId2, List.of(newHoldingValueAfterUpdate), List.of(permanentSearchLocationId1), TITLE_2, PUBLISHER_2, DATE_OF_PUBLICATION_2, CONTRIBUTOR_2, CONTRIBUTOR_NAME_TYPE_ID_2, IDENTIFIER_TYPE_VALUE_2, IDENTIFIER_TYPE_ID_2)
     );
+    var expectedAuditEntities = AuditEntityWrapper.listOf(expectedPoLines, actualPoLines, PoLine::getId);
 
     doCallRealMethod().when(inventoryUpdateService).getAndSetHolderInstanceByIdIfRequired(any(), any());
     doReturn(Future.succeededFuture(newInstance)).when(instancesService).getInstanceById(any(), any());
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId1, poLineId2)), eq(UNIVERSITY_TENANT), eq(conn));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(eq(query), eq(conn));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(conn), eq(UNIVERSITY_TENANT), any());
     doReturn(Future.succeededFuture()).when(poLinesService).updateTitles(eq(conn), eq(expectedPoLines), anyMap());
-    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), eq(expectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), eq(expectedAuditEntities), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
@@ -395,14 +402,16 @@ public class HoldingUpdateAsyncRecordHandlerTest {
       createPoLine(poLineId1, instanceId1, List.of(newHoldingValueAfterUpdate), List.of(permanentSearchLocationId1), TITLE_1, PUBLISHER_1, DATE_OF_PUBLICATION_1, CONTRIBUTOR_1, CONTRIBUTOR_NAME_TYPE_ID_1, IDENTIFIER_TYPE_VALUE_1, IDENTIFIER_TYPE_ID_1),
       createPoLine(poLineId2, instanceId1, List.of(newHoldingValueAfterUpdate), List.of(permanentSearchLocationId1), TITLE_1, PUBLISHER_1, DATE_OF_PUBLICATION_1, CONTRIBUTOR_1, CONTRIBUTOR_NAME_TYPE_ID_1, IDENTIFIER_TYPE_VALUE_1, IDENTIFIER_TYPE_ID_1)
     );
+    var expectedAuditEntities = AuditEntityWrapper.listOf(expectedPoLines, actualPoLines, PoLine::getId);
 
     doReturn(Future.succeededFuture()).when(inventoryUpdateService).getAndSetHolderInstanceByIdIfRequired(any(), any());
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId1, poLineId2)), eq(CENTRAL_TENANT), any(Conn.class));
     doReturn(Future.succeededFuture(List.of())).when(poLinesService).getPoLinesByCqlQuery(eq(query), eq(conn));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(eq(query), eq(connCentral));
     doReturn(Future.succeededFuture(2)).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(connCentral), eq(CENTRAL_TENANT), any());
     doReturn(Future.succeededFuture()).when(poLinesService).updateTitles(eq(conn), eq(List.of()), anyMap());
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), eq(List.of()), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
-    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(connCentral), eq(expectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(connCentral), eq(expectedAuditEntities), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
     var result = handler.handle(kafkaRecord);
     assertTrue(result.succeeded());
@@ -479,6 +488,7 @@ public class HoldingUpdateAsyncRecordHandlerTest {
 
     doCallRealMethod().when(inventoryUpdateService).getAndSetHolderInstanceByIdIfRequired(any(), any());
     doReturn(Future.succeededFuture(newInstance)).when(instancesService).getInstanceById(any(), any());
+    doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId1, poLineId2)), eq(UNIVERSITY_TENANT), eq(conn));
     doReturn(Future.succeededFuture(actualPoLines)).when(poLinesService).getPoLinesByCqlQuery(eq(query), eq(conn));
     doThrow(new RuntimeException(PO_LINE_SAVE_FAILED_MSG)).when(poLinesService).updatePoLines(eq(expectedPoLines), eq(conn), eq(UNIVERSITY_TENANT), any());
     doReturn(pgClient).when(dbClient).getPgClient();

--- a/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemCreateAsyncRecordHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.folio.TestUtils;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.models.ConsortiumConfiguration;
 import org.folio.rest.jaxrs.model.BatchTracking;
@@ -161,10 +162,12 @@ public class ItemCreateAsyncRecordHandlerTest {
     var poLines = List.of(poLine1, poLine2);
     var affectedPieces = List.of(affectedPiece1, affectedPiece2, affectedPiece4);
     var affectedPoLines = List.of(affectedPoLine1, affectedPoLine2);
+    var affectedWrappedPieces = AuditEntityWrapper.listOf(affectedPieces, pieces, Piece::getId);
+    var affectedWrappedPoLines = AuditEntityWrapper.listOf(affectedPoLines, poLines, PoLine::getId);
 
     // Update Pieces
     doReturn(Future.succeededFuture(pieces)).when(pieceService).getPiecesByItemId(eq(itemId1), eq(conn));
-    doReturn(Future.succeededFuture(affectedPieces)).when(pieceService).updatePiecesInventoryData(eq(pieces), eq(conn), eq(CENTRAL_TENANT));
+    doReturn(Future.succeededFuture(affectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(eq(pieces), eq(conn), eq(CENTRAL_TENANT));
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(eq(conn), anyList(), any(), anyMap());
     // Update PoLines
     doReturn(Future.succeededFuture(List.of(affectedPiece1, affectedPiece2, unaffectedPiece3))).when(pieceService).getPiecesByPoLineId(eq(poLineId1), eq(conn));
@@ -180,13 +183,13 @@ public class ItemCreateAsyncRecordHandlerTest {
     verify(handler, times(1)).processInventoryCreationEvent(eq(extractResourceEvent(kafkaRecord)), eq(CENTRAL_TENANT), anyMap(), eq(dbClient));
     verify(pieceService, times(1)).getPiecesByItemId(eq(itemId1), eq(conn));
     verify(pieceService, times(1)).updatePiecesInventoryData(eq(affectedPieces), eq(conn), eq(CENTRAL_TENANT));
-    verify(auditOutboxService, times(1)).savePiecesOutboxLog(any(Conn.class), eq(affectedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, times(1)).savePiecesOutboxLog(any(Conn.class), eq(affectedWrappedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
     // Update PoLines
     verify(pieceService, times(1)).getPiecesByPoLineId(eq(poLineId1), eq(conn));
     verify(pieceService, times(1)).getPiecesByPoLineId(eq(poLineId2), eq(conn));
-    verify(poLinesService, times(1)).getPoLinesByIdsForUpdate(eq(List.of(poLine1.getId(), poLine2.getId())), eq(CENTRAL_TENANT), eq(conn));
+    verify(poLinesService, times(2)).getPoLinesByIdsForUpdate(eq(List.of(poLine1.getId(), poLine2.getId())), eq(CENTRAL_TENANT), eq(conn));
     verify(poLinesService, times(1)).updatePoLines(eq(affectedPoLines), eq(conn), eq(CENTRAL_TENANT), any());
-    verify(auditOutboxService, times(1)).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, times(1)).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedWrappedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
     assertEquals(holdingId1, piece1.getHoldingId());
     assertEquals(holdingId1, piece2.getHoldingId());
@@ -240,10 +243,12 @@ public class ItemCreateAsyncRecordHandlerTest {
     var poLines = List.of(poLine1, poLine2);
     var affectedPieces = List.of(affectedPiece1, affectedPiece2, affectedPiece4);
     var affectedPoLines = List.of(affectedPoLine1, affectedPoLine2);
+    var affectedWrappedPieces = AuditEntityWrapper.listOf(affectedPieces, pieces, Piece::getId);
+    var affectedWrappedPoLines = AuditEntityWrapper.listOf(affectedPoLines, poLines, PoLine::getId);
 
     // Update Pieces
     doReturn(Future.succeededFuture(pieces)).when(pieceService).getPiecesByItemId(eq(itemId1), eq(conn));
-    doReturn(Future.succeededFuture(affectedPieces)).when(pieceService).updatePiecesInventoryData(eq(pieces), eq(conn), eq(CENTRAL_TENANT));
+    doReturn(Future.succeededFuture(affectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(eq(pieces), eq(conn), eq(CENTRAL_TENANT));
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(eq(conn), anyList(), any(), anyMap());
     // Update PoLines
     doReturn(Future.succeededFuture(List.of(affectedPiece1, affectedPiece2, unaffectedPiece3))).when(pieceService).getPiecesByPoLineId(eq(poLineId1), eq(conn));
@@ -259,13 +264,13 @@ public class ItemCreateAsyncRecordHandlerTest {
     verify(handler, times(1)).processInventoryCreationEvent(eq(extractResourceEvent(kafkaRecord)), eq(CENTRAL_TENANT), anyMap(), eq(dbClient));
     verify(pieceService, times(1)).getPiecesByItemId(eq(itemId1), eq(conn));
     verify(pieceService, times(1)).updatePiecesInventoryData(eq(affectedPieces), eq(conn), eq(CENTRAL_TENANT));
-    verify(auditOutboxService, times(1)).savePiecesOutboxLog(any(Conn.class), eq(affectedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, times(1)).savePiecesOutboxLog(any(Conn.class), eq(affectedWrappedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
     // Update PoLines
     verify(pieceService, times(1)).getPiecesByPoLineId(eq(poLineId1), eq(conn));
     verify(pieceService, times(1)).getPiecesByPoLineId(eq(poLineId2), eq(conn));
-    verify(poLinesService, times(1)).getPoLinesByIdsForUpdate(eq(List.of(poLine1.getId(), poLine2.getId())), eq(CENTRAL_TENANT), eq(conn));
+    verify(poLinesService, times(2)).getPoLinesByIdsForUpdate(eq(List.of(poLine1.getId(), poLine2.getId())), eq(CENTRAL_TENANT), eq(conn));
     verify(poLinesService, times(1)).updatePoLines(eq(affectedPoLines), eq(conn), eq(CENTRAL_TENANT), any());
-    verify(auditOutboxService, times(1)).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, times(1)).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedWrappedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
     assertEquals(holdingId1, piece1.getHoldingId());
     assertEquals(holdingId1, piece2.getHoldingId());
@@ -320,10 +325,12 @@ public class ItemCreateAsyncRecordHandlerTest {
     var poLines = List.of(poLine1, poLine2);
     var affectedPieces = List.of(affectedPiece1, affectedPiece2, affectedPiece4);
     var affectedPoLines = List.of(affectedPoLine1, affectedPoLine2);
+    var affectedWrappedPieces = AuditEntityWrapper.listOf(affectedPieces, pieces, Piece::getId);
+    var affectedWrappedPoLines = AuditEntityWrapper.listOf(affectedPoLines, poLines, PoLine::getId);
 
     // Update Pieces
     doReturn(Future.succeededFuture(pieces)).when(pieceService).getPiecesByItemId(eq(itemId1), eq(conn));
-    doReturn(Future.succeededFuture(affectedPieces)).when(pieceService).updatePiecesInventoryData(eq(pieces), eq(conn), eq(CENTRAL_TENANT));
+    doReturn(Future.succeededFuture(affectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(eq(pieces), eq(conn), eq(CENTRAL_TENANT));
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(eq(conn), anyList(), any(), anyMap());
     // Update PoLines
     doReturn(Future.succeededFuture(List.of(affectedPiece1, affectedPiece2, unaffectedPiece3))).when(pieceService).getPiecesByPoLineId(eq(poLineId1), eq(conn));
@@ -339,13 +346,13 @@ public class ItemCreateAsyncRecordHandlerTest {
     verify(handler, times(1)).processInventoryCreationEvent(eq(extractResourceEvent(kafkaRecord)), eq(CENTRAL_TENANT), anyMap(), eq(dbClient));
     verify(pieceService, times(1)).getPiecesByItemId(eq(itemId1), eq(conn));
     verify(pieceService, times(1)).updatePiecesInventoryData(eq(affectedPieces), eq(conn), eq(CENTRAL_TENANT));
-    verify(auditOutboxService, times(1)).savePiecesOutboxLog(any(Conn.class), eq(affectedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, times(1)).savePiecesOutboxLog(any(Conn.class), eq(affectedWrappedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
     // Update PoLines
     verify(pieceService, times(1)).getPiecesByPoLineId(eq(poLineId1), eq(conn));
     verify(pieceService, times(1)).getPiecesByPoLineId(eq(poLineId2), eq(conn));
     verify(poLinesService, times(1)).getPoLinesByIdsForUpdate(eq(List.of(poLine1.getId(), poLine2.getId())), eq(CENTRAL_TENANT), eq(conn));
     verify(poLinesService, never()).updatePoLines(eq(affectedPoLines), eq(conn), eq(CENTRAL_TENANT), any());
-    verify(auditOutboxService, never()).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, never()).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedWrappedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
     assertEquals(holdingId1, piece1.getHoldingId());
     assertEquals(holdingId1, piece2.getHoldingId());
@@ -520,7 +527,6 @@ public class ItemCreateAsyncRecordHandlerTest {
     // Common mocks
     doReturn(Future.succeededFuture(List.of(piece1, piece3))).when(pieceService).getPiecesByItemId(eq(itemId1), eq(conn));
     doReturn(Future.succeededFuture(List.of(piece2, piece4))).when(pieceService).getPiecesByItemId(eq(itemId2), eq(conn));
-    doReturn(Future.succeededFuture()).when(pieceService).updatePiecesInventoryData(anyList(), eq(conn), eq(CENTRAL_TENANT));
     doReturn(Future.succeededFuture()).when(poLinesService).updatePoLines(anyList(), eq(conn), eq(CENTRAL_TENANT), any());
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(eq(conn), anyList(), any(), anyMap());
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).savePiecesOutboxLog(eq(conn), anyList(), any(), anyMap());
@@ -535,10 +541,13 @@ public class ItemCreateAsyncRecordHandlerTest {
     var affectedPoLine2 = createPoLine(poLineId2, List.of(affectedPiece3, piece4), List.of(effectiveLocationId1, effectiveLocationId2));
     var affectedPieces = List.of(affectedPiece1, affectedPiece3);
     var affectedPoLines = List.of(affectedPoLine1, affectedPoLine2);
+    var affectedWrappedPieces = AuditEntityWrapper.listOf(affectedPieces, List.of(piece1, piece3), Piece::getId);
+    var affectedWrappedPoLines = AuditEntityWrapper.listOf(affectedPoLines, List.of(poLine1, poLine2), PoLine::getId);
 
     doReturn(Future.succeededFuture(List.of(poLine1, poLine2))).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId1, poLineId2)), eq(CENTRAL_TENANT), eq(conn));
     doReturn(Future.succeededFuture(List.of(affectedPiece1, piece2))).when(pieceService).getPiecesByPoLineId(poLineId1, conn);
     doReturn(Future.succeededFuture(List.of(affectedPiece3, piece4))).when(pieceService).getPiecesByPoLineId(poLineId2, conn);
+    doReturn(Future.succeededFuture(affectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(anyList(), eq(conn), eq(CENTRAL_TENANT));
     doReturn(Future.succeededFuture(batchTracking.withProcessedCount(1))).when(batchTrackingService).increaseBatchTrackingProgress(conn, batchId, CENTRAL_TENANT);
 
     var result = handler.handle(kafkaRecord1);
@@ -553,8 +562,8 @@ public class ItemCreateAsyncRecordHandlerTest {
     verify(batchTrackingService).increaseBatchTrackingProgress(conn, batchId, CENTRAL_TENANT);
     verify(batchTrackingService, never()).deleteBatchTracking(conn, batchId);
     // Audit logs - No POL log should be saved until batch is finished
-    verify(auditOutboxService).savePiecesOutboxLog(any(Conn.class), eq(affectedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
-    verify(auditOutboxService, never()).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService).savePiecesOutboxLog(any(Conn.class), eq(affectedWrappedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, never()).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedWrappedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
 
     //// Second event processing ////
@@ -562,13 +571,17 @@ public class ItemCreateAsyncRecordHandlerTest {
     var affectedPiece4 = createPiece(pieceId4, itemId2).withPoLineId(poLineId2).withReceivingTenantId(COLLEGE_TENANT).withHoldingId(holdingId1).withFormat(Piece.Format.PHYSICAL);
     doReturn(Future.succeededFuture(List.of(affectedPoLine1, affectedPoLine2))).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId1, poLineId2)), eq(CENTRAL_TENANT), eq(conn));
 
-    affectedPoLine1 = createPoLine(poLineId1, List.of(affectedPiece1, affectedPiece2), List.of(effectiveLocationId1, effectiveLocationId2));
-    affectedPoLine2 = createPoLine(poLineId2, List.of(affectedPiece3, affectedPiece4), List.of(effectiveLocationId1, effectiveLocationId2));
     affectedPieces = List.of(affectedPiece2, affectedPiece4);
-    affectedPoLines = List.of(affectedPoLine1, affectedPoLine2);
+    affectedPoLines = List.of(
+      createPoLine(poLineId1, List.of(affectedPiece1, affectedPiece2), List.of(effectiveLocationId1, effectiveLocationId2)),
+      createPoLine(poLineId2, List.of(affectedPiece3, affectedPiece4), List.of(effectiveLocationId1, effectiveLocationId2))
+    );
+    affectedWrappedPieces = AuditEntityWrapper.listOf(affectedPieces, List.of(piece2, piece4), Piece::getId);
+    affectedWrappedPoLines = AuditEntityWrapper.listOf(affectedPoLines, List.of(affectedPoLine1, affectedPoLine2), PoLine::getId);
 
     doReturn(Future.succeededFuture(List.of(affectedPiece1, affectedPiece2))).when(pieceService).getPiecesByPoLineId(poLineId1, conn);
     doReturn(Future.succeededFuture(List.of(affectedPiece3, affectedPiece4))).when(pieceService).getPiecesByPoLineId(poLineId2, conn);
+    doReturn(Future.succeededFuture(affectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(anyList(), eq(conn), eq(CENTRAL_TENANT));
     doReturn(Future.succeededFuture(batchTracking.withProcessedCount(2))).when(batchTrackingService).increaseBatchTrackingProgress(conn, batchId, CENTRAL_TENANT);
     doReturn(Future.succeededFuture(batchTracking.withProcessedCount(2))).when(batchTrackingService).deleteBatchTracking(conn, batchId);
 
@@ -584,8 +597,8 @@ public class ItemCreateAsyncRecordHandlerTest {
     verify(batchTrackingService, times(2)).increaseBatchTrackingProgress(conn, batchId, CENTRAL_TENANT);
     verify(batchTrackingService).deleteBatchTracking(conn, batchId);
     // Audit logs - Now POL logs should be saved, as batch is finished
-    verify(auditOutboxService).savePiecesOutboxLog(any(Conn.class), eq(affectedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
-    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService).savePiecesOutboxLog(any(Conn.class), eq(affectedWrappedPieces), eq(PieceAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(affectedWrappedPoLines), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
 
   }
 

--- a/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
@@ -40,6 +40,7 @@ import io.vertx.core.json.JsonObject;
 import one.util.streamex.StreamEx;
 
 import org.folio.TestUtils;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.event.dto.ResourceEvent;
 import org.folio.event.service.AuditOutboxService;
 import org.folio.models.ConsortiumConfiguration;
@@ -138,6 +139,7 @@ public class ItemUpdateAsyncRecordHandlerTest {
 
     var poLine = createPoLine(poLineId, holdingId1, effectiveLocationId1).withCheckinItems(checkinItems);
     var expectedPoLine = createPoLine(poLineId, holdingId2, effectiveLocationId1, effectiveLocationId2);
+    List<AuditEntityWrapper<PoLine>> expectedPoLineOutboxLogs = checkinItems ? List.of() : List.of(AuditEntityWrapper.of(expectedPoLine, poLine));
 
     var actualPieces = List.of(
       createPiece(pieceId1, itemId, holdingId1, null).withPoLineId(poLineId),
@@ -146,11 +148,12 @@ public class ItemUpdateAsyncRecordHandlerTest {
     var expectedPieces = List.of(
       createPiece(pieceId1, itemId, holdingId2, null).withPoLineId(poLineId)
     );
+    var expectedWrappedPieces = AuditEntityWrapper.listOf(expectedPieces, actualPieces, Piece::getId);
 
     doReturn(Future.succeededFuture(true)).when(pieceService).getPiecesByItemIdExist(eq(itemId), eq(DIKU_TENANT), any(Conn.class));
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByItemId(eq(itemId), any(Conn.class));
     doReturn(Future.succeededFuture(actualPieces)).when(pieceService).getPiecesByPoLineId(eq(poLineId), any(Conn.class));
-    doReturn(Future.succeededFuture(expectedPieces)).when(pieceService).updatePiecesInventoryData(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
+    doReturn(Future.succeededFuture(expectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
     doReturn(Future.succeededFuture(List.of(poLine))).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId)), eq(DIKU_TENANT), any(Conn.class));
     doReturn(Future.succeededFuture(1)).when(poLinesService).updatePoLines(eq(List.of(expectedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
     doReturn(Future.succeededFuture(true)).when(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), anyList(), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
@@ -161,10 +164,10 @@ public class ItemUpdateAsyncRecordHandlerTest {
     verify(handler).processInventoryUpdateEvent(any(ResourceEvent.class), anyMap());
     verify(pieceService).getPiecesByItemId(eq(itemId), any(Conn.class));
     verify(pieceService).updatePiecesInventoryData(eq(expectedPieces), any(Conn.class), eq(DIKU_TENANT));
-    verify(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId)), eq(DIKU_TENANT), any(Conn.class));
+    verify(poLinesService, times(checkinItems ? 1 : 2)).getPoLinesByIdsForUpdate(eq(List.of(poLineId)), eq(DIKU_TENANT), any(Conn.class));
     verify(pieceService, times(checkinItems ? 0 : 1)).getPiecesByPoLineId(eq(poLineId), any(Conn.class));
     verify(poLinesService, times(checkinItems ? 0 : 1)).updatePoLines(eq(List.of(expectedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
-    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(checkinItems ? List.of() : List.of(expectedPoLine)), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(expectedPoLineOutboxLogs), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
   }
 
   @Test
@@ -284,10 +287,11 @@ public class ItemUpdateAsyncRecordHandlerTest {
 
     //// First event processing ////
     var expectedPiece1 = createPiece(pieceId1, itemId1, holdingId2, null).withPoLineId(poLineId);
+    var expectedWrappedPieces = List.of(AuditEntityWrapper.of(expectedPiece1, piece1));
 
     doReturn(Future.succeededFuture(List.of(poLine))).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId)), eq(DIKU_TENANT), any(Conn.class));
     doReturn(Future.succeededFuture(List.of(expectedPiece1, piece2))).when(pieceService).getPiecesByPoLineId(eq(poLineId), any(Conn.class));
-    doReturn(Future.succeededFuture(List.of(expectedPiece1))).when(pieceService).updatePiecesInventoryData(eq(List.of(expectedPiece1)), any(Conn.class), eq(DIKU_TENANT));
+    doReturn(Future.succeededFuture(expectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(eq(List.of(expectedPiece1)), any(Conn.class), eq(DIKU_TENANT));
     doReturn(Future.succeededFuture(batchTracking.withProcessedCount(1))).when(batchTrackingService).increaseBatchTrackingProgress(conn, poLineId, DIKU_TENANT);
 
     var result = handler.handle(kafkaRecord1);
@@ -297,26 +301,27 @@ public class ItemUpdateAsyncRecordHandlerTest {
     verify(pieceService).getPiecesByItemId(eq(itemId1), any(Conn.class));
     verify(pieceService).updatePiecesInventoryData(eq(List.of(expectedPiece1)), any(Conn.class), eq(DIKU_TENANT));
     verify(poLinesService).updatePoLines(eq(List.of(expectedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
-    verify(auditOutboxService, never()).saveOrderLinesOutboxLogs(any(Conn.class), eq(List.of(expectedPoLine)), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(auditOutboxService, never()).saveOrderLinesOutboxLogs(any(Conn.class), eq(List.of(AuditEntityWrapper.of(expectedPoLine, poLine))), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
     verify(batchTrackingService).increaseBatchTrackingProgress(conn, poLineId, DIKU_TENANT);
     verify(batchTrackingService, never()).deleteBatchTracking(conn, poLineId);
 
     //// Second event processing ////
     var expectedPiece2 = createPiece(pieceId2, itemId2, holdingId2, null).withPoLineId(poLineId);
+    expectedWrappedPieces = List.of(AuditEntityWrapper.of(expectedPiece2, piece2));
 
     doReturn(Future.succeededFuture(List.of(expectedPoLine))).when(poLinesService).getPoLinesByIdsForUpdate(eq(List.of(poLineId)), eq(DIKU_TENANT), any(Conn.class));
     doReturn(Future.succeededFuture(List.of(expectedPiece1, expectedPiece2))).when(pieceService).getPiecesByPoLineId(eq(poLineId), any(Conn.class));
-    doReturn(Future.succeededFuture(List.of(expectedPiece2))).when(pieceService).updatePiecesInventoryData(eq(List.of(expectedPiece2)), any(Conn.class), eq(DIKU_TENANT));
+    doReturn(Future.succeededFuture(expectedWrappedPieces)).when(pieceService).updatePiecesInventoryData(eq(List.of(expectedPiece2)), any(Conn.class), eq(DIKU_TENANT));
     doReturn(Future.succeededFuture(batchTracking.withProcessedCount(2))).when(batchTrackingService).increaseBatchTrackingProgress(conn, poLineId, DIKU_TENANT);
 
     result = handler.handle(kafkaRecord2);
     assertTrue(result.succeeded());
 
-    expectedPoLine = createPoLine(poLineId, List.of(holdingId2, holdingId2), effectiveLocationId1, effectiveLocationId2);
+    var expectedUpdatedPoLine = createPoLine(poLineId, List.of(holdingId2, holdingId2), effectiveLocationId1, effectiveLocationId2);
     verify(pieceService).getPiecesByItemId(eq(itemId2), any(Conn.class));
     verify(pieceService).updatePiecesInventoryData(eq(List.of(expectedPiece2)), any(Conn.class), eq(DIKU_TENANT));
-    verify(poLinesService).updatePoLines(eq(List.of(expectedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
-    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(List.of(expectedPoLine)), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    verify(poLinesService).updatePoLines(eq(List.of(expectedUpdatedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
+    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(List.of(AuditEntityWrapper.of(expectedUpdatedPoLine, expectedPoLine))), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
     verify(batchTrackingService, times(2)).increaseBatchTrackingProgress(conn, poLineId, DIKU_TENANT);
     verify(batchTrackingService).deleteBatchTracking(conn, poLineId);
   }

--- a/src/test/java/org/folio/event/service/AuditOutboxServiceTest.java
+++ b/src/test/java/org/folio/event/service/AuditOutboxServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.vertx.core.Future;

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -356,7 +356,7 @@ public abstract class TestBase {
     assertNotNull(event.getOrderId());
     assertNotNull(event.getActionDate());
     assertNotNull(event.getEventDate());
-    assertNotNull(event.getPurchaseOrder());
+    assertNotNull(event.getOrderSnapshot());
   }
 
   protected void checkOrderLineEventContent(String eventPayload, OrderLineAuditEvent.Action action) {
@@ -367,7 +367,7 @@ public abstract class TestBase {
     assertNotNull(event.getOrderLineId());
     assertNotNull(event.getActionDate());
     assertNotNull(event.getEventDate());
-    assertNotNull(event.getPoLine());
+    assertNotNull(event.getOrderLineSnapshot());
   }
 
   protected void checkPieceEventContent(String eventPayload, PieceAuditEvent.Action action) {
@@ -377,6 +377,6 @@ public abstract class TestBase {
     assertNotNull(event.getPieceId());
     assertNotNull(event.getActionDate());
     assertNotNull(event.getEventDate());
-    assertNotNull(event.getPiece());
+    assertNotNull(event.getPieceSnapshot());
   }
 }

--- a/src/test/java/org/folio/services/lines/PoLinesServiceTest.java
+++ b/src/test/java/org/folio/services/lines/PoLinesServiceTest.java
@@ -35,6 +35,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.RowSet;
 import org.folio.dao.lines.PoLinesDAO;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.exceptions.HttpException;
 import org.folio.rest.jaxrs.model.PoLine;
@@ -44,7 +45,6 @@ import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.DBClient;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.SQLConnection;
 import org.folio.rest.persist.interfaces.Results;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -409,8 +409,10 @@ public class PoLinesServiceTest {
     }).when(pgClient).withTrans(any());
     doAnswer((Answer<Future<RowSet<Row>>>) invocation -> failedFuture(new Exception("unknown")))
       .when(conn).update(anyString(), any(PoLine.class), anyString(), anyString(), anyBoolean());
+    doReturn(succeededFuture(poLine))
+      .when(conn).getByIdForUpdate(anyString(), eq(poLineId), eq(PoLine.class));
 
-    Future<PoLine> f = pgClient.withTrans(conn -> poLinesService.doUpdatePoLine(poLine, conn));
+    Future<AuditEntityWrapper<PoLine>> f = pgClient.withTrans(conn -> poLinesService.doUpdatePoLine(poLine, conn));
 
     assertThat(f.failed(), is(true));
     io.vertx.ext.web.handler.HttpException thrown = (io.vertx.ext.web.handler.HttpException) f.cause();
@@ -452,6 +454,8 @@ public class PoLinesServiceTest {
       .when(rowSet).rowCount();
     doReturn(succeededFuture(results))
       .when(conn).get(anyString(), eq(Title.class), any(Criterion.class), anyBoolean());
+    doReturn(succeededFuture(poLine))
+      .when(conn).getByIdForUpdate(anyString(), eq(poLineId), eq(PoLine.class));
 
     Future<Void> f = poLinesService.updatePoLineWithTitle(conn, poLineId, poLine, requestContext);
 

--- a/src/test/java/org/folio/services/piece/PieceServiceTest.java
+++ b/src/test/java/org/folio/services/piece/PieceServiceTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.event.dto.AuditEntityWrapper;
 import org.folio.rest.impl.TestBase;
 import org.folio.rest.jaxrs.model.Holding;
 import org.folio.rest.jaxrs.model.Piece;
@@ -268,12 +269,12 @@ public class PieceServiceTest extends TestBase {
   void shouldNotUpdatePiecesWhenEmpty(Vertx vertx, VertxTestContext testContext) {
     new DBClient(vertx, TEST_TENANT).getPgClient().withConn(connection -> {
       var conn = spy(connection);
-      List<Piece> piecesToUpdate = List.of();
-      var updatePiecesFuture = pieceService.updatePieces(piecesToUpdate, conn, TEST_TENANT);
+      List<AuditEntityWrapper<Piece>> piecesToUpdate = List.of();
+      var updatePiecesFuture = pieceService.updatePieces(List.of(), conn, TEST_TENANT);
 
       return testContext.assertComplete(updatePiecesFuture)
         .onComplete(ar -> {
-          List<Piece> actPieces = ar.result();
+          List<AuditEntityWrapper<Piece>> actPieces = ar.result();
           testContext.verify(() -> {
             assertThat(actPieces, is(piecesToUpdate));
             verifyNoInteractions(conn);
@@ -314,8 +315,8 @@ public class PieceServiceTest extends TestBase {
         .compose(v -> pieceService.updatePiecesInventoryData(List.of(update), conn, TEST_TENANT))
         .onComplete(ar -> {
           testContext.verify(() -> {
-            assertThat(ar.result().getFirst().getHoldingId(), is(newHoldingId));
-            assertThat(ar.result().getFirst().getReceivingTenantId(), is(TEST_TENANT));
+            assertThat(ar.result().getFirst().entity().getHoldingId(), is(newHoldingId));
+            assertThat(ar.result().getFirst().entity().getReceivingTenantId(), is(TEST_TENANT));
           });
           testContext.completeNow();
         })
@@ -337,8 +338,8 @@ public class PieceServiceTest extends TestBase {
         .onComplete(ar -> {
           testContext.verify(() -> {
             assertThat(ar.result().size(), is(2));
-            assertThat(ar.result().get(0).getHoldingId(), is(newHoldingId));
-            assertThat(ar.result().get(1).getHoldingId(), is(newHoldingId2));
+            assertThat(ar.result().get(0).entity().getHoldingId(), is(newHoldingId));
+            assertThat(ar.result().get(1).entity().getHoldingId(), is(newHoldingId2));
           });
           testContext.completeNow();
         })
@@ -370,7 +371,7 @@ public class PieceServiceTest extends TestBase {
         .compose(v -> pieceService.updatePiecesInventoryData(
           List.of(new Piece().withId(pieceId).withHoldingId(null)), conn, TEST_TENANT))
         .onComplete(ar -> {
-          testContext.verify(() -> assertNull(ar.result().getFirst().getHoldingId()));
+          testContext.verify(() -> assertNull(ar.result().getFirst().entity().getHoldingId()));
           testContext.completeNow();
         })
     );
@@ -384,7 +385,7 @@ public class PieceServiceTest extends TestBase {
       pieceService.updatePiecesInventoryData(
         List.of(new Piece().withId(nonExistentId).withHoldingId(newHoldingId)), conn, TEST_TENANT)
         .onComplete(ar -> {
-          testContext.verify(() -> assertThat(ar.result().getFirst().getId(), is(nonExistentId)));
+          testContext.verify(() -> assertThat(ar.result().getFirst().entity().getId(), is(nonExistentId)));
           testContext.completeNow();
         })
     );


### PR DESCRIPTION
### **Purpose**
[[MODORDSTOR-516](https://folio-org.atlassian.net/browse/MODORDSTOR-516)] Add old object for EDIT audit events for PO, PO Line and Piece

### **Approach**
- Update acq-models
- Update audit services to use wrappers to contain original entity snapshots
- Update order related classes to pass original snapshot for audit events
- Update order line related classes to pass original snapshot for audit events
- Update piece related classes to pass original snapshot for audit events
- Update holding and item event create and update classes to support new audit logic
- Update tests
- Verify locally

### **Verification**
Order:
<img width="1437" height="1263" alt="PO" src="https://github.com/user-attachments/assets/f8d4f0f5-63d6-4720-a726-1422e1d891e1" />
Order line:
<img width="1436" height="1133" alt="POL" src="https://github.com/user-attachments/assets/470a3b01-251d-4028-9f59-b72828f035c8" />
Piece:
<img width="1442" height="610" alt="Piece" src="https://github.com/user-attachments/assets/c4deca6a-be20-4d8a-9f2c-9a4f1cbe881e" />


---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
