### PR TITLE
[MODORDSTOR-525] Intermittent deadlock (40P01) on "Change instance connection -> Move"

### DIFF
--- a/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -48,7 +48,9 @@ public class WithHoldingOrderLineUpdateInstanceStrategy implements OrderLineUpda
     var tenantId = TenantTool.tenantId(rqContext.getHeaders());
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
-      .withTrans(conn -> titleService.updateTitle(storagePol, holder.instance(), conn)
+      // locks po_line before titles. Taking the locks in a different order here would cause a deadlock.
+      .withTrans(conn -> poLinesService.getPoLineByIdForUpdate(storagePol.getId(), conn)
+        .compose(v -> titleService.updateTitle(storagePol, holder.instance(), conn))
         .compose(poLine -> updateHoldings(poLine, holder.patchOrderLineRequest().getReplaceInstanceRef(), conn, tenantId))
         .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))

--- a/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -32,7 +32,9 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy implements OrderLineU
     var storagePol = holder.storagePoLine();
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
-      .withTrans(conn -> titleService.updateTitle(storagePol, holder.instance(), conn)
+      // locks po_line before titles. Taking the locks in a different order here would cause a deadlock.
+      .withTrans(conn -> poLinesService.getPoLineByIdForUpdate(storagePol.getId(), conn)
+        .compose(v -> titleService.updateTitle(storagePol, holder.instance(), conn))
         .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))
       .onFailure(err -> log.warn("updateInstance:: Instance failed to update, poLine id={}", storagePol.getId(), err))


### PR DESCRIPTION
### **Purpose**
[MODORDSTOR-525](https://folio-org.atlassian.net/browse/MODORDSTOR-525) - Intermittent deadlock (40P01) on "Change instance connection -> Move"

### **Approach**
  `WithHoldingOrderLineUpdateInstanceStrategy` and `WithoutHoldingOrderLineUpdateInstanceStrategy` now                                                                              
  acquire `po_line` **first**, matching the lock order already used by the Kafka handler
### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
