### PR TITLE
[MODORDSTOR-527] PO line version history does not consistently highlight Holding changes when changing instance connection with "Find or create"

### DIFF
--- a/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
+++ b/src/main/java/org/folio/event/handler/ItemUpdateAsyncRecordHandler.java
@@ -123,14 +123,12 @@ public class ItemUpdateAsyncRecordHandler extends InventoryUpdateAsyncRecordHand
       holder.getBatchHolder().getBatchId(), holder.getBatchHolder().isBatchMode(), holder.getBatchHolder().isLastInBatch());
     return orderLineLocationUpdateService.updatePoLineLocationData(poLineIds, holder.getItem(), false, holder.getOrderTenantId(), holder.getHeaders(), conn)
       .compose(wrappedPoLines -> {
-        // Only save POL outbox logs if NOT in batch mode OR if this is the last item in batch
-        if (holder.getBatchHolder().isBatchMode() && !holder.getBatchHolder().isLastInBatch()) {
-          log.debug("processPoLinesUpdate:: Batch mode enabled and not last item, skipping POL outbox save");
+        if (holder.getBatchHolder().isBatchMode()) {
+          log.debug("processPoLinesUpdate:: Batch mode enabled, skipping POL outbox save; the PATCH transaction emits the authoritative version");
           return Future.succeededFuture(false);
-        } else {
-          log.debug("processPoLinesUpdate:: Saving POLs to outbox (non-batch mode or last item in batch)");
-          return auditOutboxService.saveOrderLinesOutboxLogs(conn, wrappedPoLines, OrderLineAuditEvent.Action.EDIT, holder.getHeaders());
         }
+        log.debug("processPoLinesUpdate:: Non-batch item update, saving POLs to outbox");
+        return auditOutboxService.saveOrderLinesOutboxLogs(conn, wrappedPoLines, OrderLineAuditEvent.Action.EDIT, holder.getHeaders());
       })
       .mapEmpty();
   }

--- a/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithHoldingOrderLineUpdateInstanceStrategy.java
@@ -60,10 +60,13 @@ public class WithHoldingOrderLineUpdateInstanceStrategy implements OrderLineUpda
   private Future<PoLine> updateHoldings(PoLine poLine, ReplaceInstanceRef replaceInstanceRef, Conn conn, String tenantId) {
     if (!isUpdatedHolding(replaceInstanceRef.getHoldings())) {
       log.info("Holding does not require an update");
-      return Future.succeededFuture(poLine);
+      // Re-read the po_line to avoid lost updates
+      return getPoLineForUpdate(poLine.getId(), conn);
     }
     return pieceService.updatePieces(poLine, replaceInstanceRef, conn, tenantId)
-      .map(v -> updateLocations(poLine, replaceInstanceRef))
+      // Re-read the po_line to avoid lost updates
+      .compose(v -> getPoLineForUpdate(poLine.getId(), conn))
+      .map(lockedPoLine -> updateLocations(lockedPoLine, replaceInstanceRef))
       .onComplete(ar -> {
         if (ar.failed()) {
           log.warn("updateHoldings failed, poLine id={}", poLine.getId(), ar.cause());
@@ -71,6 +74,12 @@ public class WithHoldingOrderLineUpdateInstanceStrategy implements OrderLineUpda
           log.debug("updateHoldings completed, poLine id={}", poLine.getId());
         }
       });
+  }
+
+  private Future<PoLine> getPoLineForUpdate(String poLineId, Conn conn) {
+    return poLinesService.getPoLineByIdForUpdate(poLineId, conn)
+      .map(optionalPoLine -> optionalPoLine.orElseThrow(() ->
+        new HttpException(Response.Status.NOT_FOUND.getStatusCode(), "PoLine not found by id: " + poLineId)));
   }
 
   private boolean isUpdatedHolding(List<Holding> holdings) {

--- a/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
+++ b/src/main/java/org/folio/orders/lines/update/instance/WithoutHoldingOrderLineUpdateInstanceStrategy.java
@@ -33,7 +33,12 @@ public class WithoutHoldingOrderLineUpdateInstanceStrategy implements OrderLineU
 
     return new DBClient(rqContext.getContext(), rqContext.getHeaders()).getPgClient()
       // locks po_line before titles. Taking the locks in a different order here would cause a deadlock.
-      .withTrans(conn -> poLinesService.updateInstanceIdForPoLine(storagePol, holder.instance(), conn, rqContext.getHeaders())
+      // Re-read the po_line under lock first so the instance update is applied to the latest committed
+      // state rather than the snapshot read before the transaction, avoiding a lost update.
+      .withTrans(conn -> poLinesService.getPoLineByIdForUpdate(storagePol.getId(), conn)
+        .map(optionalPoLine -> optionalPoLine.orElseThrow(() ->
+          new HttpException(Response.Status.NOT_FOUND.getStatusCode(), "PoLine not found by id: " + storagePol.getId())))
+        .compose(lockedPoLine -> poLinesService.updateInstanceIdForPoLine(lockedPoLine, holder.instance(), conn, rqContext.getHeaders()))
         .compose(poLine -> titleService.updateTitle(poLine, holder.instance(), conn)))
       .onSuccess(v -> log.info("updateInstance:: Instance was updated successfully, poLine id={}", storagePol.getId()))
       .onFailure(err -> log.warn("updateInstance:: Instance failed to update, poLine id={}", storagePol.getId(), err))

--- a/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
+++ b/src/test/java/org/folio/event/handler/ItemUpdateAsyncRecordHandlerTest.java
@@ -321,7 +321,9 @@ public class ItemUpdateAsyncRecordHandlerTest {
     verify(pieceService).getPiecesByItemId(eq(itemId2), any(Conn.class));
     verify(pieceService).updatePiecesInventoryData(eq(List.of(expectedPiece2)), any(Conn.class), eq(DIKU_TENANT));
     verify(poLinesService).updatePoLines(eq(List.of(expectedUpdatedPoLine)), any(Conn.class), eq(DIKU_TENANT), anyMap());
-    verify(auditOutboxService).saveOrderLinesOutboxLogs(any(Conn.class), eq(List.of(AuditEntityWrapper.of(expectedUpdatedPoLine, expectedPoLine))), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
+    // In batch mode (change-instance flow) the item handler never emits the po_line audit, not even on the
+    // last item of the batch - the change-instance PATCH transaction emits the authoritative version instead.
+    verify(auditOutboxService, never()).saveOrderLinesOutboxLogs(any(Conn.class), anyList(), eq(OrderLineAuditEvent.Action.EDIT), anyMap());
     verify(batchTrackingService, times(2)).increaseBatchTrackingProgress(conn, poLineId, DIKU_TENANT);
     verify(batchTrackingService).deleteBatchTracking(conn, poLineId);
   }


### PR DESCRIPTION
### **Purpose**
[MODORDSTOR-527](https://folio-org.atlassian.net/browse/MODORDSTOR-527) - PO line version history does not consistently highlight Holding changes when changing instance connection with "Find or create"

### **Approach**
- In batch mode, the intermediate PO line version is no longer emitted; the direct PATCH transaction produces the single authoritative version.
- The PATCH now re-reads the PO line under SELECT FOR UPDATE inside the transaction and rebases the instance/location changes on that fresh row, preventing the lost update. Existing lock ordering is preserved (pieces -> po_line -> titles).

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
