### PR TITLE
Trillium release v14.0.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## 14.0.3 - Released (Trillium R1 2026 - Bugfix)
+The primary focus of this release was to fix issue when title is not updated after changing instance connection.
+
+[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v14.0.2...v14.0.3)
+
+### Bug Fixes
+* [MODORDSTOR-524](https://folio-org.atlassian.net/browse//MODORDSTOR-524) - Title name is not updated after changing instance connection
+
 ## 14.0.2 - Released (Trillium R1 2026 - Bugfix)
 The primary focus of this release was to fix issues with nextPoLineNumber and nextInvoiceLineNumber usage.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 14.0.3 - Released (Trillium R1 2026 - Bugfix)
-The primary focus of this release was to fix issue when title is not updated after changing instance connection.
+The primary focus of this release was to fix the issue where the title is not updated after changing the instance connection.
 
 [Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v14.0.2...v14.0.3)
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>14.0.3-SNAPSHOT</version>
+  <version>14.0.3</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -634,7 +634,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v14.0.0</tag>
+    <tag>v14.0.3</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-orders-storage</artifactId>
-  <version>14.0.3</version>
+  <version>14.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -634,7 +634,7 @@
     <url>https://github.com/folio-org/mod-orders-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-orders-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-orders-storage.git</developerConnection>
-    <tag>v14.0.3</tag>
+    <tag>v14.0.0</tag>
   </scm>
 
 </project>

--- a/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -45,11 +45,10 @@ public class WithHoldingOrderLineUpdateInstanceStrategy implements OrderLineUpda
 
     log.info("updateInstance:: Updating instance for poLine id={}", holder.storagePoLine().getId());
     var storagePol = holder.storagePoLine();
-    var instanceId = holder.patchOrderLineRequest().getReplaceInstanceRef().getNewInstanceId();
     var tenantId = TenantTool.tenantId(rqContext.getHeaders());
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
-      .withTrans(conn -> titleService.updateTitle(storagePol, instanceId, conn)
+      .withTrans(conn -> titleService.updateTitle(storagePol, holder.instance(), conn)
         .compose(poLine -> updateHoldings(poLine, holder.patchOrderLineRequest().getReplaceInstanceRef(), conn, tenantId))
         .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))

--- a/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -48,7 +48,9 @@ public class WithHoldingOrderLineUpdateInstanceStrategy implements OrderLineUpda
     var tenantId = TenantTool.tenantId(rqContext.getHeaders());
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
-      .withTrans(conn -> titleService.updateTitle(storagePol, holder.instance(), conn)
+      // locks po_line before titles. Taking the locks in a different order here would cause a deadlock.
+      .withTrans(conn -> poLinesService.getPoLineByIdForUpdate(storagePol.getId(), conn)
+        .compose(v -> titleService.updateTitle(storagePol, holder.instance(), conn))
         .compose(poLine -> updateHoldings(poLine, holder.patchOrderLineRequest().getReplaceInstanceRef(), conn, tenantId))
         .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))

--- a/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -48,11 +48,10 @@ public class WithHoldingOrderLineUpdateInstanceStrategy implements OrderLineUpda
     var tenantId = TenantTool.tenantId(rqContext.getHeaders());
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
-      // locks po_line before titles. Taking the locks in a different order here would cause a deadlock.
-      .withTrans(conn -> poLinesService.getPoLineByIdForUpdate(storagePol.getId(), conn)
-        .compose(v -> titleService.updateTitle(storagePol, holder.instance(), conn))
-        .compose(poLine -> updateHoldings(poLine, holder.patchOrderLineRequest().getReplaceInstanceRef(), conn, tenantId))
-        .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
+      // locks pieces before po_line before titles. Taking the locks in a different order here would cause a deadlock.
+      .withTrans(conn -> updateHoldings(storagePol, holder.patchOrderLineRequest().getReplaceInstanceRef(), conn, tenantId)
+        .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders()))
+        .compose(poLine -> titleService.updateTitle(poLine, holder.instance(), conn)))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))
       .onFailure(err -> log.warn("updateInstance:: Instance failed to update, poLine id={}", storagePol.getId(), err))
       .mapEmpty();

