### PR TITLE
MODORDSTOR-522 Support deprecated flag on acquisition methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 15.0.0 - Unreleased
+
+### Stories
+* [MODORDSTOR-522](https://folio-org.atlassian.net/browse/MODORDSTOR-522) - Support deprecated flag on acquisition methods
+
 ## 14.0.0 - Released (Trillium R1 2025)
 The primary focus of this release was to upgrade to Vert.x 5.0, implement FQM entity types, improve batch processing and audit logging, and enhance receiving functionality.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -138,7 +138,7 @@
     },
     {
       "id": "orders-storage.acquisition-methods",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/src/main/resources/templates/db_scripts/data-migration/15.0.0/acquisition_method_add_deprecated.sql
+++ b/src/main/resources/templates/db_scripts/data-migration/15.0.0/acquisition_method_add_deprecated.sql
@@ -1,0 +1,8 @@
+UPDATE ${myuniversity}_${mymodule}.acquisition_method
+SET jsonb = jsonb_set(
+    jsonb,
+    '{deprecated}',
+    'false'::jsonb,
+    true
+)
+WHERE NOT jsonb ? 'deprecated';

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -200,6 +200,11 @@
       "run": "after",
       "snippetPath": "data-migration/15.0.0/fill_missing_next_pol_number.ftl",
       "fromModuleVersion": "mod-orders-storage-15.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/15.0.0/acquisition_method_add_deprecated.sql",
+      "fromModuleVersion": "mod-orders-storage-15.0.0"
     }
   ],
   "tables": [

--- a/src/test/java/org/folio/StorageTestSuite.java
+++ b/src/test/java/org/folio/StorageTestSuite.java
@@ -42,6 +42,7 @@ import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.core.ResponseUtilTest;
 import org.folio.rest.core.RestClientTest;
+import org.folio.rest.impl.AcquisitionMethodDeprecatedQueryTest;
 import org.folio.rest.impl.BatchTrackingAPITest;
 import org.folio.rest.impl.ClaimingAPITest;
 import org.folio.rest.impl.CustomFieldsAPITest;
@@ -369,4 +370,7 @@ public class StorageTestSuite {
 
   @Nested
   class SuffixDeprecatedQueryTestNested extends SuffixDeprecatedQueryTest {}
+
+  @Nested
+  class AcquisitionMethodDeprecatedQueryTestNested extends AcquisitionMethodDeprecatedQueryTest {}
 }

--- a/src/test/java/org/folio/rest/impl/AcquisitionMethodDeprecatedQueryTest.java
+++ b/src/test/java/org/folio/rest/impl/AcquisitionMethodDeprecatedQueryTest.java
@@ -1,0 +1,169 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.given;
+import static io.vertx.core.json.JsonObject.mapFrom;
+
+import static org.folio.rest.utils.TestEntities.ACQUISITION_METHOD;
+import static org.folio.StorageTestSuite.storageUrl;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import io.restassured.http.ContentType;
+import io.restassured.http.Headers;
+import io.vertx.core.json.JsonObject;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.UUID;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.folio.StorageTestSuite;
+import org.folio.rest.jaxrs.model.AcquisitionMethod;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.ModuleName;
+import org.folio.rest.util.TestConfig;
+import org.folio.rest.utils.IsolatedTenant;
+import org.folio.rest.utils.TenantApiTestUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@Log4j2
+@IsolatedTenant
+public class AcquisitionMethodDeprecatedQueryTest extends TestBase {
+
+  private static final String userId = UUID.randomUUID().toString();
+  private static Headers headers;
+
+  public AcquisitionMethodDeprecatedQueryTest() {
+    AcquisitionMethodDeprecatedQueryTest.headers = getIsolatedTenantHeaders(userId);
+  }
+
+  @BeforeAll
+  public static void beforeAll() throws ExecutionException, InterruptedException, TimeoutException {
+    TestConfig.startMockServer();
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    TestConfig.closeMockServer();
+  }
+
+  @Test
+  public void testQueryDeprecatedAcquisitionMethods() throws MalformedURLException {
+    // API round-trip: a method flagged as deprecated via POST is filterable server-side
+    AcquisitionMethod deprecatedMethod = createData("Deprecated method", true);
+
+    given()
+        .headers(headers)
+        .contentType(ContentType.JSON)
+        .queryParam("query", "(deprecated=true)")
+        .when()
+        .get(storageUrl(ACQUISITION_METHOD.getEndpoint()))
+        .then()
+        .statusCode(200)
+        .body("acquisitionMethods", hasSize(1))
+        .body("totalRecords", equalTo(1))
+        .body("acquisitionMethods[0].value", equalTo(deprecatedMethod.getValue()))
+        .body("acquisitionMethods[0].deprecated", equalTo(deprecatedMethod.getDeprecated()));
+
+    // ...and is excluded by the inverse filter
+    given()
+        .headers(headers)
+        .contentType(ContentType.JSON)
+        .queryParam("query", String.format("(id==%s and deprecated=false)", deprecatedMethod.getId()))
+        .when()
+        .get(storageUrl(ACQUISITION_METHOD.getEndpoint()))
+        .then()
+        .statusCode(200)
+        .body("totalRecords", equalTo(0));
+  }
+
+  @Test
+  public void testBackfillMigrationForRowsMissingDeprecatedField() throws MalformedURLException {
+    String schema = String.join("_", ISOLATED_TENANT, ModuleName.getModuleName());
+
+    // Simulate a pre-migration row: insert directly so the jsonb has no 'deprecated' key
+    String id = UUID.randomUUID().toString();
+    JsonObject legacyJson = new JsonObject()
+        .put("id", id)
+        .put("value", "Legacy method")
+        .put("source", "User");
+    executeSql(String.format("INSERT INTO %s.acquisition_method (id, jsonb) VALUES ('%s', '%s'::jsonb)",
+        schema, id, legacyJson.encode()));
+
+    // Sanity check: the legacy row exists and is found by id
+    given()
+        .headers(headers)
+        .contentType(ContentType.JSON)
+        .queryParam("query", String.format("(id==%s)", id))
+        .when()
+        .get(storageUrl(ACQUISITION_METHOD.getEndpoint()))
+        .then()
+        .statusCode(200)
+        .body("totalRecords", equalTo(1));
+
+    // Without the backfill the legacy row is NOT matched by deprecated==false
+    given()
+        .headers(headers)
+        .contentType(ContentType.JSON)
+        .queryParam("query", String.format("(id==%s and deprecated=false)", id))
+        .when()
+        .get(storageUrl(ACQUISITION_METHOD.getEndpoint()))
+        .then()
+        .statusCode(200)
+        .body("totalRecords", equalTo(0));
+
+    /*
+      Run a real tenant upgrade from a pre-deprecated module version, so the backfill is
+      executed by RMB through its registration in schema.json (snippetPath resolution,
+      fromModuleVersion gating and placeholder substitution) instead of running the SQL
+      file directly from the test.
+    */
+    TenantAttributes upgradeAttributes = TenantApiTestUtil.prepareTenantBody(false, false)
+        .withModuleFrom(String.format("%s-%s", ModuleName.getModuleName(), "14.0.0"));
+    TenantApiTestUtil.postTenant(ISOLATED_TENANT_HEADER, upgradeAttributes);
+
+    // After the backfill the legacy row is matched and carries deprecated=false
+    given()
+        .headers(headers)
+        .contentType(ContentType.JSON)
+        .queryParam("query", String.format("(id==%s and deprecated=false)", id))
+        .when()
+        .get(storageUrl(ACQUISITION_METHOD.getEndpoint()))
+        .then()
+        .statusCode(200)
+        .body("totalRecords", equalTo(1))
+        .body("acquisitionMethods[0].id", equalTo(id))
+        .body("acquisitionMethods[0].deprecated", equalTo(false));
+  }
+
+  private void executeSql(String sql) {
+    try {
+      PostgresClient.getInstance(StorageTestSuite.getVertx(), ISOLATED_TENANT)
+          .execute(sql)
+          .toCompletionStage().toCompletableFuture().get(60, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    } catch (ExecutionException | TimeoutException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private AcquisitionMethod createData(String value, boolean deprecated) throws MalformedURLException {
+    var acquisitionMethodId = UUID.randomUUID().toString();
+
+    AcquisitionMethod acquisitionMethod = new AcquisitionMethod()
+        .withId(acquisitionMethodId)
+        .withValue(value)
+        .withSource(AcquisitionMethod.Source.USER)
+        .withDeprecated(deprecated);
+    createEntity(ACQUISITION_METHOD.getEndpoint(), mapFrom(acquisitionMethod).encode(), headers);
+    return acquisitionMethod;
+  }
+}


### PR DESCRIPTION
- back-fill deprecated=false on existing rows (data migration)
- bump orders-storage.acquisition-methods interface 1.0 -> 1.1
- add AcquisitionMethodDeprecatedQueryTest

[MODORDSTOR-522](https://folio-org.atlassian.net/browse/MODORDSTOR-522)

### **Purpose**
Acquisition methods can now be marked as deprecated so obsolete values no longer
pollute selection lists but stay visible and searchable on existing records
(https://folio-org.atlassian.net/browse/UIOR-1157). The `deprecated` boolean was
added to the shared schema via acq-models (MODORDSTOR-521, already on master).
This PR completes the storage side: without a back-fill, rows created before the
field existed are silently missed by `deprecated==false` CQL queries, and the
interface version must advertise the new field.

### **Approach**
- Data migration (`15.0.0`) sets `deprecated=false` on all `acquisition_method`
  rows missing the key (idempotent `jsonb_set`, mirrors the prefix/suffix
  deprecation migration), registered in `schema.json`.
- `orders-storage.acquisition-methods` bumped 1.0 -> 1.1 (additive change).
---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - No breaking changes; the field is optional with a default.
  - [x] API/schema changes — `deprecated` added via acq-models submodule (MODORDSTOR-521, merged separately)
  - [x] Interface version updates — `orders-storage.acquisition-methods` 1.0 → 1.1; mod-orders will require 1.1 (MODORDERS-1463, merge after this PR)
  - [x] DB schema changes / migration scripts — back-fill only, no DDL
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