--- a/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -32,7 +32,9 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy implements OrderLineU
     var storagePol = holder.storagePoLine();
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
-      .withTrans(conn -> titleService.updateTitle(storagePol, holder.instance(), conn)
+      // locks po_line before titles. Taking the locks in a different order here would cause a deadlock.
+      .withTrans(conn -> poLinesService.getPoLineByIdForUpdate(storagePol.getId(), conn)
+        .compose(v -> titleService.updateTitle(storagePol, holder.instance(), conn))
         .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))
       .onFailure(err -> log.warn("updateInstance:: Instance failed to update, poLine id={}", storagePol.getId(), err))

--- a/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -30,10 +30,9 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy implements OrderLineU
 
     log.info("updateInstance:: Starting update instance process for poLine id={}", holder.storagePoLine().getId());
     var storagePol = holder.storagePoLine();
-    var instanceId = holder.patchOrderLineRequest().getReplaceInstanceRef().getNewInstanceId();
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
-      .withTrans(conn -> titleService.updateTitle(storagePol, instanceId, conn)
+      .withTrans(conn -> titleService.updateTitle(storagePol, holder.instance(), conn)
         .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))
       .onFailure(err -> log.warn("updateInstance:: Instance failed to update, poLine id={}", storagePol.getId(), err))

--- a/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -33,9 +33,8 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy implements OrderLineU
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
       // locks po_line before titles. Taking the locks in a different order here would cause a deadlock.
-      .withTrans(conn -> poLinesService.getPoLineByIdForUpdate(storagePol.getId(), conn)
-        .compose(v -> titleService.updateTitle(storagePol, holder.instance(), conn))
-        .compose(poLine -> poLinesService.updateInstanceIdForPoLine(poLine, holder.instance(), conn, rqContext.getHeaders())))
+      .withTrans(conn -> poLinesService.updateInstanceIdForPoLine(storagePol, holder.instance(), conn, rqContext.getHeaders())
+        .compose(poLine -> titleService.updateTitle(poLine, holder.instance(), conn)))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))
       .onFailure(err -> log.warn("updateInstance:: Instance failed to update, poLine id={}", storagePol.getId(), err))
       .mapEmpty();

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -301,6 +301,11 @@ public class PoLinesService {
     return promise.future();
   }
 
+  public Future<Optional<PoLine>> getPoLineByIdForUpdate(String id, Conn conn) {
+    log.debug("getPoLineByIdForUpdate:: Getting POL for update: '{}'", id);
+    return conn.getByIdForUpdate(PO_LINE_TABLE, id, PoLine.class).map(Optional::ofNullable);
+  }
+
   public Future<PoLine> updateInstanceIdForPoLine(PoLine poLine, JsonObject instance, Conn conn, Map<String, String> headers) {
     updateInstanceFieldsForPoLine(poLine, instance);
     return doUpdatePoLine(poLine, conn)

--- a/src/main/java/org/folio/services/lines/PoLinesService.java
+++ b/src/main/java/org/folio/services/lines/PoLinesService.java
@@ -301,11 +301,6 @@ public class PoLinesService {
     return promise.future();
   }
 
-  public Future<Optional<PoLine>> getPoLineByIdForUpdate(String id, Conn conn) {
-    log.debug("getPoLineByIdForUpdate:: Getting POL for update: '{}'", id);
-    return conn.getByIdForUpdate(PO_LINE_TABLE, id, PoLine.class).map(Optional::ofNullable);
-  }
-
   public Future<PoLine> updateInstanceIdForPoLine(PoLine poLine, JsonObject instance, Conn conn, Map<String, String> headers) {
     updateInstanceFieldsForPoLine(poLine, instance);
     return doUpdatePoLine(poLine, conn)

--- a/src/main/java/org/folio/services/title/TitleService.java
+++ b/src/main/java/org/folio/services/title/TitleService.java
@@ -24,8 +24,10 @@ import org.folio.rest.jaxrs.model.Title;
 import org.folio.rest.jaxrs.model.TitleSequenceNumbers;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.util.InventoryUtils;
 
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
@@ -49,19 +51,34 @@ public class TitleService {
       });
   }
 
-  private Future<PoLine> updateInstanceIdForTitle(PoLine poLine, Title title, String instanceId, Conn conn) {
+  private Future<PoLine> updateInstanceForTitle(PoLine poLine, Title title, JsonObject instance, Conn conn) {
     Criterion criterion = getCriteriaByFieldNameAndValueNotJsonb(POLINE_ID_FIELD, poLine.getId());
-    title.setInstanceId(instanceId);
+    updateInstanceFieldsForTitle(title, instance);
     return conn.update(TITLES_TABLE, title, JSONB, criterion.toString(), false)
       .map(poLine)
       .recover(t -> Future.failedFuture(httpHandleFailure(t)))
-      .onSuccess(v -> log.info("InstanceId in Title record {} was successfully updated", title.getId()))
-      .onFailure(t -> log.error("updateInstanceIdForTitle failed, poLineId={}, titleId={}", poLine.getId(), title.getId(), t));
+      .onSuccess(v -> log.info("Instance data in Title record {} was successfully updated", title.getId()))
+      .onFailure(t -> log.error("updateInstanceForTitle failed, poLineId={}, titleId={}", poLine.getId(), title.getId(), t));
   }
 
-  public Future<PoLine> updateTitle(PoLine poLine, String instanceId, Conn conn) {
+  /**
+   * Applies the instance-derived fields to the given title. Mirrors {@code PoLinesService#updateInstanceFieldsForPoLine},
+   * so that a PO line and its title stay in sync with the same instance data. Updating the instanceId alone is not enough:
+   * a title would then keep displaying the name of the previously connected instance while already pointing at the new one.
+   */
+  private void updateInstanceFieldsForTitle(Title title, JsonObject instance) {
+    title.withInstanceId(InventoryUtils.getInstanceId(instance))
+      .withTitle(InventoryUtils.getInstanceTitle(instance))
+      .withPublisher(InventoryUtils.getPublisher(instance))
+      .withPublishedDate(InventoryUtils.getPublicationDate(instance))
+      .withContributors(InventoryUtils.getContributors(instance))
+      .withProductIds(InventoryUtils.getProductIds(instance));
+  }
+
+  public Future<PoLine> updateTitle(PoLine poLine, JsonObject instance, Conn conn) {
+    var instanceId = InventoryUtils.getInstanceId(instance);
     return getTitleByPoLineId(poLine.getId(), conn)
-      .compose(title -> updateInstanceIdForTitle(poLine, title, instanceId, conn))
+      .compose(title -> updateInstanceForTitle(poLine, title, instance, conn))
       .onSuccess(v -> log.debug("updateTitle:: Succeeded for poLineId={}, instanceId={}", poLine.getId(), instanceId))
       .onFailure(t -> log.error("updateTitle:: Failed for poLineId={}, instanceId={}", poLine.getId(), instanceId, t));
   }

--- a/src/main/java/org/folio/util/InventoryUtils.java
+++ b/src/main/java/org/folio/util/InventoryUtils.java
@@ -12,6 +12,7 @@ import static org.folio.event.dto.InstanceFields.CONTRIBUTOR_NAME;
 import static org.folio.event.dto.InstanceFields.CONTRIBUTOR_NAME_TYPE_ID;
 import static org.folio.event.dto.InstanceFields.CONTRIBUTORS;
 import static org.folio.event.dto.InstanceFields.DATE_OF_PUBLICATION;
+import static org.folio.event.dto.InstanceFields.ID;
 import static org.folio.event.dto.InstanceFields.IDENTIFIERS;
 import static org.folio.event.dto.InstanceFields.IDENTIFIER_TYPE_ID;
 import static org.folio.event.dto.InstanceFields.IDENTIFIER_TYPE_VALUE;
@@ -21,6 +22,10 @@ import static org.folio.event.dto.InstanceFields.TITLE;
 
 @UtilityClass
 public class InventoryUtils {
+
+  public static String getInstanceId(JsonObject instance) {
+    return instance.getString(ID.getValue());
+  }
 
   public static String getInstanceTitle(JsonObject instance) {
     return instance.getString(TITLE.getValue());

--- a/src/test/java/org/folio/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
+++ b/src/test/java/org/folio/orders/lines/update/OrderLineUpdateInstanceHandlerTest.java
@@ -78,6 +78,14 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
 
   static final String TEST_TENANT = "test_tenant";
   public static final String INSTANCE_MOCK_FILE = "mockdata/inventory/instance.json";
+  private static final String INSTANCE_MOCK_ID = "e677e090-7dfc-4a40-b5fd-fde37793c52b";
+  private static final String INSTANCE_MOCK_PUBLISHER = "Hirmer";
+  private static final String INSTANCE_MOCK_PUBLISHED_DATE = "c2014";
+  private static final String INSTANCE_MOCK_FIRST_CONTRIBUTOR = "Arnhold, Hermann";
+  private static final int INSTANCE_MOCK_CONTRIBUTORS_COUNT = 3;
+  private static final String INSTANCE_MOCK_FIRST_PRODUCT_ID = "(OCoLC)ocn893407036";
+  private static final int INSTANCE_MOCK_PRODUCT_IDS_COUNT = 4;
+  private static final String OLD_TITLE_NAME = "Old title name";
   private static final Header TEST_TENANT_HEADER = new Header(OKAPI_HEADER_TENANT, TEST_TENANT);
   private Map<String, String> headers = new HashMap<>(Collections.singletonMap(OKAPI_HEADER_TENANT, TEST_TENANT));
 
@@ -100,7 +108,7 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
 
   private static TenantJob tenantJob;
   private final String newHoldingId = UUID.randomUUID().toString();
-  private final String newInstanceId = UUID.randomUUID().toString();
+  private final String newInstanceId = INSTANCE_MOCK_ID;
   private static boolean runningOnOwn;
 
   @BeforeEach
@@ -150,6 +158,7 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
     PoLine poLine = new PoLine()
       .withId(poLineId)
       .withInstanceId(instanceId)
+      .withTitleOrPackage(OLD_TITLE_NAME)
       .withOrderFormat(PoLine.OrderFormat.PHYSICAL_RESOURCE)
       .withPhysical(new Physical()
         .withCreateInventory(Physical.CreateInventory.INSTANCE_HOLDING_ITEM))
@@ -157,7 +166,8 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
     Title title = new Title()
       .withId(titleId)
       .withPoLineId(poLineId)
-      .withInstanceId(instanceId);
+      .withInstanceId(instanceId)
+      .withTitle(OLD_TITLE_NAME);
     JsonObject instance = new JsonObject(getFile(INSTANCE_MOCK_FILE));
     Piece piece = new Piece()
       .withId(pieceId)
@@ -220,6 +230,13 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
         testContext.verify(() -> {
           assertThat(actTitle.getId(), is(titleId));
           assertThat(actTitle.getInstanceId(), is(newInstanceId));
+          assertThat(actTitle.getTitle(), is(instance.getString("title")));
+          assertThat(actTitle.getPublisher(), is(INSTANCE_MOCK_PUBLISHER));
+          assertThat(actTitle.getPublishedDate(), is(INSTANCE_MOCK_PUBLISHED_DATE));
+          assertThat(actTitle.getContributors().size(), is(INSTANCE_MOCK_CONTRIBUTORS_COUNT));
+          assertThat(actTitle.getContributors().getFirst().getContributor(), is(INSTANCE_MOCK_FIRST_CONTRIBUTOR));
+          assertThat(actTitle.getProductIds().size(), is(INSTANCE_MOCK_PRODUCT_IDS_COUNT));
+          assertThat(actTitle.getProductIds().getFirst().getProductId(), is(INSTANCE_MOCK_FIRST_PRODUCT_ID));
         });
         testContext.completeNow();
       })
@@ -402,13 +419,15 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
     PoLine poLine = new PoLine()
       .withId(poLineId)
       .withInstanceId(instanceId)
+      .withTitleOrPackage(OLD_TITLE_NAME)
       .withOrderFormat(PoLine.OrderFormat.ELECTRONIC_RESOURCE)
       .withEresource(new Eresource()
         .withCreateInventory(Eresource.CreateInventory.INSTANCE));
     Title title = new Title()
       .withId(titleId)
       .withPoLineId(poLineId)
-      .withInstanceId(instanceId);
+      .withInstanceId(instanceId)
+      .withTitle(OLD_TITLE_NAME);
     JsonObject instance = new JsonObject(getFile(INSTANCE_MOCK_FILE));
     ReplaceInstanceRef replaceInstanceRef = new ReplaceInstanceRef()
       .withNewInstanceId(newInstanceId)
@@ -449,6 +468,13 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
         testContext.verify(() -> {
           assertThat(actTitle.getId(), is(titleId));
           assertThat(actTitle.getInstanceId(), is(newInstanceId));
+          assertThat(actTitle.getTitle(), is(instance.getString("title")));
+          assertThat(actTitle.getPublisher(), is(INSTANCE_MOCK_PUBLISHER));
+          assertThat(actTitle.getPublishedDate(), is(INSTANCE_MOCK_PUBLISHED_DATE));
+          assertThat(actTitle.getContributors().size(), is(INSTANCE_MOCK_CONTRIBUTORS_COUNT));
+          assertThat(actTitle.getContributors().getFirst().getContributor(), is(INSTANCE_MOCK_FIRST_CONTRIBUTOR));
+          assertThat(actTitle.getProductIds().size(), is(INSTANCE_MOCK_PRODUCT_IDS_COUNT));
+          assertThat(actTitle.getProductIds().getFirst().getProductId(), is(INSTANCE_MOCK_FIRST_PRODUCT_ID));
         });
         testContext.completeNow();
       })
@@ -458,6 +484,7 @@ public class OrderLineUpdateInstanceHandlerTest extends TestBase {
         testContext.verify(() -> {
           assertThat(actPoLine.getId(), is(poLineId));
           assertThat(actPoLine.getInstanceId(), is(newInstanceId));
+          assertThat(actPoLine.getTitleOrPackage(), is(instance.getString("title")));
         });
         testContext.completeNow();
       })));

--- a/src/test/java/org/folio/services/title/TitleServiceTest.java
+++ b/src/test/java/org/folio/services/title/TitleServiceTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import io.restassured.http.Header;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
@@ -49,6 +50,7 @@ public class TitleServiceTest extends TestBase {
   TitleService titleService = new TitleService();
   private static TenantJob tenantJob;
   private final String newInstanceId = UUID.randomUUID().toString();
+  private final String newInstanceTitle = "New instance title";
 
   @BeforeEach
   public void initMocks() throws MalformedURLException {
@@ -93,14 +95,19 @@ public class TitleServiceTest extends TestBase {
       });
     });
 
+    JsonObject newInstance = new JsonObject()
+      .put("id", newInstanceId)
+      .put("title", newInstanceTitle);
+
     testContext.assertComplete(client.getPgClient()
-      .withTrans(conn -> promise2.future().compose(o -> titleService.updateTitle(poLine, newInstanceId, conn))
+      .withTrans(conn -> promise2.future().compose(o -> titleService.updateTitle(poLine, newInstance, conn))
         .onComplete(v -> titleService.getTitleByPoLineId(poLineId, conn)
           .onComplete(ar -> {
             Title actTitle = ar.result();
             testContext.verify(() -> {
               assertThat(actTitle.getId(), is(titleId));
               assertThat(actTitle.getInstanceId(), is(newInstanceId));
+              assertThat(actTitle.getTitle(), is(newInstanceTitle));
             });
             testContext.completeNow();
           }))));


### PR DESCRIPTION
## 14.0.3 - Released (Trillium R1 2026 - Bugfix)
The primary focus of this release was to fix issue when title is not updated after changing instance connection.

[Full Changelog](https://github.com/folio-org/mod-orders-storage/compare/v14.0.2...v14.0.3)

### Bug Fixes
* [MODORDSTOR-524](https://folio-org.atlassian.net/browse//MODORDSTOR-524) - Title name is not updated after changing instance connection